### PR TITLE
ci: drop unfulfillable PR-title check from merge-sentinel's required list

### DIFF
--- a/.merge-sentinel.yml
+++ b/.merge-sentinel.yml
@@ -1,7 +1,10 @@
 rules:
-  - required_checks:
-      - Lint PR / Validate PR title
-    required_pattern:
+  # Lint PR / Validate PR title only runs on pull_request_target, never on
+  # merge_group, so it can't be required here: merge-sentinel would sit
+  # pending on every merge-queue entry until the queue's check timeout
+  # evicts it. PR title format is still enforced continuously by that
+  # workflow pre-queue; this only skips re-verifying it at merge time.
+  - required_pattern:
       - "policy-bot: *"
 
   - branch_filter:


### PR DESCRIPTION
## Summary
`.merge-sentinel.yml`'s first rule unconditionally required `Lint PR / Validate PR title` (from `pr-lint.yml`). That workflow only triggers on `pull_request_target`, never `merge_group`, so that named check can never exist for a merge-queue entry.

Concretely, in merge-sentinel's evaluator this isn't an immediate failure — a missing entry in `required_checks` (as opposed to an unmatched `required_pattern`) is recorded with status `missing`, which counts as pending, not failing. So `merge-sentinel` (itself a required check) would sit in_progress forever on every merge-queue entry, until the queue's own `check_response_timeout_minutes` expires and evicts the PR.

Dropped the `required_checks` entry, keeping the `required_pattern: ["policy-bot: *"]` in the same rule. PR title format is still enforced continuously by `pr-lint.yml` pre-queue (opened/edited/synchronize); this only stops re-verifying it at merge time, same tradeoff already reflected in the branch ruleset no longer listing `Validate PR title` as a top-level required check either.

## Test plan
- [ ] YAML validated to parse cleanly
- [ ] Confirm merge-sentinel reaches success on a live queue entry instead of sitting pending