### PR TITLE
ci: add merge_group triggers for merge queue readiness

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -11,6 +11,13 @@ on:
       - 'develop/**'
     paths-ignore:
       - "docs/**"
+  # merge_group does not support branch/path filters, so this runs
+  # unconditionally on every queue entry. Only build_debug is required, via
+  # merge-sentinel's "Analysis / build_debug" check; clang_tidy is skipped
+  # below since it isn't required and its incremental diff relies on
+  # github.base_ref, which merge_group runs don't have.
+  merge_group:
+    types: [checks_requested]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -155,6 +162,9 @@ jobs:
           echo "**🛡️ Code coverage available [here]($link)**" >> $GITHUB_STEP_SUMMARY
 
   clang_tidy:
+    # Not required for merging; skip on merge_group since its incremental
+    # diff below depends on github.base_ref, which only pull_request runs set.
+    if: github.event_name != 'merge_group'
     runs-on: ubuntu-latest
     container: ghcr.io/acts-project/ubuntu2404_clang22:87
 

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -9,6 +9,11 @@ on:
       - 'develop/**'
     paths-ignore:
       - "docs/**"
+  # merge_group does not support branch/path filters, so this runs
+  # unconditionally on every queue entry (unlike the pull_request trigger
+  # above). Required via merge-sentinel's "Builds / *" pattern.
+  merge_group:
+    types: [checks_requested]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -7,6 +7,9 @@ on:
       - main
       - 'release/**'
       - 'develop/**'
+  # Required directly ("lint") and via merge-sentinel's "Checks / *" pattern.
+  merge_group:
+    types: [checks_requested]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/.github/workflows/detray.yml
+++ b/.github/workflows/detray.yml
@@ -11,6 +11,12 @@ on:
     paths:
       - "Detray/**"
       - ".github/workflows/detray.yml"
+  # merge_group does not support path filters, so this runs on every queue
+  # entry targeting main, not just ones touching Detray/. Only required via
+  # merge-sentinel's "Detray / *" pattern, which is itself path-gated, so a
+  # non-Detray entry running this wastes compute but doesn't block merging.
+  merge_group:
+    types: [checks_requested]
 
 # Cancel existing jobs on new pushes.
 concurrency:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,9 @@ on:
       - main
       - 'release/**'
       - 'develop/**'
+  # Required directly ("docs") and via merge-sentinel's "Docs / docs" check.
+  merge_group:
+    types: [checks_requested]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -16,6 +16,9 @@ permissions:
 
 jobs:
   post_comment:
+    # Builds also runs on push and merge_group, neither of which has a PR to
+    # comment on ("Determine PR number" below would fail resolving one).
+    if: github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -21,7 +21,15 @@ jobs:
     name: SonarCloud
     runs-on: ubuntu-latest
     container: ghcr.io/acts-project/ubuntu2404:87
-    if: github.event.workflow_run.conclusion == 'success'
+    # Only pull_request and push-to-main are handled below (PR mode / push
+    # mode). Analysis also runs on merge_group, which matches neither, so
+    # skip the job outright instead of paying for checkout+deps to do nothing.
+    if: |
+      github.event.workflow_run.conclusion == 'success' &&
+      (
+        github.event.workflow_run.event == 'pull_request' ||
+        (github.event.workflow_run.event == 'push' && github.ref == 'refs/heads/main')
+      )
     steps:
       - name: Install APT packages
         run: |


### PR DESCRIPTION
## Summary
Part of evaluating a switch to GitHub's native merge queue on `main`. Adds `merge_group` triggers to the workflows that actually gate merges (directly required, or required via merge-sentinel's rules), and guards the `workflow_run`-triggered downstream workflows against firing on merge-queue runs.

- `builds.yml`, `checks.yml`, `docs.yml`, `detray.yml`: add `merge_group: types: [checks_requested]`.
- `analysis.yml`: add the same trigger, but skip the non-required `clang_tidy` job on `merge_group` — it isn't required for merging and its incremental diff relies on `github.base_ref`, which merge_group runs don't set.
- `report.yml`: guard the `post_comment` job to `pull_request`-triggered upstream runs only — it resolves a PR number from the upstream run's branch, which doesn't exist for a merge-queue temp branch.
- `sonarcloud.yml`: move the existing per-step `pull_request`/`push` guards up to the job level, so a `merge_group`-triggered upstream run skips outright instead of paying for checkout + dependency install to do nothing.

Not touched, intentionally:
- `devcontainer-ci.yml`, `traccc.yml`: not required checks, already validated pre-queue.
- `labels.yml`, `milestone.yml`, `pr-lint.yml`, `remove-automerge-label.yml`: `pull_request_target`-based PR-metadata workflows; `merge_group` has no PR to act on.

Note `merge_group` doesn't support `branches`/`paths` filters at the trigger level (unlike `push`/`pull_request`), so `builds.yml`/`analysis.yml` will now run on every queue entry regardless of docs-only changes, and `detray.yml` on every entry regardless of whether `Detray/` changed — an extra-compute tradeoff, not a correctness issue.

Separately: `Validate PR title` and `check_milestone` are currently direct required status checks in branch protection, but structurally can't run on `merge_group` (no PR to validate). GitHub currently shares one required-checks list between PR entry and merge-queue merge, so these will need to be dropped from the required list before "Require merge queue" is enabled, or queue entries will hang waiting for statuses that never arrive. Not addressed in this PR.

## Test plan
- [ ] YAML validated to parse cleanly (done locally via `YAML.load_file`)
- [ ] Exercise on a low-stakes branch with merge queue enabled before flipping `main`
- [ ] Confirm merge-sentinel's `merge_group` support (separate work in `~/dev/sentinel`, branch `merge-queue-support`) is deployed and the app has the required permissions before relying on this