### PR TITLE
ci: prevent merge queue ejections from concurrency-group cancellation

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -14,7 +14,12 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  # Never cancel a merge_group run: it's a required check for a queue entry,
+  # and a cancellation reads as a failure to the queue, ejecting the PR.
+  # (push here is already branches: [main], so it can't collide with the
+  # merge queue's gh-readonly-queue/** temp ref the way the other workflows'
+  # unrestricted push triggers could.)
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 # ccache is saved from `main` only: a PR-written cache is readable by that PR
 # alone, but still evicts `main`'s entries from the shared 10 GB.

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -2,6 +2,11 @@ name: Builds
 
 on:
   push:
+    # The merge queue also pushes to its temp ref, which separately triggers
+    # merge_group below; without this the two runs share a concurrency group
+    # and cancel-in-progress evicts the PR from the queue (#5884 follow-up).
+    branches-ignore:
+      - "gh-readonly-queue/**"
   pull_request:
     branches:
       - main
@@ -12,7 +17,9 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  # Never cancel a merge_group run: it's a required check for a queue entry,
+  # and a cancellation reads as a failure to the queue, ejecting the PR.
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 # ccache is saved from `main` only: a PR-written cache is readable by that PR
 # alone, but still evicts `main`'s entries from the shared 10 GB.

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -2,6 +2,11 @@ name: Checks
 
 on:
   push:
+    # The merge queue also pushes to its temp ref, which separately triggers
+    # merge_group below; without this the two runs share a concurrency group
+    # and cancel-in-progress evicts the PR from the queue (#5884 follow-up).
+    branches-ignore:
+      - "gh-readonly-queue/**"
   pull_request:
     branches:
       - main
@@ -10,7 +15,9 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  # Never cancel a merge_group run: it's a required check for a queue entry,
+  # and a cancellation reads as a failure to the queue, ejecting the PR.
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 permissions:
   contents: read

--- a/.github/workflows/detray.yml
+++ b/.github/workflows/detray.yml
@@ -2,6 +2,11 @@ name: Detray
 
 on:
   push:
+    # The merge queue also pushes to its temp ref, which separately triggers
+    # merge_group below; without this the two runs share a concurrency group
+    # and cancel-in-progress evicts the PR from the queue (#5884 follow-up).
+    branches-ignore:
+      - "gh-readonly-queue/**"
     paths:
       - "Detray/**"
       - ".github/workflows/detray.yml"
@@ -15,7 +20,9 @@ on:
 # Cancel existing jobs on new pushes.
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  # Never cancel a merge_group run: it's a required check for a queue entry,
+  # and a cancellation reads as a failure to the queue, ejecting the PR.
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 permissions:
   contents: read

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,6 +2,11 @@ name: Docs
 
 on:
   push:
+    # The merge queue also pushes to its temp ref, which separately triggers
+    # merge_group below; without this the two runs share a concurrency group
+    # and cancel-in-progress evicts the PR from the queue (#5884 follow-up).
+    branches-ignore:
+      - "gh-readonly-queue/**"
   pull_request:
     branches:
       - main
@@ -10,7 +15,9 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  # Never cancel a merge_group run: it's a required check for a queue entry,
+  # and a cancellation reads as a failure to the queue, ejecting the PR.
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
Follow-up to #5884. After enabling the merge queue, PRs were getting ejected — traced to concurrency-group self-cancellation, a known GitHub Actions/merge-queue interaction.

**Mechanism:** the merge queue pushes the merge commit to a temp `refs/heads/gh-readonly-queue/<base>/pr-<n>-<sha>` ref. That push both fires the workflow's `push:` trigger (unrestricted in `builds.yml`/`checks.yml`/`docs.yml`, path-restricted but not branch-restricted in `detray.yml`) *and* the `merge_group:` trigger added in #5884, for the same ref. Both resolve to the same concurrency group — `github.head_ref` is empty for both event types, so both fall back to the identical `github.ref` — so `cancel-in-progress: true` cancels one of the two duplicate runs. GitHub's merge queue treats a cancelled run of a required check the same as a failed one, and ejects the PR.

## Changes
- `builds.yml`, `checks.yml`, `docs.yml`, `detray.yml`: exclude `gh-readonly-queue/**` from the `push:` trigger, so it doesn't fire redundantly alongside `merge_group:` for the same ref.
- All five workflows (`builds`, `checks`, `docs`, `detray`, and `analysis` for defense-in-depth — its `push:` is already `branches: [main]` only, so it isn't exposed to this specific collision): `cancel-in-progress: ${{ github.event_name != 'merge_group' }}` instead of unconditional `true`. A merge_group run is a required check for a queue entry and should never be auto-cancelled.

## Test plan
- [ ] YAML validated to parse cleanly
- [ ] Confirm on a live queue entry that Builds/Checks/Docs/Detray no longer double-fire and the PR isn't ejected