### PR TITLE
ci: Compile the GNN plugin's non-CUDA paths and enforce warnings

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -460,8 +460,7 @@ jobs:
   # ─────────────────────────────────────────────────────────────────────
   # Compiles the full CUDA GNN stack on an ordinary CPU runner and hands the
   # build directory to `gnn_gpu`, which is the only job that occupies a GPU
-  # slot. One CUDA build serves both: it is a strict superset of a CPU-only
-  # GNN build, so there is no reason to compile the stack twice.
+  # slot.
   #
   # Push runs are deliberately unfiltered: they populate the ccache that pull
   # request runs restore from, and give every commit on a long-lived branch a
@@ -507,13 +506,33 @@ jobs:
           restore-keys: |
             ccache-${{ runner.os }}-${{ github.job }}-${{ env.CCACHE_KEY_SUFFIX }}-
 
+      # Compiles the `#else` arms of `#ifdef ACTS_GNN_WITH_CUDA`, which the
+      # configure below excludes. That definition is on ActsPluginGnn alone, so
+      # every ActsCore object stays valid and only the plugin recompiles;
+      # `--target` holds it there, the definition being PUBLIC. Running first
+      # fails fast and leaves `gnn_gpu` the tree the real configure produced.
+      #
+      # MODULEMAP goes off with CUDA: set_option_if forces ACTS_ENABLE_CUDA
+      # back ON while it is set with the plugin. It guards a `.cu` source and
+      # no C++. Catches errors, not warnings -- the preset compiles with `-w`.
+      - name: Configure without CUDA
+        run: >
+          ccache -z &&
+          CI/dependencies/run.sh .env
+          cmake -B build -S .
+          --preset=github-ci-gnn
+          -DACTS_ENABLE_CUDA=OFF
+          -DACTS_GNN_ENABLE_MODULEMAP=OFF
+
+      - name: Compile the non-CUDA code paths
+        run: cmake --build build --target ActsPluginGnn
+
       # The preset pins CMAKE_CUDA_ARCHITECTURES/TORCH_CUDA_ARCH_LIST to 75;86:
       # 75 is the T4 the tests run on, 86 lets an sm_86 node join the pool. A
       # missing 75 builds fine here and fails on the GPU with "no kernel image
       # is available for execution on the device".
       - name: Configure
         run: >
-          ccache -z &&
           CI/dependencies/run.sh .env
           cmake -B build -S .
           --preset=github-ci-gnn

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -558,6 +558,12 @@ if(ACTS_BUILD_PLUGIN_GNN)
     else()
         message(STATUS "Build GNN plugin for CPU only")
     endif()
+    # FRNN and ModuleMapGraph are built from vendored upstream sources, which
+    # are not ours to keep warning-clean. A normal variable, so it shadows the
+    # cache entry for the subdirectories added below and is restored before any
+    # ACTS target follows.
+    set(_acts_gnn_warning_as_error "${CMAKE_COMPILE_WARNING_AS_ERROR}")
+    set(CMAKE_COMPILE_WARNING_AS_ERROR OFF)
     if(ACTS_GNN_ENABLE_TORCH)
         find_package(Torch REQUIRED)
         if(ACTS_ENABLE_CUDA)
@@ -571,6 +577,7 @@ if(ACTS_BUILD_PLUGIN_GNN)
             add_subdirectory(thirdparty/ModuleMapGraph)
         endif()
     endif()
+    set(CMAKE_COMPILE_WARNING_AS_ERROR "${_acts_gnn_warning_as_error}")
 endif()
 if(ACTS_BUILD_PLUGIN_ONNX OR ACTS_GNN_ENABLE_ONNX)
     find_package(onnxruntime ${_acts_onnxruntime_version} MODULE REQUIRED)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -181,12 +181,12 @@
         {
             "name": "github-ci-gnn",
             "displayName": "GitHub-CI Gnn",
+            "description": "GNN build for the gnn_build job. Warnings are errors, as everywhere else in CI.",
             "generator": "Ninja",
             "inherits": "common",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Release",
-                "CMAKE_CXX_FLAGS": "-w",
-                "CMAKE_CUDA_FLAGS": "-w",
+                "CMAKE_COMPILE_WARNING_AS_ERROR": "ON",
                 "CMAKE_CUDA_ARCHITECTURES": "75;86",
                 "TORCH_CUDA_ARCH_LIST": "7.5;8.6",
                 "ACTS_FORCE_ASSERTIONS": "ON",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -181,7 +181,7 @@
         {
             "name": "github-ci-gnn",
             "displayName": "GitHub-CI Gnn",
-            "description": "GNN build for the gnn_build job. Warnings are errors, as everywhere else in CI.",
+            "description": "GNN build for the gnn_build job. Warnings are errors, as everywhere else in CI. Only the Plugins/Gnn unit tests are ever run from this build, so the Core and Examples suites and the integration tests are switched off; Tests/UnitTests/CMakeLists.txt adds Plugins unconditionally, so the GNN ones survive. ODD, DD4hep and ROOT stay on because the `-k gpu` python tests need a detector and read back ROOT output.",
             "generator": "Ninja",
             "inherits": "common",
             "cacheVariables": {
@@ -200,6 +200,9 @@
                 "ACTS_GNN_ENABLE_ONNX": "ON",
                 "ACTS_ENABLE_CUDA": "ON",
                 "ACTS_GNN_ENABLE_MODULEMAP": "ON",
+                "ACTS_BUILD_INTEGRATIONTESTS": "OFF",
+                "ACTS_BUILD_CORE_UNITTESTS": "OFF",
+                "ACTS_BUILD_EXAMPLES_UNITTESTS": "OFF",
                 "ACTS_USE_SYSTEM_NLOHMANN_JSON": "ON",
                 "ACTS_USE_SYSTEM_PYBIND11": "ON"
             }

--- a/Examples/Algorithms/TrackFindingGnn/src/TrackFindingAlgorithmGnn.cpp
+++ b/Examples/Algorithms/TrackFindingGnn/src/TrackFindingAlgorithmGnn.cpp
@@ -224,7 +224,11 @@ ProcessCode TrackFindingAlgorithmGnn::execute(
     onetrack.reserve(candidate.size());
 
     for (auto i : candidate) {
-      for (const auto& sl : sortedSpacePoints.at(i).sourceLinks()) {
+      // Named, so the proxy outlives the loop: as a temporary it would be
+      // destroyed at the end of the full expression, leaving the range-for
+      // iterating a span whose owner is gone.
+      const auto sp = sortedSpacePoints.at(i);
+      for (const auto& sl : sp.sourceLinks()) {
         onetrack.push_back(sl.template get<IndexSourceLink>().index());
       }
     }

--- a/Plugins/Gnn/CMakeLists.txt
+++ b/Plugins/Gnn/CMakeLists.txt
@@ -37,6 +37,14 @@ if(ACTS_GNN_ENABLE_TORCH)
             src/TorchMetricLearning.cpp
             src/buildEdges.cpp
     )
+    # FRNN edge building is CUDA-only. One of the two definitions of
+    # detail::buildEdgesFRNN is always linked, so buildEdges.cpp can call it
+    # unconditionally.
+    if(ACTS_ENABLE_CUDA)
+        target_sources(ActsPluginGnn PRIVATE src/buildEdgesFRNN.cpp)
+    else()
+        target_sources(ActsPluginGnn PRIVATE src/buildEdgesFRNNNoCuda.cpp)
+    endif()
 endif()
 
 if(ACTS_GNN_ENABLE_TENSORRT)
@@ -85,6 +93,10 @@ if(ACTS_ENABLE_CUDA)
             src/Stages.cu
     )
 else()
+    # The other half of DeviceOps.hpp: every device entry point, defined to
+    # throw. Host code calls them unconditionally and dispatches on the runtime
+    # device, so nothing above needs a preprocessor branch.
+    target_sources(ActsPluginGnn PRIVATE src/DeviceOpsNoCuda.cpp)
 endif()
 
 if(ACTS_GNN_ENABLE_TORCH)

--- a/Plugins/Gnn/CMakeLists.txt
+++ b/Plugins/Gnn/CMakeLists.txt
@@ -1,5 +1,6 @@
 acts_add_library(
     PluginGnn
+    src/CudaUnavailable.cpp
     src/GnnPipeline.cpp
     src/Stages.cpp
     src/Tensor.cpp

--- a/Plugins/Gnn/src/CudaUnavailable.cpp
+++ b/Plugins/Gnn/src/CudaUnavailable.cpp
@@ -1,0 +1,21 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "CudaUnavailable.hpp"
+
+#include <stdexcept>
+#include <string>
+
+namespace ActsPlugins::detail {
+
+void throwNoCudaSupport(std::string_view operation) {
+  throw std::runtime_error("Cannot " + std::string(operation) +
+                           ": ACTS was not compiled with CUDA support");
+}
+
+}  // namespace ActsPlugins::detail

--- a/Plugins/Gnn/src/CudaUnavailable.hpp
+++ b/Plugins/Gnn/src/CudaUnavailable.hpp
@@ -1,0 +1,23 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <string_view>
+
+namespace ActsPlugins::detail {
+
+/// Report that a CUDA-only code path was reached in a build configured without
+/// CUDA. Keeps each `#else` arm of `#ifdef ACTS_GNN_WITH_CUDA` to a single call
+/// against one always-compiled definition.
+///
+/// @param operation what the caller was asked to do, phrased to follow
+///        "Cannot ", e.g. "clone CUDA tensor"
+[[noreturn]] void throwNoCudaSupport(std::string_view operation);
+
+}  // namespace ActsPlugins::detail

--- a/Plugins/Gnn/src/CudaUnavailable.hpp
+++ b/Plugins/Gnn/src/CudaUnavailable.hpp
@@ -13,8 +13,8 @@
 namespace ActsPlugins::detail {
 
 /// Report that a CUDA-only code path was reached in a build configured without
-/// CUDA. Keeps each `#else` arm of `#ifdef ACTS_GNN_WITH_CUDA` to a single call
-/// against one always-compiled definition.
+/// CUDA. Shared by the no-CUDA implementations of the device entry points, so
+/// they read as one line each.
 ///
 /// @param operation what the caller was asked to do, phrased to follow
 ///        "Cannot ", e.g. "clone CUDA tensor"

--- a/Plugins/Gnn/src/DeviceOps.hpp
+++ b/Plugins/Gnn/src/DeviceOps.hpp
@@ -1,0 +1,68 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include "ActsPlugins/Gnn/Stages.hpp"
+#include "ActsPlugins/Gnn/Tensor.hpp"
+
+#include <cstddef>
+#include <vector>
+
+namespace ActsPlugins::detail {
+
+/// Every operation in this plugin that needs a GPU, declared without naming a
+/// CUDA type: `cudaStream_t` here is the forward-declared `CUstream_st *` from
+/// Tensor.hpp, which is the type the CUDA runtime uses too.
+///
+/// Exactly one implementation is linked -- the `.cu` translation units when the
+/// plugin is built with CUDA, DeviceOpsNoCuda.cpp otherwise -- so callers below
+/// dispatch on the runtime device and need no preprocessor branch. Both
+/// implementations are built by CI, which is what keeps them in step.
+///
+/// Reaching any of these without CUDA means a CUDA tensor was constructed
+/// first, which cudaCreateTensorMemory refuses, so the no-CUDA definitions are
+/// unreachable rather than merely unsupported.
+
+/// Allocate device memory for a tensor. @p ctx must carry a stream.
+TensorPtr cudaCreateTensorMemory(std::size_t nbytes,
+                                 const ExecutionContext &ctx);
+
+/// Copy @p nbytes between host and device in either direction. @p to must carry
+/// a stream.
+void cudaCopyTensorMemory(void *dst, const void *src, std::size_t nbytes,
+                          Device from, const ExecutionContext &to);
+
+/// Apply the logistic function to @p tensor in place.
+void cudaSigmoid(Tensor<float> &tensor, cudaStream_t stream);
+
+/// Element-wise `scores > cut`.
+Tensor<bool> cudaScoreMask(const Tensor<float> &scores, float cut,
+                           cudaStream_t stream);
+
+/// Gather the rows of @p tensor selected by @p mask.
+template <typename T>
+Tensor<T> cudaSelectRows(const Tensor<T> &tensor, const Tensor<bool> &mask,
+                         const ExecutionContext &execContext);
+
+/// Gather the columns of @p tensor selected by @p mask.
+template <typename T>
+Tensor<T> cudaSelectCols(const Tensor<T> &tensor, const Tensor<bool> &mask,
+                         const ExecutionContext &execContext);
+
+/// Scale each column of @p src by the matching entry of @p scales.
+template <typename T>
+Tensor<T> cudaMulPerColumn(const Tensor<T> &src, const Tensor<T> &scales,
+                           const ExecutionContext &execContext);
+
+/// Drop nodes no edge refers to, renumbering the edge index to match.
+PipelineTensors cudaRemoveUnusedNodes(PipelineTensors &&tensors,
+                                      std::vector<int> &spacePointIds,
+                                      const ExecutionContext &execCtx);
+
+}  // namespace ActsPlugins::detail

--- a/Plugins/Gnn/src/DeviceOpsNoCuda.cpp
+++ b/Plugins/Gnn/src/DeviceOpsNoCuda.cpp
@@ -1,0 +1,84 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <cstdint>
+
+#include "CudaUnavailable.hpp"
+#include "DeviceOps.hpp"
+
+namespace ActsPlugins::detail {
+
+TensorPtr cudaCreateTensorMemory(std::size_t /*nbytes*/,
+                                 const ExecutionContext & /*ctx*/) {
+  throwNoCudaSupport("create CUDA tensor");
+}
+
+void cudaCopyTensorMemory(void * /*dst*/, const void * /*src*/,
+                          std::size_t /*nbytes*/, Device /*from*/,
+                          const ExecutionContext & /*to*/) {
+  throwNoCudaSupport("copy CUDA tensor memory");
+}
+
+void cudaSigmoid(Tensor<float> & /*tensor*/, cudaStream_t /*stream*/) {
+  throwNoCudaSupport("apply sigmoid to CUDA tensor");
+}
+
+Tensor<bool> cudaScoreMask(const Tensor<float> & /*scores*/, float /*cut*/,
+                           cudaStream_t /*stream*/) {
+  throwNoCudaSupport("compute score mask on CUDA tensor");
+}
+
+template <typename T>
+Tensor<T> cudaSelectRows(const Tensor<T> & /*tensor*/,
+                         const Tensor<bool> & /*mask*/,
+                         const ExecutionContext & /*execContext*/) {
+  throwNoCudaSupport("selectRows on CUDA tensor");
+}
+
+template <typename T>
+Tensor<T> cudaSelectCols(const Tensor<T> & /*tensor*/,
+                         const Tensor<bool> & /*mask*/,
+                         const ExecutionContext & /*execContext*/) {
+  throwNoCudaSupport("selectCols on CUDA tensor");
+}
+
+template <typename T>
+Tensor<T> cudaMulPerColumn(const Tensor<T> & /*src*/,
+                           const Tensor<T> & /*scales*/,
+                           const ExecutionContext & /*execContext*/) {
+  throwNoCudaSupport("apply feature scales on CUDA tensor");
+}
+
+PipelineTensors cudaRemoveUnusedNodes(PipelineTensors && /*tensors*/,
+                                      std::vector<int> & /*spacePointIds*/,
+                                      const ExecutionContext & /*execCtx*/) {
+  throwNoCudaSupport("removeUnusedNodes on CUDA tensor");
+}
+
+// The same set Tensor.cu instantiates. A mismatch here is a link error in the
+// CUDA-off build, which is why that build is part of CI.
+template Tensor<float> cudaSelectRows(const Tensor<float> &,
+                                      const Tensor<bool> &,
+                                      const ExecutionContext &);
+template Tensor<std::int64_t> cudaSelectRows(const Tensor<std::int64_t> &,
+                                             const Tensor<bool> &,
+                                             const ExecutionContext &);
+template Tensor<float> cudaSelectCols(const Tensor<float> &,
+                                      const Tensor<bool> &,
+                                      const ExecutionContext &);
+template Tensor<std::int64_t> cudaSelectCols(const Tensor<std::int64_t> &,
+                                             const Tensor<bool> &,
+                                             const ExecutionContext &);
+template Tensor<float> cudaMulPerColumn(const Tensor<float> &,
+                                        const Tensor<float> &,
+                                        const ExecutionContext &);
+template Tensor<std::int64_t> cudaMulPerColumn(const Tensor<std::int64_t> &,
+                                               const Tensor<std::int64_t> &,
+                                               const ExecutionContext &);
+
+}  // namespace ActsPlugins::detail

--- a/Plugins/Gnn/src/Stages.cpp
+++ b/Plugins/Gnn/src/Stages.cpp
@@ -11,6 +11,8 @@
 #include <algorithm>
 #include <stdexcept>
 
+#include "CudaUnavailable.hpp"
+
 namespace ActsPlugins {
 
 namespace {
@@ -77,9 +79,7 @@ PipelineTensors removeUnusedNodes(PipelineTensors &&tensors,
     return detail::cudaRemoveUnusedNodes(std::move(tensors), spacePointIds,
                                          execCtx);
 #else
-    throw std::runtime_error(
-        "Cannot removeUnusedNodes on CUDA tensor, library not compiled with "
-        "CUDA");
+    detail::throwNoCudaSupport("removeUnusedNodes on CUDA tensor");
 #endif
   }
 

--- a/Plugins/Gnn/src/Stages.cpp
+++ b/Plugins/Gnn/src/Stages.cpp
@@ -11,7 +11,7 @@
 #include <algorithm>
 #include <stdexcept>
 
-#include "CudaUnavailable.hpp"
+#include "DeviceOps.hpp"
 
 namespace ActsPlugins {
 
@@ -59,14 +59,6 @@ PipelineTensors cpuRemoveUnusedNodes(PipelineTensors &&tensors,
 
 }  // namespace
 
-#ifdef ACTS_GNN_WITH_CUDA
-namespace detail {
-PipelineTensors cudaRemoveUnusedNodes(PipelineTensors &&tensors,
-                                      std::vector<int> &spacePointIds,
-                                      const ExecutionContext &execCtx);
-}  // namespace detail
-#endif
-
 PipelineTensors removeUnusedNodes(PipelineTensors &&tensors,
                                   std::vector<int> &spacePointIds,
                                   const ExecutionContext &execCtx) {
@@ -75,12 +67,8 @@ PipelineTensors removeUnusedNodes(PipelineTensors &&tensors,
   }
 
   if (tensors.nodeFeatures.device().isCuda()) {
-#ifdef ACTS_GNN_WITH_CUDA
     return detail::cudaRemoveUnusedNodes(std::move(tensors), spacePointIds,
                                          execCtx);
-#else
-    detail::throwNoCudaSupport("removeUnusedNodes on CUDA tensor");
-#endif
   }
 
   return cpuRemoveUnusedNodes(std::move(tensors), spacePointIds, execCtx);

--- a/Plugins/Gnn/src/Tensor.cpp
+++ b/Plugins/Gnn/src/Tensor.cpp
@@ -8,14 +8,10 @@
 
 #include "ActsPlugins/Gnn/Tensor.hpp"
 
-#ifdef ACTS_GNN_WITH_CUDA
-#include "ActsPlugins/Gnn/detail/CudaUtils.hpp"
-#endif
-
 #include <cstring>
 #include <span>
 
-#include "CudaUnavailable.hpp"
+#include "DeviceOps.hpp"
 
 namespace ActsPlugins {
 
@@ -30,18 +26,8 @@ TensorPtr createTensorMemory(std::size_t nbytes,
     }
     return TensorPtr(ptr,
                      [](void *p) { delete[] static_cast<std::byte *>(p); });
-  } else {
-#ifdef ACTS_GNN_WITH_CUDA
-    assert(execContext.stream.has_value());
-    auto stream = *execContext.stream;
-    void *ptr{};
-    ACTS_CUDA_CHECK(cudaMallocAsync(&ptr, nbytes, stream));
-    return TensorPtr(
-        ptr, [stream](void *p) { ACTS_CUDA_CHECK(cudaFreeAsync(p, stream)); });
-#else
-    throwNoCudaSupport("create CUDA tensor");
-#endif
   }
+  return cudaCreateTensorMemory(nbytes, execContext);
 }
 
 TensorPtr cloneTensorMemory(const TensorPtr &ptr, std::size_t nbytes,
@@ -50,53 +36,16 @@ TensorPtr cloneTensorMemory(const TensorPtr &ptr, std::size_t nbytes,
   if (devFrom.isCpu() && to.device.isCpu()) {
     std::memcpy(clone.get(), ptr.get(), nbytes);
   } else {
-#ifdef ACTS_GNN_WITH_CUDA
-    assert(to.stream.has_value());
-    if (devFrom.isCuda() && to.device.isCuda()) {
-      ACTS_CUDA_CHECK(cudaMemcpyAsync(clone.get(), ptr.get(), nbytes,
-                                      cudaMemcpyDeviceToDevice, *to.stream));
-    } else if (devFrom.isCpu() && to.device.isCuda()) {
-      ACTS_CUDA_CHECK(cudaMemcpyAsync(clone.get(), ptr.get(), nbytes,
-                                      cudaMemcpyHostToDevice, *to.stream));
-    } else if (devFrom.isCuda() && to.device.isCpu()) {
-      ACTS_CUDA_CHECK(cudaMemcpyAsync(clone.get(), ptr.get(), nbytes,
-                                      cudaMemcpyDeviceToHost, *to.stream));
-    }
-#else
-    throwNoCudaSupport("clone CUDA tensor");
-#endif
+    cudaCopyTensorMemory(clone.get(), ptr.get(), nbytes, devFrom, to);
   }
   return clone;
 }
 
-void cudaSigmoid(Tensor<float> &tensor, cudaStream_t stream);
-
-Tensor<bool> cudaScoreMask(const Tensor<float> &scores, float cut,
-                           cudaStream_t stream);
-
-template <typename T>
-Tensor<T> cudaSelectRows(const Tensor<T> &tensor, const Tensor<bool> &mask,
-                         const ExecutionContext &execContext);
-
-template <typename T>
-Tensor<T> cudaSelectCols(const Tensor<T> &tensor, const Tensor<bool> &mask,
-                         const ExecutionContext &execContext);
-
-template <typename T>
-Tensor<T> cudaMulPerColumn(const Tensor<T> &src, const Tensor<T> &scales,
-                           const ExecutionContext &execContext);
-
 }  // namespace detail
 
-// `stream` is only read on the CUDA path.
-void sigmoid(Tensor<float> &tensor,
-             [[maybe_unused]] std::optional<cudaStream_t> stream) {
+void sigmoid(Tensor<float> &tensor, std::optional<cudaStream_t> stream) {
   if (tensor.device().type == Device::Type::eCUDA) {
-#ifdef ACTS_GNN_WITH_CUDA
-    return ActsPlugins::detail::cudaSigmoid(tensor, stream.value());
-#else
-    detail::throwNoCudaSupport("apply sigmoid to CUDA tensor");
-#endif
+    return detail::cudaSigmoid(tensor, stream.value());
   }
 
   for (auto it = tensor.data(); it != tensor.data() + tensor.size(); ++it) {
@@ -153,31 +102,25 @@ std::pair<Tensor<std::int64_t>, std::optional<Tensor<float>>> applyEdgeLimit(
                 newEdgeFeatureTensor->data());
     }
   } else {
-#ifdef ACTS_GNN_WITH_CUDA
     ExecutionContext gpuCtx{edgeIndex.device(), stream};
+    const Device devFrom = edgeIndex.device();
 
     newEdgeIndexTensor = Tensor<std::int64_t>::Create({2, maxEdges}, gpuCtx);
-    ACTS_CUDA_CHECK(cudaMemcpyAsync(newEdgeIndexTensor->data(),
-                                    edgeIndex.data(),
-                                    maxEdges * sizeof(std::int64_t),
-                                    cudaMemcpyDeviceToDevice, stream.value()));
-    ACTS_CUDA_CHECK(cudaMemcpyAsync(newEdgeIndexTensor->data() + maxEdges,
-                                    edgeIndex.data() + nEdgesOld,
-                                    maxEdges * sizeof(std::int64_t),
-                                    cudaMemcpyDeviceToDevice, stream.value()));
+    detail::cudaCopyTensorMemory(newEdgeIndexTensor->data(), edgeIndex.data(),
+                                 maxEdges * sizeof(std::int64_t), devFrom,
+                                 gpuCtx);
+    detail::cudaCopyTensorMemory(
+        newEdgeIndexTensor->data() + maxEdges, edgeIndex.data() + nEdgesOld,
+        maxEdges * sizeof(std::int64_t), devFrom, gpuCtx);
 
     if (edgeFeatures.has_value()) {
       newEdgeFeatureTensor =
           Tensor<float>::Create({maxEdges, nEdgeFeatures}, gpuCtx);
 
-      ACTS_CUDA_CHECK(
-          cudaMemcpyAsync(newEdgeFeatureTensor->data(), edgeFeatures->data(),
-                          maxEdges * nEdgeFeatures * sizeof(float),
-                          cudaMemcpyDeviceToDevice, stream.value()));
+      detail::cudaCopyTensorMemory(
+          newEdgeFeatureTensor->data(), edgeFeatures->data(),
+          maxEdges * nEdgeFeatures * sizeof(float), devFrom, gpuCtx);
     }
-#else
-    detail::throwNoCudaSupport("apply edge limit to CUDA tensors");
-#endif
   }
 
   return {std::move(newEdgeIndexTensor.value()),
@@ -192,11 +135,7 @@ Tensor<bool> scoreMask(const Tensor<float> &scores, float cut,
   ExecutionContext execContext{scores.device(), stream};
 
   if (scores.device().type == Device::Type::eCUDA) {
-#ifdef ACTS_GNN_WITH_CUDA
     return detail::cudaScoreMask(scores, cut, stream.value());
-#else
-    detail::throwNoCudaSupport("compute score mask on CUDA tensor");
-#endif
   }
 
   auto mask = Tensor<bool>::Create(scores.shape(), execContext);
@@ -213,11 +152,7 @@ Tensor<T> selectRows(const Tensor<T> &tensor, const Tensor<bool> &mask,
   const auto nCols = tensor.shape()[1];
 
   if (tensor.device().type == Device::Type::eCUDA) {
-#ifdef ACTS_GNN_WITH_CUDA
     return detail::cudaSelectRows(tensor, mask, execContext);
-#else
-    detail::throwNoCudaSupport("selectRows on CUDA tensor");
-#endif
   }
 
   const std::size_t n =
@@ -242,11 +177,7 @@ Tensor<T> selectCols(const Tensor<T> &tensor, const Tensor<bool> &mask,
   const auto nColsSrc = tensor.shape()[1];
 
   if (tensor.device().type == Device::Type::eCUDA) {
-#ifdef ACTS_GNN_WITH_CUDA
     return detail::cudaSelectCols(tensor, mask, execContext);
-#else
-    detail::throwNoCudaSupport("selectCols on CUDA tensor");
-#endif
   }
 
   const std::size_t n =
@@ -274,17 +205,11 @@ Tensor<T> mulPerColumn(const Tensor<T> &src, const std::vector<T> &scales,
   }
 
   if (execContext.device.type == Device::Type::eCUDA) {
-#ifdef ACTS_GNN_WITH_CUDA
     // Move scales to device (as Tensor)
     auto scalesTensor = Tensor<T>::Create({cols, 1ul}, execContext);
-    assert(execContext.stream.has_value());
-    ACTS_CUDA_CHECK(cudaMemcpyAsync(scalesTensor.data(), scales.data(),
-                                    cols * sizeof(T), cudaMemcpyHostToDevice,
-                                    *execContext.stream));
+    detail::cudaCopyTensorMemory(scalesTensor.data(), scales.data(),
+                                 cols * sizeof(T), Device::Cpu(), execContext);
     return detail::cudaMulPerColumn(src, scalesTensor, execContext);
-#else
-    detail::throwNoCudaSupport("apply feature scales on CUDA tensor");
-#endif
   }
 
   auto result = Tensor<T>::Create({rows, cols}, execContext);

--- a/Plugins/Gnn/src/Tensor.cpp
+++ b/Plugins/Gnn/src/Tensor.cpp
@@ -15,6 +15,8 @@
 #include <cstring>
 #include <span>
 
+#include "CudaUnavailable.hpp"
+
 namespace ActsPlugins {
 
 namespace detail {
@@ -37,8 +39,7 @@ TensorPtr createTensorMemory(std::size_t nbytes,
     return TensorPtr(
         ptr, [stream](void *p) { ACTS_CUDA_CHECK(cudaFreeAsync(p, stream)); });
 #else
-    throw std::runtime_error(
-        "Cannot create CUDA tensor, library was not compiled with CUDA");
+    throwNoCudaSupport("create CUDA tensor");
 #endif
   }
 }
@@ -62,8 +63,7 @@ TensorPtr cloneTensorMemory(const TensorPtr &ptr, std::size_t nbytes,
                                       cudaMemcpyDeviceToHost, *to.stream));
     }
 #else
-    throw std::runtime_error(
-        "Cannot clone CUDA tensor, library was not compiled with CUDA");
+    throwNoCudaSupport("clone CUDA tensor");
 #endif
   }
   return clone;
@@ -88,14 +88,14 @@ Tensor<T> cudaMulPerColumn(const Tensor<T> &src, const Tensor<T> &scales,
 
 }  // namespace detail
 
-void sigmoid(Tensor<float> &tensor, std::optional<cudaStream_t> stream) {
+// `stream` is only read on the CUDA path.
+void sigmoid(Tensor<float> &tensor,
+             [[maybe_unused]] std::optional<cudaStream_t> stream) {
   if (tensor.device().type == Device::Type::eCUDA) {
 #ifdef ACTS_GNN_WITH_CUDA
     return ActsPlugins::detail::cudaSigmoid(tensor, stream.value());
 #else
-    throw std::runtime_error(
-        "Cannot apply sigmoid to CUDA tensor, library was not compiled with "
-        "CUDA");
+    detail::throwNoCudaSupport("apply sigmoid to CUDA tensor");
 #endif
   }
 
@@ -176,9 +176,7 @@ std::pair<Tensor<std::int64_t>, std::optional<Tensor<float>>> applyEdgeLimit(
                           cudaMemcpyDeviceToDevice, stream.value()));
     }
 #else
-    throw std::runtime_error(
-        "Cannot apply edge limit to CUDA tensors, library was not compiled "
-        "with CUDA");
+    detail::throwNoCudaSupport("apply edge limit to CUDA tensors");
 #endif
   }
 
@@ -197,9 +195,7 @@ Tensor<bool> scoreMask(const Tensor<float> &scores, float cut,
 #ifdef ACTS_GNN_WITH_CUDA
     return detail::cudaScoreMask(scores, cut, stream.value());
 #else
-    throw std::runtime_error(
-        "Cannot compute score mask on CUDA tensor, library was not compiled "
-        "with CUDA");
+    detail::throwNoCudaSupport("compute score mask on CUDA tensor");
 #endif
   }
 
@@ -220,8 +216,7 @@ Tensor<T> selectRows(const Tensor<T> &tensor, const Tensor<bool> &mask,
 #ifdef ACTS_GNN_WITH_CUDA
     return detail::cudaSelectRows(tensor, mask, execContext);
 #else
-    throw std::runtime_error(
-        "Cannot selectRows on CUDA tensor, library was not compiled with CUDA");
+    detail::throwNoCudaSupport("selectRows on CUDA tensor");
 #endif
   }
 
@@ -250,8 +245,7 @@ Tensor<T> selectCols(const Tensor<T> &tensor, const Tensor<bool> &mask,
 #ifdef ACTS_GNN_WITH_CUDA
     return detail::cudaSelectCols(tensor, mask, execContext);
 #else
-    throw std::runtime_error(
-        "Cannot selectCols on CUDA tensor, library was not compiled with CUDA");
+    detail::throwNoCudaSupport("selectCols on CUDA tensor");
 #endif
   }
 
@@ -289,9 +283,7 @@ Tensor<T> mulPerColumn(const Tensor<T> &src, const std::vector<T> &scales,
                                     *execContext.stream));
     return detail::cudaMulPerColumn(src, scalesTensor, execContext);
 #else
-    throw std::runtime_error(
-        "Cannot apply feature scales on CUDA tensor, library was not compiled "
-        "with CUDA");
+    detail::throwNoCudaSupport("apply feature scales on CUDA tensor");
 #endif
   }
 

--- a/Plugins/Gnn/src/Tensor.cu
+++ b/Plugins/Gnn/src/Tensor.cu
@@ -14,6 +14,8 @@
 #include <thrust/execution_policy.h>
 #include <thrust/iterator/counting_iterator.h>
 
+#include "DeviceOps.hpp"
+
 namespace {
 
 __global__ void sigmoidImpl(std::size_t size, float *array) {
@@ -87,6 +89,30 @@ __global__ void mulPerColKernel(std::size_t total, std::size_t cols,
 }  // namespace
 
 namespace ActsPlugins::detail {
+
+TensorPtr cudaCreateTensorMemory(std::size_t nbytes,
+                                 const ExecutionContext &ctx) {
+  assert(ctx.stream.has_value());
+  auto stream = *ctx.stream;
+  void *ptr{};
+  ACTS_CUDA_CHECK(cudaMallocAsync(&ptr, nbytes, stream));
+  return TensorPtr(
+      ptr, [stream](void *p) { ACTS_CUDA_CHECK(cudaFreeAsync(p, stream)); });
+}
+
+void cudaCopyTensorMemory(void *dst, const void *src, std::size_t nbytes,
+                          Device from, const ExecutionContext &to) {
+  assert(to.stream.has_value());
+  cudaMemcpyKind kind = cudaMemcpyHostToHost;
+  if (from.isCuda() && to.device.isCuda()) {
+    kind = cudaMemcpyDeviceToDevice;
+  } else if (from.isCpu() && to.device.isCuda()) {
+    kind = cudaMemcpyHostToDevice;
+  } else if (from.isCuda() && to.device.isCpu()) {
+    kind = cudaMemcpyDeviceToHost;
+  }
+  ACTS_CUDA_CHECK(cudaMemcpyAsync(dst, src, nbytes, kind, *to.stream));
+}
 
 void cudaSigmoid(Tensor<float> &tensor, cudaStream_t stream) {
   dim3 blockDim = 1024;

--- a/Plugins/Gnn/src/buildEdges.cpp
+++ b/Plugins/Gnn/src/buildEdges.cpp
@@ -19,18 +19,6 @@
 #include <torch/script.h>
 #include <torch/torch.h>
 
-#ifdef ACTS_GNN_WITH_CUDA
-#include <cuda.h>
-#include <cuda_runtime_api.h>
-#include <grid/counting_sort.h>
-#include <grid/find_nbrs.h>
-#include <grid/grid.h>
-#include <grid/insert_points.h>
-#include <grid/prefix_sum.h>
-#endif
-
-#include "CudaUnavailable.hpp"
-
 using namespace torch::indexing;
 
 using namespace Acts;
@@ -64,121 +52,6 @@ torch::Tensor ActsPlugins::detail::postprocessEdgeTensor(torch::Tensor edges,
   }
 
   return edges.toType(torch::kInt64);
-}
-
-torch::Tensor ActsPlugins::detail::buildEdgesFRNN(torch::Tensor &embedFeatures,
-                                                  float rVal, int kVal,
-                                                  bool flipDirections) {
-#ifdef ACTS_GNN_WITH_CUDA
-  const auto device = embedFeatures.device();
-
-  const std::int64_t numSpacePoints = embedFeatures.size(0);
-  const int dim = embedFeatures.size(1);
-
-  const int grid_params_size = 8;
-  const int grid_delta_idx = 3;
-  const int grid_total_idx = 7;
-  const int grid_max_res = 128;
-  const int grid_dim = 3;
-
-  if (dim < 3) {
-    throw std::runtime_error("DIM < 3 is not supported for now.\n");
-  }
-
-  const float radius_cell_ratio = 2.0;
-  const int batch_size = 1;
-  int G = -1;
-
-  // Set up grid properties
-  torch::Tensor grid_min;
-  torch::Tensor grid_max;
-  torch::Tensor grid_size;
-
-  torch::Tensor embedTensor = embedFeatures.reshape({1, numSpacePoints, dim});
-  torch::Tensor gridParamsCuda =
-      torch::zeros({batch_size, grid_params_size}, device).to(torch::kFloat32);
-  torch::Tensor r_tensor = torch::full({batch_size}, rVal, device);
-  torch::Tensor lengths = torch::full({batch_size}, numSpacePoints, device);
-
-  // build the grid
-  for (int i = 0; i < batch_size; i++) {
-    torch::Tensor allPoints =
-        embedTensor.index({i, Slice(None, lengths.index({i}).item().to<long>()),
-                           Slice(None, grid_dim)});
-    grid_min = std::get<0>(allPoints.min(0));
-    grid_max = std::get<0>(allPoints.max(0));
-    gridParamsCuda.index_put_({i, Slice(None, grid_delta_idx)}, grid_min);
-
-    grid_size = grid_max - grid_min;
-
-    float cell_size =
-        r_tensor.index({i}).item().to<float>() / radius_cell_ratio;
-
-    if (cell_size < (grid_size.min().item().to<float>() / grid_max_res)) {
-      cell_size = grid_size.min().item().to<float>() / grid_max_res;
-    }
-
-    gridParamsCuda.index_put_({i, grid_delta_idx}, 1 / cell_size);
-
-    gridParamsCuda.index_put_({i, Slice(1 + grid_delta_idx, grid_total_idx)},
-                              floor(grid_size / cell_size) + 1);
-
-    gridParamsCuda.index_put_(
-        {i, grid_total_idx},
-        gridParamsCuda.index({i, Slice(1 + grid_delta_idx, grid_total_idx)})
-            .prod());
-
-    if (G < gridParamsCuda.index({i, grid_total_idx}).item().to<int>()) {
-      G = gridParamsCuda.index({i, grid_total_idx}).item().to<int>();
-    }
-  }
-
-  torch::Tensor pc_grid_cnt =
-      torch::zeros({batch_size, G}, device).to(torch::kInt32);
-  torch::Tensor pc_grid_cell =
-      torch::full({batch_size, numSpacePoints}, -1, device).to(torch::kInt32);
-  torch::Tensor pc_grid_idx =
-      torch::full({batch_size, numSpacePoints}, -1, device).to(torch::kInt32);
-
-  // put space points into the grid
-  InsertPointsCUDA(embedTensor, lengths.to(torch::kInt64), gridParamsCuda,
-                   pc_grid_cnt, pc_grid_cell, pc_grid_idx, G);
-
-  torch::Tensor pc_grid_off =
-      torch::full({batch_size, G}, 0, device).to(torch::kInt32);
-  torch::Tensor grid_params = gridParamsCuda.to(torch::kCPU);
-
-  // for loop seems not to be necessary anymore
-  pc_grid_off = PrefixSumCUDA(pc_grid_cnt, grid_params);
-
-  torch::Tensor sorted_points =
-      torch::zeros({batch_size, numSpacePoints, dim}, device)
-          .to(torch::kFloat32);
-  torch::Tensor sorted_points_idxs =
-      torch::full({batch_size, numSpacePoints}, -1, device).to(torch::kInt32);
-
-  CountingSortCUDA(embedTensor, lengths.to(torch::kInt64), pc_grid_cell,
-                   pc_grid_idx, pc_grid_off, sorted_points, sorted_points_idxs);
-
-  auto [indices, distances] = FindNbrsCUDA(
-      sorted_points, sorted_points, lengths.to(torch::kInt64),
-      lengths.to(torch::kInt64), pc_grid_off.to(torch::kInt32),
-      sorted_points_idxs, sorted_points_idxs,
-      gridParamsCuda.to(torch::kFloat32), kVal, r_tensor, r_tensor * r_tensor);
-  torch::Tensor positiveIndices = indices >= 0;
-
-  torch::Tensor repeatRange = torch::arange(positiveIndices.size(1), device)
-                                  .repeat({1, positiveIndices.size(2), 1})
-                                  .transpose(1, 2);
-
-  torch::Tensor stackedEdges = torch::stack(
-      {repeatRange.index({positiveIndices}), indices.index({positiveIndices})});
-
-  return postprocessEdgeTensor(std::move(stackedEdges), true, true,
-                               flipDirections);
-#else
-  ActsPlugins::detail::throwNoCudaSupport("run ActsPlugins::buildEdgesFRNN");
-#endif
 }
 
 /// This is a very unsophisticated span implementation to avoid data copies in
@@ -268,10 +141,8 @@ torch::Tensor ActsPlugins::detail::buildEdgesKDTree(
 torch::Tensor ActsPlugins::detail::buildEdges(torch::Tensor &embedFeatures,
                                               float rVal, int kVal,
                                               bool flipDirections) {
-#ifdef ACTS_GNN_WITH_CUDA
   if (embedFeatures.is_cuda()) {
     return detail::buildEdgesFRNN(embedFeatures, rVal, kVal, flipDirections);
   }
-#endif
   return detail::buildEdgesKDTree(embedFeatures, rVal, kVal, flipDirections);
 }

--- a/Plugins/Gnn/src/buildEdges.cpp
+++ b/Plugins/Gnn/src/buildEdges.cpp
@@ -29,6 +29,8 @@
 #include <grid/prefix_sum.h>
 #endif
 
+#include "CudaUnavailable.hpp"
+
 using namespace torch::indexing;
 
 using namespace Acts;
@@ -175,8 +177,7 @@ torch::Tensor ActsPlugins::detail::buildEdgesFRNN(torch::Tensor &embedFeatures,
   return postprocessEdgeTensor(std::move(stackedEdges), true, true,
                                flipDirections);
 #else
-  throw std::runtime_error(
-      "ACTS not compiled with CUDA, cannot run ActsPlugins::buildEdgesFRNN");
+  ActsPlugins::detail::throwNoCudaSupport("run ActsPlugins::buildEdgesFRNN");
 #endif
 }
 

--- a/Plugins/Gnn/src/buildEdgesFRNN.cpp
+++ b/Plugins/Gnn/src/buildEdgesFRNN.cpp
@@ -1,0 +1,135 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "ActsPlugins/Gnn/detail/buildEdges.hpp"
+
+#include <cstdint>
+#include <stdexcept>
+#include <utility>
+
+#include <cuda.h>
+#include <cuda_runtime_api.h>
+#include <grid/counting_sort.h>
+#include <grid/find_nbrs.h>
+#include <grid/grid.h>
+#include <grid/insert_points.h>
+#include <grid/prefix_sum.h>
+#include <torch/torch.h>
+
+using namespace torch::indexing;
+
+torch::Tensor ActsPlugins::detail::buildEdgesFRNN(torch::Tensor &embedFeatures,
+                                                  float rVal, int kVal,
+                                                  bool flipDirections) {
+  const auto device = embedFeatures.device();
+
+  const std::int64_t numSpacePoints = embedFeatures.size(0);
+  const int dim = embedFeatures.size(1);
+
+  const int grid_params_size = 8;
+  const int grid_delta_idx = 3;
+  const int grid_total_idx = 7;
+  const int grid_max_res = 128;
+  const int grid_dim = 3;
+
+  if (dim < 3) {
+    throw std::runtime_error("DIM < 3 is not supported for now.\n");
+  }
+
+  const float radius_cell_ratio = 2.0;
+  const int batch_size = 1;
+  int G = -1;
+
+  // Set up grid properties
+  torch::Tensor grid_min;
+  torch::Tensor grid_max;
+  torch::Tensor grid_size;
+
+  torch::Tensor embedTensor = embedFeatures.reshape({1, numSpacePoints, dim});
+  torch::Tensor gridParamsCuda =
+      torch::zeros({batch_size, grid_params_size}, device).to(torch::kFloat32);
+  torch::Tensor r_tensor = torch::full({batch_size}, rVal, device);
+  torch::Tensor lengths = torch::full({batch_size}, numSpacePoints, device);
+
+  // build the grid
+  for (int i = 0; i < batch_size; i++) {
+    torch::Tensor allPoints =
+        embedTensor.index({i, Slice(None, lengths.index({i}).item().to<long>()),
+                           Slice(None, grid_dim)});
+    grid_min = std::get<0>(allPoints.min(0));
+    grid_max = std::get<0>(allPoints.max(0));
+    gridParamsCuda.index_put_({i, Slice(None, grid_delta_idx)}, grid_min);
+
+    grid_size = grid_max - grid_min;
+
+    float cell_size =
+        r_tensor.index({i}).item().to<float>() / radius_cell_ratio;
+
+    if (cell_size < (grid_size.min().item().to<float>() / grid_max_res)) {
+      cell_size = grid_size.min().item().to<float>() / grid_max_res;
+    }
+
+    gridParamsCuda.index_put_({i, grid_delta_idx}, 1 / cell_size);
+
+    gridParamsCuda.index_put_({i, Slice(1 + grid_delta_idx, grid_total_idx)},
+                              floor(grid_size / cell_size) + 1);
+
+    gridParamsCuda.index_put_(
+        {i, grid_total_idx},
+        gridParamsCuda.index({i, Slice(1 + grid_delta_idx, grid_total_idx)})
+            .prod());
+
+    if (G < gridParamsCuda.index({i, grid_total_idx}).item().to<int>()) {
+      G = gridParamsCuda.index({i, grid_total_idx}).item().to<int>();
+    }
+  }
+
+  torch::Tensor pc_grid_cnt =
+      torch::zeros({batch_size, G}, device).to(torch::kInt32);
+  torch::Tensor pc_grid_cell =
+      torch::full({batch_size, numSpacePoints}, -1, device).to(torch::kInt32);
+  torch::Tensor pc_grid_idx =
+      torch::full({batch_size, numSpacePoints}, -1, device).to(torch::kInt32);
+
+  // put space points into the grid
+  InsertPointsCUDA(embedTensor, lengths.to(torch::kInt64), gridParamsCuda,
+                   pc_grid_cnt, pc_grid_cell, pc_grid_idx, G);
+
+  torch::Tensor pc_grid_off =
+      torch::full({batch_size, G}, 0, device).to(torch::kInt32);
+  torch::Tensor grid_params = gridParamsCuda.to(torch::kCPU);
+
+  // for loop seems not to be necessary anymore
+  pc_grid_off = PrefixSumCUDA(pc_grid_cnt, grid_params);
+
+  torch::Tensor sorted_points =
+      torch::zeros({batch_size, numSpacePoints, dim}, device)
+          .to(torch::kFloat32);
+  torch::Tensor sorted_points_idxs =
+      torch::full({batch_size, numSpacePoints}, -1, device).to(torch::kInt32);
+
+  CountingSortCUDA(embedTensor, lengths.to(torch::kInt64), pc_grid_cell,
+                   pc_grid_idx, pc_grid_off, sorted_points, sorted_points_idxs);
+
+  auto [indices, distances] = FindNbrsCUDA(
+      sorted_points, sorted_points, lengths.to(torch::kInt64),
+      lengths.to(torch::kInt64), pc_grid_off.to(torch::kInt32),
+      sorted_points_idxs, sorted_points_idxs,
+      gridParamsCuda.to(torch::kFloat32), kVal, r_tensor, r_tensor * r_tensor);
+  torch::Tensor positiveIndices = indices >= 0;
+
+  torch::Tensor repeatRange = torch::arange(positiveIndices.size(1), device)
+                                  .repeat({1, positiveIndices.size(2), 1})
+                                  .transpose(1, 2);
+
+  torch::Tensor stackedEdges = torch::stack(
+      {repeatRange.index({positiveIndices}), indices.index({positiveIndices})});
+
+  return postprocessEdgeTensor(std::move(stackedEdges), true, true,
+                               flipDirections);
+}

--- a/Plugins/Gnn/src/buildEdgesFRNNNoCuda.cpp
+++ b/Plugins/Gnn/src/buildEdgesFRNNNoCuda.cpp
@@ -1,0 +1,19 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "ActsPlugins/Gnn/detail/buildEdges.hpp"
+
+#include <torch/torch.h>
+
+#include "CudaUnavailable.hpp"
+
+torch::Tensor ActsPlugins::detail::buildEdgesFRNN(
+    torch::Tensor & /*embedFeatures*/, float /*rVal*/, int /*kVal*/,
+    bool /*flipDirections*/) {
+  throwNoCudaSupport("run FRNN edge building");
+}

--- a/Plugins/Gnn/src/printCudaMemInfo.hpp
+++ b/Plugins/Gnn/src/printCudaMemInfo.hpp
@@ -33,12 +33,12 @@ inline void printCudaMemInfo(const Acts::Logger& logger) {
     ACTS_VERBOSE("Current CUDA device: " << device);
     ACTS_VERBOSE("Memory (used / total) [in MB]: " << (total - free) / mb
                                                    << " / " << total / mb);
-  } else {
-    ACTS_VERBOSE("No memory info, CUDA disabled");
+    return;
   }
-#else
-  ACTS_VERBOSE("No memory info, CUDA disabled");
 #endif
+  // Nothing to report: CUDA is compiled out, or the level would discard the
+  // query above anyway.
+  ACTS_VERBOSE("No memory info, CUDA disabled");
 }
 
 }  // namespace


### PR DESCRIPTION
Follow-up to #5859, which removed `gnn_cpu`. andiwand pointed out on that PR that the GNN plugin's `#ifdef ACTS_GNN_WITH_CUDA` / `#else` code would stop being compiled. It would have, and looking into it turned up two neighbouring gaps in the same job.

**The plugin's device code is now selected at link time, not by the preprocessor.** `Tensor.cpp`, `Stages.cpp` and `buildEdges.cpp` contain no `ACTS_GNN_WITH_CUDA`. Every operation needing a GPU is declared once in `Plugins/Gnn/src/DeviceOps.hpp` and implemented twice: the `.cu` translation units when the plugin is built with CUDA, `DeviceOpsNoCuda.cpp` otherwise. Host code calls those entry points unconditionally and keeps dispatching on the runtime device, exactly as before.

The declarations need no CUDA type: `Tensor.hpp` forward-declares `CUstream_st` and aliases `cudaStream_t` to a pointer to it, which is the type the CUDA runtime uses too, so one header is valid both in a `.cu` and in a build with no toolkit. Four sites called the runtime directly rather than dispatching; those move behind `cudaCreateTensorMemory` and `cudaCopyTensorMemory` in `Tensor.cu`. Both take the `ExecutionContext` rather than a bare stream, so the assertion that a stream was supplied stays on the CUDA side. FRNN edge building gets the same treatment one level up, in `buildEdgesFRNN.cpp` and `buildEdgesFRNNNoCuda.cpp`.

The gain is that the host translation units are now identical in both configurations, so there is no configuration-dependent host code left to keep in step. The cost is that a signature changing in `Tensor.cu` and not in `DeviceOpsNoCuda.cpp` is an undefined symbol rather than a compile error — which is caught, because:

**`gnn_build` compiles the CUDA-off configuration too.** It configures with `ACTS_ENABLE_CUDA=OFF`, builds `--target ActsPluginGnn`, then reconfigures and does the real CUDA build in the same directory. `ACTS_GNN_WITH_CUDA` is a compile definition on `ActsPluginGnn` alone — no `ActsCore` command line mentions it — so every Core object stays valid and only the plugin's own translation units are compiled twice. The `.cu` sources are not in the target at all with CUDA off, so the expensive half is skipped. Building the one target keeps it bounded; the definition is `PUBLIC`, so a full build would pull in the plugin's consumers. The CPU pass runs first, so a broken CPU path fails before the CUDA and Torch compiles are paid for, and the tree `gnn_gpu` receives is the one the real configure produced.

Worth knowing before anyone simplifies it: `-DACTS_ENABLE_CUDA=OFF` alone does nothing here, because `set_option_if` forces it back ON whenever `ACTS_GNN_ENABLE_MODULEMAP` is set with the plugin, and the preset sets both. Hence the module map going off alongside it, which costs no C++ coverage — `ACTS_GNN_WITH_MODULEMAP` guards a `.cu` source and nothing else.

**Warnings are errors in this job now.** Every other CI preset inherits `ci-common` and gets `CMAKE_COMPILE_WARNING_AS_ERROR`; `github-ci-gnn` inherits `common` and set `-w` on top, so the GNN plugin, the GNN examples and the GNN python bindings — the only ACTS code this job compiles that no other job does — were the one corner where warnings neither failed a build nor appeared in a log. Set directly rather than by switching inheritance, which would pull in DD4hep, EDM4hep, GeoModel, Geant4 Fatras, benchmarks and alignment.

**And it stops building the tests it never runs.** `gnn_gpu` runs `ctest -R "(Gnn|ConnectedComponentsCuda|JunctionRemoval|Tensor)"`, which matches four executables, all in `Tests/UnitTests/Plugins/Gnn`; the integration tests are already excluded from the artifact by the Package step, so they were compiled and discarded. Core unit tests, Examples unit tests and integration tests go off. This restores most of what #5803 did for `gnn_cpu` and #5859 lost along with the job. ODD, DD4hep and ROOT stay on, unlike that preset: `gnn_gpu` also runs the `-k gpu` python tests, which need a detector and read back ROOT output.

--- END COMMIT MESSAGE ---

## Notes for reviewers

**The new job earned its place on its first run.** Before the link-time refactor was added, it failed on `buildEdges.cpp` with four `-Werror=unused-parameter` for `buildEdgesFRNN`'s arguments, unused because the `#ifdef` deletes the body and leaves only a throw. That is a real defect on `main` today, invisible to every existing job, and exactly the class that no amount of restructuring the `#else` arms would have found — only compiling the configuration does. The refactor removes it at the source, since `buildEdgesFRNN` leaves `buildEdges.cpp` entirely.

**One behaviour change, in the `buildEdges` dispatcher.** It routed CUDA tensors to the KD-tree implementation when built without CUDA; that path takes `data_ptr<float>()` and dereferences it on the host, so a device pointer there is undefined behaviour rather than a fallback. It now calls `buildEdgesFRNN`, which throws. Only reachable if a CUDA tensor exists in a non-CUDA build, which `TorchMetricLearning` asserts against — though that assert is a no-op under `NDEBUG`, so an exception seems clearly better than the alternative. Happy to restore the old routing if anyone disagrees.

**What still has a preprocessor branch, deliberately.** `GnnPipeline.cpp`'s CUDA stream guard and `printCudaMemInfo.hpp` use `#ifdef` with no `#else`, and the Torch classifiers keep their `CUDAGuard`/`assert` pairs. Those omit code rather than replace it, so there is no second implementation to drift out of step, and folding them in would mean changing stream and guard ownership.

**Verification.** Locally, with `ACTS_BUILD_PLUGIN_GNN=ON, ACTS_GNN_ENABLE_TORCH=OFF, ACTS_ENABLE_CUDA=OFF`: the plugin compiles and links warning-free and all four GNN unit tests pass; the test trim leaves exactly the four executables `gnn_gpu` matches; the forced-CUDA behaviour above reproduces. Not reachable locally, and so first exercised by this PR's own CI: `buildEdges.cpp` and both FRNN translation units, which need the Torch backend — `buildEdgesFRNN.cpp` in particular is a verbatim move of the previous `#ifdef` body. The CUDA toggle itself is not exercised end to end either, since it needs a CUDA toolkit; what was checked directly is the target scoping it relies on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9MmXvVAyVC1KaDDt7Xm5o
