### PR TITLE
ci: Add an accelerator flavor axis to dependency lockfile selection

### DIFF
--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -30,6 +30,12 @@ inputs:
     description: 'C++ standard for lockfile selection (e.g. 20, 23). Defaults to 20.'
     required: false
     default: '20'
+  # The flavors are published at cxx23 only, so setting this with cxx_std 20
+  # yields a C++23-built stack. Accepted for now; the selection logs it.
+  flavor:
+    description: 'Accelerator flavor for lockfile selection (e.g. cuda13, rocm-gfx90a). Defaults to the plain CPU stack.'
+    required: false
+    default: ''
   env_file:
     description: 'Where to generate the environment file'
     required: true
@@ -139,6 +145,7 @@ runs:
         ENV_FILE: ${{ inputs.env_file }}
         FULL_INSTALL: ${{ inputs.full_install }}
         COMPILER: ${{ inputs.compiler }}
+        FLAVOR: ${{ inputs.flavor }}
       run: |
         args="-e $ENV_FILE"
         if [ "$FULL_INSTALL" == "true" ]; then
@@ -148,6 +155,10 @@ runs:
         if [ -n "$COMPILER" ]; then
           echo "With compiler"
           args="${args} -c $COMPILER"
+        fi
+        if [ -n "$FLAVOR" ]; then
+          echo "With flavor $FLAVOR"
+          args="${args} -F $FLAVOR"
         fi
 
         CI/dependencies/setup.sh $args

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -109,6 +109,27 @@ jobs:
         run: >
           CI/check_unused_files.py
 
+  # The CI tooling's own self-tests, which otherwise have no feedback loop:
+  # broken tooling fails in some other job that already paid for a container
+  # pull. Grouped because they are pure python and run in seconds; separate
+  # steps so a failure names the suite. test_public_api_surface.py stays in
+  # `api_surface` -- it skips its drift check without doxygen on PATH.
+  self_tests:
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.14'
+      - name: Dependency lockfile selection
+        run: >
+          CI/dependencies/test_select_lockfile.py
+      - name: Deprecated-docs checker
+        run: >
+          CI/public_api/test_check_deprecated_docs.py
+
   api_surface:
     runs-on: ubuntu-latest
     env:
@@ -131,10 +152,10 @@ jobs:
           mv doxygen-${{ env.DOXYGEN_VERSION }}/bin/doxygen /usr/local/bin/doxygen
           doxygen --version
       - name: Self-test the surface tooling
-        # Guards the classification logic and catches Doxygen output drift.
-        run: |
+        # Here, not in `self_tests`: only this job has doxygen on PATH, and the
+        # drift check skips itself without it.
+        run: >
           CI/public_api/test_public_api_surface.py
-          CI/public_api/test_check_deprecated_docs.py
       - name: Require @deprecated docs on [[deprecated]] declarations
         # Every [[deprecated]] attribute must carry a Doxygen @deprecated command
         # so the deprecation is visible in the published docs, not just at

--- a/CI/dependencies/select_lockfile.py
+++ b/CI/dependencies/select_lockfile.py
@@ -207,6 +207,15 @@ def main():
         default=os.environ.get("CXXSTD", "20"),
         help="C++ standard (e.g. 20, 23). Defaults to CXXSTD env var or 20.",
     )
+    parser.add_argument(
+        "--flavor",
+        type=str,
+        default=os.environ.get("FLAVOR"),
+        help=(
+            "Accelerator flavor (e.g. cuda13, rocm-gfx90a). 'host' or unset "
+            "selects the plain CPU stack. Defaults to the FLAVOR env var."
+        ),
+    )
     args = parser.parse_args()
 
     # Normalize to cxxNN format used in lockfile names
@@ -216,9 +225,15 @@ def main():
         exit(1)
     args.cxx = f"cxx{cxx}"
 
+    # ci-dependencies spells the plain CPU stack as the flavor `host`, which
+    # produces a triplet with no flavor token at all. Normalise both spellings
+    # to None so everything downstream compares against the parsed token.
+    args.flavor = normalize_flavor(args.flavor)
+
     print("Fetching lockfiles for tag:", args.tag)
     print("Architecture:", args.arch)
     print("C++ standard variant:", args.cxx)
+    print("Flavor:", args.flavor or "host")
 
     base_url = f"https://api.github.com/repos/acts-project/ci-dependencies/releases/tags/{args.tag}"
 
@@ -230,7 +245,7 @@ def main():
     for arch, compilers in lockfiles.items():
         print(f"> {arch}:")
         for c, (n, _) in compilers.items():
-            print(f"  - {c}: {n}")
+            print(f"  - {c} [flavor: {extract_flavor(c) or 'host'}]: {n}")
 
     if args.arch not in lockfiles:
         print(f"No lockfile found for architecture {args.arch}")
@@ -248,7 +263,7 @@ def main():
     else:
         compiler = None
 
-    lockfile = select_lockfile(lockfiles, args.arch, compiler, args.cxx)
+    lockfile = select_lockfile(lockfiles, args.arch, compiler, args.cxx, args.flavor)
 
     print("Selected lockfile:", lockfile)
 
@@ -292,23 +307,73 @@ def parse_assets(data: Dict) -> Dict[str, Dict[str, Tuple[str, str]]]:
     return lockfiles
 
 
+def normalize_flavor(flavor: Optional[str]) -> Optional[str]:
+    """`host`, "" and None all mean the plain CPU stack, which has no token."""
+    flavor = flavor.strip() if flavor else ""
+    return None if flavor in ("", "host") else flavor
+
+
+def extract_flavor(spec: str) -> Optional[str]:
+    """Flavor token of a compiler spec, or None for the host stack.
+
+    Lockfiles are named `<arch>_<compiler>_cxx<std>[_<flavor>]`
+    (ci-dependencies flavors/README.md) and `parse_assets` strips the arch, so
+    the flavor is whatever follows `cxx<std>` -- rejoined, since a flavor name
+    may contain underscores. Pre-cxx specs (`gcc@13.3.0`, `default`) have none.
+    """
+    parts = spec.split("_")
+    for i, part in enumerate(parts):
+        if re.fullmatch(r"cxx\d+", part):
+            rest = "_".join(parts[i + 1 :])
+            return rest or None
+    return None
+
+
+def extract_cxx(spec: str) -> Optional[str]:
+    """`cxx<std>` token of a compiler spec, or None.
+
+    Not a suffix test: on a flavored spec it sits in the middle
+    (`gcc@15.2.0_cxx23_cuda13`), where `endswith("_cxx23")` silently misses.
+    """
+    for part in spec.split("_"):
+        if re.fullmatch(r"cxx\d+", part):
+            return part
+    return None
+
+
 def select_lockfile(
     lockfiles: Dict[str, Dict[str, Tuple[str, str]]],
     arch: str,
     compiler: Optional[str],
     cxx: str = "cxx20",
+    flavor: Optional[str] = None,
 ) -> str:
-    arch_lockfiles = lockfiles[arch]
+    # Filter first, so every rule below (family, version, cxx) stays inside one
+    # accelerator stack rather than falling back across them.
+    arch_lockfiles = {
+        comp: v for comp, v in lockfiles[arch].items() if extract_flavor(comp) == flavor
+    }
+
+    if not arch_lockfiles:
+        # Fail hard: a CUDA job handed the host lockfile fails much later, in a
+        # configure step, with an error pointing nowhere near here.
+        available = sorted({extract_flavor(c) or "host" for c in lockfiles[arch]})
+        print(
+            f"No lockfile found for flavor '{flavor or 'host'}' on {arch}; "
+            f"available flavors: {', '.join(available)}"
+        )
+        exit(1)
 
     # Resolve default lockfile (legacy format has "default", new format may not)
     if "default" in arch_lockfiles:
         _, lockfile = arch_lockfiles["default"]
     else:
-        # New format: no default, use first cxx20 variant when compiler unspecified
+        # New format: no default, use first matching cxx variant when compiler
+        # unspecified
         cxx_defaults = [
             (comp, url)
             for comp, (_, url) in arch_lockfiles.items()
-            if comp.endswith(f"_{cxx}")
+            if extract_cxx(comp) == cxx
         ]
         if cxx_defaults:
             _, lockfile = cxx_defaults[0]
@@ -358,8 +423,20 @@ def select_lockfile(
     }
 
     if not compiler_matches:
-        # No exact version match - use highest version of same family
-        highest = max(family_matches.keys(), key=extract_version)
+        # No exact version match: take the highest of the family, but keep the
+        # requested C++ standard if it publishes one. Without that second
+        # filter `max` breaks the tie in dict order, so an unknown compiler
+        # version (clang 22.1.7 -> 22.1.8) silently loses a cxx23 request too.
+        highest_version = max(map(extract_version, family_matches.keys()))
+        candidates = {
+            comp: v
+            for comp, v in family_matches.items()
+            if extract_version(comp) == highest_version
+        }
+        cxx_candidates = {
+            comp: v for comp, v in candidates.items() if extract_cxx(comp) == cxx
+        }
+        highest = next(iter(cxx_candidates or candidates))
         _, lockfile = family_matches[highest]
         print(
             f"No lockfile found for compiler '{compiler}', "
@@ -370,7 +447,7 @@ def select_lockfile(
     # Prefer cxx-specific variant; exact family name takes priority over alias
     # (compiler_matches already contains both clang and llvm aliases)
     cxx_matches = {
-        comp: v for comp, v in compiler_matches.items() if comp.endswith(f"_{cxx}")
+        comp: v for comp, v in compiler_matches.items() if extract_cxx(comp) == cxx
     }
     if cxx_matches:
         exact_family = next(
@@ -389,11 +466,13 @@ def select_lockfile(
         _, lockfile = compiler_matches[compiler]
         return lockfile
 
-    # Fallback: first available (e.g. different cxx variant)
+    # Fallback: first available. The normal path for the flavors, published at
+    # cxx23 only, so a cxx20 job asking for `cuda13` gets the cxx23 stack --
+    # deliberate; see the `flavor` input in .github/actions/dependencies.
     first_comp, (_, lockfile) = next(iter(compiler_matches.items()))
     print(
-        f"No lockfile found for compiler '{compiler}' with {cxx}, "
-        f"falling back to '{first_comp}': {lockfile}"
+        f"No lockfile found for compiler '{compiler}' with {cxx} "
+        f"(flavor '{flavor or 'host'}'), falling back to '{first_comp}': {lockfile}"
     )
     return lockfile
 

--- a/CI/dependencies/setup.sh
+++ b/CI/dependencies/setup.sh
@@ -127,10 +127,13 @@ function retry_transient() {
 }
 
 # Parse command line arguments
-while getopts "c:t:d:e:s:fh" opt; do
+while getopts "c:t:d:e:s:F:fh" opt; do
   case ${opt} in
     c )
       compiler=$OPTARG
+      ;;
+    F )
+      flavor=$OPTARG
       ;;
     t )
       tag=$OPTARG
@@ -155,6 +158,7 @@ while getopts "c:t:d:e:s:fh" opt; do
       echo "  -d <destination> Specify install destination (defaults based on CI environment)"
       echo "  -e <env_file>    Specify environment file to output environments to"
       echo "  -s <cxx_std>     C++ standard for lockfile selection (e.g. 20, 23). Defaults to CXXSTD env var or 20."
+      echo "  -F <flavor>      Accelerator flavor (e.g. cuda13, rocm-gfx90a). Defaults to FLAVOR env var or the host stack."
       echo "  -f               Full dependency installation. Includes Geant4 datasets and Python packages."
       echo "  -h               Show this help message"
       exit 0
@@ -214,6 +218,14 @@ fi
 
 if [ -z "${cxx_std:-}" ]; then
   cxx_std="${CXXSTD:-20}"
+fi
+
+# `host` is the plain CPU stack, published with no flavor token: pass nothing.
+if [ -z "${flavor:-}" ]; then
+  flavor="${FLAVOR:-}"
+fi
+if [ "${flavor}" == "host" ]; then
+  flavor=""
 fi
 
 checkpoint "Create environment file $(realpath "$env_file")"
@@ -334,6 +346,10 @@ cmd=(
 
 if [ "${compiler}" != "default" ]; then
     cmd+=("--compiler-binary" "${compiler}")
+fi
+
+if [ -n "${flavor}" ]; then
+    cmd+=("--flavor" "${flavor}")
 fi
 
 "${cmd[@]}"

--- a/CI/dependencies/test_select_lockfile.py
+++ b/CI/dependencies/test_select_lockfile.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Self-tests for select_lockfile.py.
+
+Guards asset-name parsing and the selection rules. Picking the wrong lockfile
+does not fail here: it fails minutes later in a configure step, on a runner.
+
+Run directly; non-zero exit on failure. Also collectable by pytest.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Dict, Optional
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+
+import select_lockfile as sl  # noqa: E402
+
+# Real asset names from v24.0.0, the first release carrying flavors, in the
+# shape the GitHub releases API returns them.
+V24_ASSETS = [
+    "spack_darwin-tahoe-aarch64.lock",
+    "spack_darwin-tahoe-aarch64_apple-clang@17.0.0_cxx23.lock",
+    "spack_linux-almalinux9-x86_64.lock",
+    "spack_linux-almalinux9-x86_64_gcc@15.2.1_cxx23.lock",
+    "spack_linux-ubuntu26.04-aarch64_gcc@15.2.0_cxx23.lock",
+    "spack_linux-ubuntu26.04-x86_64.lock",
+    "spack_linux-ubuntu26.04-x86_64_gcc@15.2.0_cxx20.lock",
+    "spack_linux-ubuntu26.04-x86_64_gcc@15.2.0_cxx23.lock",
+    "spack_linux-ubuntu26.04-x86_64_gcc@15.2.0_cxx23_cuda13.lock",
+    "spack_linux-ubuntu26.04-x86_64_gcc@15.2.0_cxx23_rocm-gfx90a.lock",
+    "spack_linux-ubuntu26.04-x86_64_llvm@22.1.8_cxx23.lock",
+]
+
+# v23.3.1, pre-flavor, so today's host selections stay covered too.
+V23_ASSETS = [
+    "spack_linux-ubuntu24.04-x86_64.lock",
+    "spack_linux-ubuntu24.04-x86_64_gcc@13.3.0_cxx20.lock",
+    "spack_linux-ubuntu24.04-x86_64_llvm@22.1.7_cxx20.lock",
+    "spack_linux-ubuntu24.04-x86_64_llvm@22.1.7_cxx23.lock",
+]
+
+UBUNTU26 = "linux-ubuntu26.04-x86_64"
+UBUNTU24 = "linux-ubuntu24.04-x86_64"
+
+
+def _release(names: list[str]) -> Dict:
+    return {
+        "assets": [
+            {"name": n, "browser_download_url": f"https://example.invalid/{n}"}
+            for n in names
+        ]
+    }
+
+
+def _select(
+    names: list[str],
+    arch: str,
+    compiler: Optional[str],
+    cxx: str = "cxx20",
+    flavor: Optional[str] = None,
+) -> str:
+    """Select against a synthetic release, returning the chosen asset name."""
+    lockfiles = sl.parse_assets(_release(names))
+    url = sl.select_lockfile(lockfiles, arch, compiler, cxx, flavor)
+    return url.rsplit("/", 1)[-1]
+
+
+# --- flavor token extraction -----------------------------------------------
+
+
+def test_extract_flavor_host_specs():
+    assert sl.extract_flavor("gcc@15.2.0_cxx23") is None
+    assert sl.extract_flavor("gcc@13.3.0") is None, "pre-cxx spec has no flavor"
+    assert sl.extract_flavor("default") is None
+
+
+def test_extract_flavor_accelerator_specs():
+    assert sl.extract_flavor("gcc@15.2.0_cxx23_cuda13") == "cuda13"
+    assert sl.extract_flavor("gcc@15.2.0_cxx23_rocm-gfx90a") == "rocm-gfx90a"
+
+
+def test_extract_flavor_keeps_underscores_in_flavor_name():
+    # Not shipped today, but the grammar permits it and take-last would truncate.
+    assert sl.extract_flavor("gcc@15.2.0_cxx23_cuda13_sm90") == "cuda13_sm90"
+
+
+def test_normalize_flavor():
+    assert sl.normalize_flavor("host") is None, "'host' is the plain CPU stack"
+    assert sl.normalize_flavor("") is None
+    assert sl.normalize_flavor(None) is None
+    assert sl.normalize_flavor("  cuda13 ") == "cuda13"
+
+
+# --- flavor selection -------------------------------------------------------
+
+
+def test_flavored_lockfile_is_selected():
+    got = _select(V24_ASSETS, UBUNTU26, "gcc@15.2.0", cxx="cxx23", flavor="cuda13")
+    assert got == "spack_linux-ubuntu26.04-x86_64_gcc@15.2.0_cxx23_cuda13.lock", got
+
+
+def test_flavor_name_with_dash_is_selected():
+    got = _select(V24_ASSETS, UBUNTU26, "gcc@15.2.0", cxx="cxx23", flavor="rocm-gfx90a")
+    assert (
+        got == "spack_linux-ubuntu26.04-x86_64_gcc@15.2.0_cxx23_rocm-gfx90a.lock"
+    ), got
+
+
+def test_host_request_never_picks_a_flavored_lockfile():
+    # Before flavors were parsed, these were ordinary candidates in the pool.
+    for cxx in ("cxx20", "cxx23"):
+        got = _select(V24_ASSETS, UBUNTU26, "gcc@15.2.0", cxx=cxx)
+        assert sl.extract_flavor(got) is None, f"{cxx} picked flavored {got}"
+
+
+def test_flavor_falls_back_across_cxx_but_not_across_flavor():
+    # Flavors ship at cxx23 only, so cxx20+cuda13 must land on the cxx23 CUDA
+    # stack -- never the cxx20 *host* stack, the wrong-but-plausible answer.
+    got = _select(V24_ASSETS, UBUNTU26, "gcc@15.2.0", cxx="cxx20", flavor="cuda13")
+    assert got == "spack_linux-ubuntu26.04-x86_64_gcc@15.2.0_cxx23_cuda13.lock", got
+
+
+def test_unknown_flavor_exits_rather_than_falling_back():
+    # Returning the host stack would surface as a missing-CUDA configure error
+    # much later, pointing nowhere near the cause.
+    try:
+        _select(V24_ASSETS, UBUNTU26, "gcc@15.2.0", cxx="cxx23", flavor="cuda12")
+    except SystemExit as e:
+        assert e.code == 1, e.code
+    else:
+        raise AssertionError("expected a hard failure for an unavailable flavor")
+
+
+def test_flavor_request_on_arch_without_flavors_exits():
+    try:
+        _select(V23_ASSETS, UBUNTU24, "gcc@13.3.0", cxx="cxx20", flavor="cuda13")
+    except SystemExit as e:
+        assert e.code == 1, e.code
+    else:
+        raise AssertionError("expected a hard failure on a flavorless release")
+
+
+# --- pre-existing selection rules, unchanged by the flavor axis --------------
+
+
+def test_exact_compiler_and_cxx_match():
+    got = _select(V24_ASSETS, UBUNTU26, "gcc@15.2.0", cxx="cxx20")
+    assert got == "spack_linux-ubuntu26.04-x86_64_gcc@15.2.0_cxx20.lock", got
+
+
+def test_clang_is_an_alias_for_llvm():
+    got = _select(V24_ASSETS, UBUNTU26, "clang@22.1.8", cxx="cxx23")
+    assert got == "spack_linux-ubuntu26.04-x86_64_llvm@22.1.8_cxx23.lock", got
+
+
+def test_unknown_compiler_version_uses_highest_of_family():
+    got = _select(V23_ASSETS, UBUNTU24, "llvm@22.1.1", cxx="cxx23")
+    assert got == "spack_linux-ubuntu24.04-x86_64_llvm@22.1.7_cxx23.lock", got
+
+
+def test_no_compiler_uses_the_arch_default():
+    got = _select(V24_ASSETS, UBUNTU26, None, cxx="cxx20")
+    assert got == "spack_linux-ubuntu26.04-x86_64.lock", got
+
+
+def test_v23_host_selection_is_unchanged():
+    # In production today: whatever else moves, this must not.
+    got = _select(V23_ASSETS, UBUNTU24, "gcc@13.3.0", cxx="cxx20")
+    assert got == "spack_linux-ubuntu24.04-x86_64_gcc@13.3.0_cxx20.lock", got
+
+
+def _main() -> int:
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"ok   {name}")
+            except AssertionError as e:
+                failures += 1
+                print(f"FAIL {name}: {e}")
+    print(f"\n{failures} failure(s)")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_main())


### PR DESCRIPTION
ci-dependencies v24.0.0 introduces accelerator "flavors": lockfiles named after a target triplet `<arch>_<compiler>_cxx<std>[_<flavor>]`, where the flavor token carries a CUDA or ROCm dependency stack (`cuda13`, `rocm-gfx90a`) and its absence means the plain CPU stack.

select_lockfile.py had no notion of that token. It parsed everything after the arch as one opaque compiler spec, which left flavored lockfiles unreachable -- there was no way to ask for one -- while making them live candidates in the compiler-family pool for host jobs, where only the shape of the cxx suffix test kept them from being selected.

So parse the triplet explicitly and filter on the flavor before any other rule runs, keeping every fallback (compiler family, version, C++ standard) inside one accelerator stack. An unavailable flavor is a hard failure rather than a fall back to the host stack: silently handing a CUDA job the CPU lockfile surfaces minutes later as a missing-CUDA configure error that points nowhere near the cause.

Two fixes fall out of parsing the tokens rather than suffix-matching them:

- The C++ standard is now matched against the parsed `cxx<std>` token instead of `endswith("_cxx23")`, which on a flavored spec sits in the middle and never matched.
- The highest-version fallback (taken when the image's compiler version has no lockfile) now keeps the requested C++ standard. It previously broke the version tie in dict order, so a cxx23 job could silently get a cxx20 stack.

No selection changes for any job running today: the v23.3.1 gcc, clang, macOS and almalinux resolutions are unchanged, and covered by the new self-test along with the flavor rules.

That self-test is the third piece of CI tooling with one, so they are grouped into a single `self_tests` job instead of accumulating a job per script. The public-API surface suite stays in `api_surface`: it needs doxygen on PATH to catch output drift and skips that test silently without it, so running it anywhere else would look green while checking less.

