### PR TITLE
perf(traccc): Initialize CKF detector in global memory once

### DIFF
--- a/Traccc/device/alpaka/include/traccc/alpaka/finding/combinatorial_kalman_filter_algorithm.hpp
+++ b/Traccc/device/alpaka/include/traccc/alpaka/finding/combinatorial_kalman_filter_algorithm.hpp
@@ -156,12 +156,15 @@ class combinatorial_kalman_filter_algorithm
   /// @param n_threads The number of threads to launch the kernel with
   /// @param config The track finding configuration
   /// @param det The detector object
+  /// @param device_detector The device detector built by
+  ///                        @c create_device_detector
   /// @param bfield The magnetic field object
   /// @param payload The payload for the kernel
   ///
   void propagate_to_next_surface_kernel(
       unsigned int n_threads, const finding_config& config,
-      const detector_buffer& det, const magnetic_field& bfield,
+      const detector_buffer& det, const move_only_any& device_detector,
+      const magnetic_field& bfield,
       const device::propagate_to_next_surface_payload& payload) const override;
 
   /// Launch the @c gather_best_tips_per_measurement kernel
@@ -203,6 +206,11 @@ class combinatorial_kalman_filter_algorithm
       unsigned int n_threads, bool run_mbf_smoother,
       const measurement_selector::config& calib_cfg,
       const device::build_tracks_payload& payload) const override;
+
+  move_only_any create_device_detector(
+      const detector_buffer& det) const override;
+
+  void synchronize() const override;
 
   /// @}
 

--- a/Traccc/device/alpaka/src/finding/combinatorial_kalman_filter_algorithm.cpp
+++ b/Traccc/device/alpaka/src/finding/combinatorial_kalman_filter_algorithm.cpp
@@ -30,7 +30,13 @@
 #include "traccc/finding/device/progressive_kalman_filter.hpp"
 #include "traccc/finding/device/propagate_to_next_surface.hpp"
 #include "traccc/finding/device/remove_duplicates.hpp"
+#include "traccc/geometry/detector_buffer.hpp"
 #include "traccc/utils/detector_buffer_bfield_visitor.hpp"
+
+// System include(s).
+#include <new>
+#include <type_traits>
+#include <utility>
 
 namespace traccc::alpaka {
 namespace kernels {
@@ -139,19 +145,35 @@ struct progressive_kalman_filter {
   }
 };
 
+/// Alpaka kernel functor that constructs the device detector in place
+///
+/// The detector is built once into global memory rather than in every thread,
+/// so that the propagation kernels only carry a pointer to it.
+template <typename detector_t>
+struct create_device_detector {
+  template <typename TAcc>
+  ALPAKA_FN_ACC void operator()(TAcc const& acc,
+                                typename detector_t::const_view_type in,
+                                detector_t* out) const {
+    if (::alpaka::getIdx<::alpaka::Grid, ::alpaka::Threads>(acc)[0] == 0u) {
+      new (out) detector_t(in);
+    }
+  }
+};
+
 /// Alpaka kernel functor for @c traccc::device::propagate_to_next_surface
 template <typename propagator_t, typename bfield_t>
 struct propagate_to_next_surface {
   template <typename TAcc>
   ALPAKA_FN_ACC void operator()(
       TAcc const& acc, const finding_config& cfg,
-      const typename propagator_t::detector_type::const_view_type* det_data,
+      const typename propagator_t::detector_type* det_data_ptr,
       const bfield_t& field_data,
       const device::propagate_to_next_surface_payload& payload) const {
     device::global_index_t globalThreadIdx =
         ::alpaka::getIdx<::alpaka::Grid, ::alpaka::Threads>(acc)[0];
     device::propagate_to_next_surface<propagator_t, bfield_t>(
-        globalThreadIdx, cfg, *det_data, field_data, payload);
+        globalThreadIdx, cfg, det_data_ptr, field_data, payload);
   }
 };
 
@@ -433,7 +455,8 @@ void combinatorial_kalman_filter_algorithm::sort_param_ids_by_keys(
 
 void combinatorial_kalman_filter_algorithm::propagate_to_next_surface_kernel(
     unsigned int n_threads, const finding_config& config,
-    const detector_buffer& detector, const magnetic_field& field,
+    const detector_buffer& detector, const move_only_any& device_detector,
+    const magnetic_field& field,
     const device::propagate_to_next_surface_payload& payload) const {
   // Establish the kernel launch parameters.
   const unsigned int deviceThreads = warp_size() * 4;
@@ -445,13 +468,15 @@ void combinatorial_kalman_filter_algorithm::propagate_to_next_surface_kernel(
                                          alpaka::bfield_type_list<scalar>>(
       detector, field,
       [&]<typename detector_traits_t, typename bfield_view_t>(
-          const typename detector_traits_t::view& det,
+          const typename detector_traits_t::view&,
           const bfield_view_t& bfield) {
-        // Copy the detector data to device memory.
-        vecmem::data::vector_buffer<typename detector_traits_t::view>
-            device_det(1u, mr().main);
-        copy().setup(device_det)->ignore();
-        copy()({1u, &det}, device_det)->ignore();
+        // The detector was already built in global memory by
+        // create_device_detector, which dispatched over the same detector
+        // type list, so this is the type it stored there.
+        const vecmem::data::vector_buffer<typename detector_traits_t::device>&
+            device_detector_buffer =
+                device_detector.as<vecmem::data::vector_buffer<
+                    typename detector_traits_t::device>>();
 
         // Launch the kernel to propagate all active tracks to the next
         // surface.
@@ -462,7 +487,30 @@ void combinatorial_kalman_filter_algorithm::propagate_to_next_surface_kernel(
                 traccc::details::ckf_propagator_t<
                     typename detector_traits_t::device, bfield_view_t>,
                 bfield_view_t>{},
-            config, device_det.ptr(), bfield, payload);
+            config, device_detector_buffer.ptr(), bfield, payload);
+      });
+}
+
+move_only_any combinatorial_kalman_filter_algorithm::create_device_detector(
+    const detector_buffer& det) const {
+  return detector_buffer_visitor<detector_type_list>(
+      det, [&]<typename detector_traits_t>(
+               const typename detector_traits_t::view& det_view) {
+        using device_detector_t = typename detector_traits_t::device;
+
+        static_assert(
+            std::is_trivially_destructible_v<device_detector_t>,
+            "the detector is placement-constructed and never destroyed, so it "
+            "must not need a destructor");
+
+        vecmem::data::vector_buffer<device_detector_t> buffer(1u, mr().main);
+
+        ::alpaka::exec<Acc>(
+            details::get_queue(queue()), makeWorkDiv<Acc>(1u, 1u),
+            kernels::create_device_detector<device_detector_t>{}, det_view,
+            buffer.ptr());
+
+        return move_only_any{std::move(buffer)};
       });
 }
 
@@ -524,6 +572,10 @@ void combinatorial_kalman_filter_algorithm::build_tracks_kernel(
                       makeWorkDiv<Acc>(deviceBlocks, deviceThreads),
                       kernels::build_tracks{}, run_mbf_smoother, calib_cfg,
                       payload);
+}
+
+void combinatorial_kalman_filter_algorithm::synchronize() const {
+  queue().synchronize();
 }
 
 }  // namespace traccc::alpaka

--- a/Traccc/device/common/include/traccc/finding/device/combinatorial_kalman_filter_algorithm.hpp
+++ b/Traccc/device/common/include/traccc/finding/device/combinatorial_kalman_filter_algorithm.hpp
@@ -215,7 +215,8 @@ class combinatorial_kalman_filter_algorithm
   ///
   virtual void propagate_to_next_surface_kernel(
       unsigned int n_threads, const finding_config& config,
-      const detector_buffer& det, const magnetic_field& bfield,
+      const detector_buffer& det, const move_only_any& device_detector,
+      const magnetic_field& bfield,
       const device::propagate_to_next_surface_payload& payload) const = 0;
 
   /// Launch the @c gather_best_tips_per_measurement kernel
@@ -257,6 +258,12 @@ class combinatorial_kalman_filter_algorithm
       unsigned int n_threads, bool run_mbf_smoother,
       const measurement_selector::config& calib_cfg,
       const device::build_tracks_payload& payload) const = 0;
+
+  virtual move_only_any create_device_detector(
+      const detector_buffer& det) const = 0;
+
+  /// Wait for all work this algorithm enqueued to complete
+  virtual void synchronize() const = 0;
 
   /// @}
 

--- a/Traccc/device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp
+++ b/Traccc/device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp
@@ -26,7 +26,7 @@ namespace traccc::device {
 template <typename propagator_t, typename bfield_t>
 TRACCC_HOST_DEVICE inline void propagate_to_next_surface(
     const global_index_t globalIndex, const finding_config& cfg,
-    const typename propagator_t::detector_type::const_view_type& det_data,
+    const typename propagator_t::detector_type* const det_data_ptr,
     const bfield_t& field_data,
     const propagate_to_next_surface_payload& payload) {
   using algebra_t = typename propagator_t::detector_type::algebra_type;
@@ -57,9 +57,6 @@ TRACCC_HOST_DEVICE inline void propagate_to_next_surface(
   vecmem::device_vector<unsigned int> tips(payload.tips_view);
   vecmem::device_vector<unsigned int> tip_lengths(payload.tip_lengths_view);
 
-  // Detector
-  typename propagator_t::detector_type det(det_data);
-
   // Parameters
   bound_track_parameters_collection_types::device params(payload.params_view);
 
@@ -74,7 +71,7 @@ TRACCC_HOST_DEVICE inline void propagate_to_next_surface(
   propagator_t propagator(cfg.propagation);
 
   // Create propagator state
-  typename propagator_t::state propagation(in_par, field_data, det);
+  typename propagator_t::state propagation(in_par, field_data, *det_data_ptr);
   propagation.set_particle(
       detail::correct_particle_hypothesis(cfg.ptc_hypothesis, in_par));
   propagation.stepping()

--- a/Traccc/device/common/include/traccc/finding/device/propagate_to_next_surface.hpp
+++ b/Traccc/device/common/include/traccc/finding/device/propagate_to_next_surface.hpp
@@ -81,15 +81,14 @@ struct propagate_to_next_surface_payload {
 ///
 /// @param[in] globalIndex        The index of the current thread
 /// @param[in] cfg                Track finding config object
-/// @param[in] det_data           View object to the tracking detector
-///                               description
+/// @param[in] det_data_ptr       Pointer to the tracking detector description
 /// @param[in] field_data         View object to the magnetic field
 /// @param[inout] payload      The function call payload
 ///
 template <typename propagator_t, typename bfield_t>
 TRACCC_HOST_DEVICE inline void propagate_to_next_surface(
     global_index_t globalIndex, const finding_config& cfg,
-    const typename propagator_t::detector_type::const_view_type& det_data,
+    const typename propagator_t::detector_type* const det_data_ptr,
     const bfield_t& field_data,
     const propagate_to_next_surface_payload& payload);
 

--- a/Traccc/device/common/src/finding/combinatorial_kalman_filter_algorithm.cpp
+++ b/Traccc/device/common/src/finding/combinatorial_kalman_filter_algorithm.cpp
@@ -61,6 +61,8 @@ auto combinatorial_kalman_filter_algorithm::operator()(
 
   const finding_config& cfg = m_data->m_config;
 
+  const move_only_any device_detector = create_device_detector(det);
+
   /*****************************************************************
    * Measurement Operations
    *****************************************************************/
@@ -497,7 +499,7 @@ auto combinatorial_kalman_filter_algorithm::operator()(
         }
 
         propagate_to_next_surface_kernel(
-            n_candidates, cfg, det, bfield,
+            n_candidates, cfg, det, device_detector, bfield,
             {.params_view = in_params_buffer,
              .params_liveness_view = param_liveness_buffer,
              .param_ids_view = param_ids_buffer,
@@ -663,6 +665,8 @@ auto combinatorial_kalman_filter_algorithm::operator()(
                  "progressive filter!"
               << std::endl;
   }
+
+  synchronize();
 
   return track_candidates_buffer;
 }

--- a/Traccc/device/cuda/CMakeLists.txt
+++ b/Traccc/device/cuda/CMakeLists.txt
@@ -63,6 +63,7 @@ traccc_add_library( traccc_cuda cuda TYPE SHARED
   "src/finding/kernels/build_tracks.cuh"
   "src/finding/kernels/condense_tracks.cuh"
   "src/finding/kernels/condense_tracks.cu"
+  "src/finding/kernels/create_device_detector.cuh"
   "src/finding/kernels/find_tracks.cuh"
   "src/finding/kernels/gather_best_tips_per_measurement.cu"
   "src/finding/kernels/gather_measurement_votes.cu"
@@ -137,6 +138,10 @@ endfunction()
 
 # Generate specializations for the kernels.
 foreach(DETECTOR_NAME ${TRACCC_SUPPORTED_DETECTORS})
+    traccc_add_cuda_specialization(
+      "src/finding/kernels/specializations/create_device_detector.cu.in"
+      DETECTOR_NAME "${DETECTOR_NAME}"
+    )
     traccc_add_cuda_specialization(
       "src/finding/kernels/specializations/find_tracks.cu.in"
       DETECTOR_NAME "${DETECTOR_NAME}"

--- a/Traccc/device/cuda/include/traccc/cuda/finding/combinatorial_kalman_filter_algorithm.hpp
+++ b/Traccc/device/cuda/include/traccc/cuda/finding/combinatorial_kalman_filter_algorithm.hpp
@@ -161,7 +161,8 @@ class combinatorial_kalman_filter_algorithm
   ///
   void propagate_to_next_surface_kernel(
       unsigned int n_threads, const finding_config& config,
-      const detector_buffer& det, const magnetic_field& bfield,
+      const detector_buffer& det, const move_only_any& device_detector,
+      const magnetic_field& bfield,
       const device::propagate_to_next_surface_payload& payload) const override;
 
   /// Launch the @c gather_best_tips_per_measurement kernel
@@ -203,6 +204,11 @@ class combinatorial_kalman_filter_algorithm
       unsigned int n_threads, bool run_mbf_smoother,
       const measurement_selector::config& calib_cfg,
       const device::build_tracks_payload& payload) const override;
+
+  move_only_any create_device_detector(
+      const detector_buffer& det) const override;
+
+  void synchronize() const override;
 
   /// @}
 

--- a/Traccc/device/cuda/src/finding/combinatorial_kalman_filter_algorithm.cu
+++ b/Traccc/device/cuda/src/finding/combinatorial_kalman_filter_algorithm.cu
@@ -10,6 +10,7 @@
 #include "../utils/magnetic_field_types.hpp"
 #include "./kernels/build_tracks.cuh"
 #include "./kernels/condense_tracks.cuh"
+#include "./kernels/create_device_detector.cuh"
 #include "./kernels/fill_finding_duplicate_removal_sort_keys.cuh"
 #include "./kernels/fill_finding_propagation_sort_keys.cuh"
 #include "./kernels/find_tracks.cuh"
@@ -33,6 +34,10 @@
 #include <thrust/execution_policy.h>
 #include <thrust/scan.h>
 #include <thrust/sort.h>
+
+// System include(s).
+#include <type_traits>
+#include <utility>
 
 namespace traccc::cuda {
 
@@ -248,7 +253,8 @@ void combinatorial_kalman_filter_algorithm::sort_param_ids_by_keys(
 
 void combinatorial_kalman_filter_algorithm::propagate_to_next_surface_kernel(
     unsigned int n_threads, const finding_config& config,
-    const detector_buffer& detector, const magnetic_field& field,
+    const detector_buffer& detector, const move_only_any& device_detector,
+    const magnetic_field& field,
     const device::propagate_to_next_surface_payload& payload) const {
   // Establish the kernel launch parameters.
   const unsigned int deviceThreads = warp_size() * 4;
@@ -260,14 +266,19 @@ void combinatorial_kalman_filter_algorithm::propagate_to_next_surface_kernel(
                                          cuda::bfield_type_list<scalar>>(
       detector, field,
       [&]<typename detector_traits_t, typename bfield_view_t>(
-          const typename detector_traits_t::view& det,
+          const typename detector_traits_t::view&,
           const bfield_view_t& bfield) {
+        const vecmem::data::vector_buffer<typename detector_traits_t::device>&
+            device_detector_buffer =
+                device_detector.as<vecmem::data::vector_buffer<
+                    typename detector_traits_t::device>>();
+
         propagate_to_next_surface<
             traccc::details::ckf_propagator_t<
                 typename detector_traits_t::device, bfield_view_t>,
             bfield_view_t>(deviceBlocks, deviceThreads, 0u,
-                           details::get_stream(stream()), config, det, bfield,
-                           payload);
+                           details::get_stream(stream()), config,
+                           device_detector_buffer.ptr(), bfield, payload);
       });
   TRACCC_CUDA_ERROR_CHECK(cudaGetLastError());
 }
@@ -331,6 +342,30 @@ void combinatorial_kalman_filter_algorithm::build_tracks_kernel(
                           details::get_stream(stream())>>>(run_mbf_smoother,
                                                            calib_cfg, payload);
   TRACCC_CUDA_ERROR_CHECK(cudaGetLastError());
+}
+
+move_only_any combinatorial_kalman_filter_algorithm::create_device_detector(
+    const detector_buffer& det) const {
+  return detector_buffer_visitor<
+      detector_type_list>(det, [&]<typename detector_traits_t>(
+                                   const typename detector_traits_t::view&
+                                       det_view) {
+    static_assert(
+        std::is_trivially_destructible_v<typename detector_traits_t::device>,
+        "the detector is placement-constructed and never destroyed, so it "
+        "must not need a destructor");
+
+    vecmem::data::vector_buffer<typename detector_traits_t::device>
+        device_detector_buffer(1, mr().main);
+    traccc::cuda::create_device_detector<typename detector_traits_t::device>(
+        details::get_stream(stream()), det_view, device_detector_buffer.ptr());
+    TRACCC_CUDA_ERROR_CHECK(cudaGetLastError());
+    return move_only_any{std::move(device_detector_buffer)};
+  });
+}
+
+void combinatorial_kalman_filter_algorithm::synchronize() const {
+  stream().synchronize();
 }
 
 }  // namespace traccc::cuda

--- a/Traccc/device/cuda/src/finding/kernels/create_device_detector.cuh
+++ b/Traccc/device/cuda/src/finding/kernels/create_device_detector.cuh
@@ -1,0 +1,29 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2026 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// CUDA include(s).
+#include <cuda_runtime.h>
+
+namespace traccc::cuda {
+
+/// Construct the device detector in place, in global memory
+///
+/// The detector is built once rather than in every thread, so that the
+/// propagation kernels only carry a pointer to it.
+///
+/// @param stream The stream to launch the kernel on
+/// @param in     View of the detector to build from
+/// @param out    Global memory to construct the detector into
+///
+template <typename detector_t>
+void create_device_detector(const cudaStream_t& stream,
+                            typename detector_t::const_view_type in,
+                            detector_t* out);
+
+}  // namespace traccc::cuda

--- a/Traccc/device/cuda/src/finding/kernels/propagate_to_next_surface.hpp
+++ b/Traccc/device/cuda/src/finding/kernels/propagate_to_next_surface.hpp
@@ -20,7 +20,7 @@ template <typename propagator_t, typename bfield_t>
 void propagate_to_next_surface(
     const dim3& grid_size, const dim3& block_size, std::size_t shared_mem_size,
     const cudaStream_t& stream, const finding_config& cfg,
-    const typename propagator_t::detector_type::const_view_type& det_data,
+    const typename propagator_t::detector_type* det_data_ptr,
     const bfield_t& field_data,
     const device::propagate_to_next_surface_payload& payload);
 

--- a/Traccc/device/cuda/src/finding/kernels/specializations/create_device_detector.cu.in
+++ b/Traccc/device/cuda/src/finding/kernels/specializations/create_device_detector.cu.in
@@ -1,0 +1,19 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2026 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "src/finding/kernels/specializations/create_device_detector_src.cuh"
+
+// Project include(s).
+#include "traccc/geometry/detector.hpp"
+
+namespace traccc::cuda {
+template void create_device_detector<traccc::@DETECTOR_NAME@ ::device>(
+    const cudaStream_t& stream,
+    traccc::@DETECTOR_NAME@ ::device::const_view_type in,
+    traccc::@DETECTOR_NAME@ ::device* out);
+}  // namespace traccc::cuda

--- a/Traccc/device/cuda/src/finding/kernels/specializations/create_device_detector_src.cuh
+++ b/Traccc/device/cuda/src/finding/kernels/specializations/create_device_detector_src.cuh
@@ -1,0 +1,37 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2026 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Local include(s).
+#include "../create_device_detector.cuh"
+
+// System include(s).
+#include <new>
+
+namespace traccc::cuda {
+namespace kernels {
+
+template <typename detector_t>
+__global__ void create_device_detector(typename detector_t::const_view_type in,
+                                       detector_t* out) {
+  unsigned int thread_id = blockIdx.x * blockDim.x + threadIdx.x;
+
+  if (thread_id == 0) {
+    new (out) detector_t(in);
+  }
+}
+
+}  // namespace kernels
+
+template <typename detector_t>
+void create_device_detector(const cudaStream_t& stream,
+                            typename detector_t::const_view_type in,
+                            detector_t* out) {
+  kernels::create_device_detector<detector_t><<<1, 1, 0, stream>>>(in, out);
+}
+}  // namespace traccc::cuda

--- a/Traccc/device/cuda/src/finding/kernels/specializations/propagate_to_next_surface.cu.in
+++ b/Traccc/device/cuda/src/finding/kernels/specializations/propagate_to_next_surface.cu.in
@@ -24,7 +24,7 @@ using propagator_t = traccc::details::ckf_propagator_t<@DETECTOR_NAME@::device, 
 template void propagate_to_next_surface<propagator_t, bfield_t>(
     const dim3& grid_size, const dim3& block_size, std::size_t shared_mem_size,
     const cudaStream_t& stream, const finding_config&,
-    const @DETECTOR_NAME@::device::const_view_type&,
+    const @DETECTOR_NAME@::device*,
     const bfield_t&,
     const device::propagate_to_next_surface_payload&);
 

--- a/Traccc/device/cuda/src/finding/kernels/specializations/propagate_to_next_surface_src.cuh
+++ b/Traccc/device/cuda/src/finding/kernels/specializations/propagate_to_next_surface_src.cuh
@@ -21,8 +21,7 @@ namespace kernels {
 template <typename propagator_t, typename bfield_t>
 __global__ __launch_bounds__(128) void propagate_to_next_surface(
     const __grid_constant__ finding_config cfg,
-    const __grid_constant__
-    typename propagator_t::detector_type::const_view_type det_data,
+    const typename propagator_t::detector_type* __restrict__ const det_data_ptr,
     const __grid_constant__ bfield_t field_data,
     const __grid_constant__ device::propagate_to_next_surface_payload payload) {
   // TODO: Reenable this this additional checks for compilation with the ABI
@@ -30,7 +29,7 @@ __global__ __launch_bounds__(128) void propagate_to_next_surface(
   // TRACCC_CUDA_SPILL_TO_SHARED_MEMORY;
 
   device::propagate_to_next_surface<propagator_t>(
-      details::global_index1(), cfg, det_data, field_data, payload);
+      details::global_index1(), cfg, det_data_ptr, field_data, payload);
 }
 
 }  // namespace kernels
@@ -39,11 +38,11 @@ template <typename propagator_t, typename bfield_t>
 void propagate_to_next_surface(
     const dim3& grid_size, const dim3& block_size, std::size_t shared_mem_size,
     const cudaStream_t& stream, const finding_config& cfg,
-    const typename propagator_t::detector_type::const_view_type& det_data,
+    const typename propagator_t::detector_type* det_data_ptr,
     const bfield_t& field_data,
     const device::propagate_to_next_surface_payload& payload) {
   kernels::propagate_to_next_surface<propagator_t>
-      <<<grid_size, block_size, shared_mem_size, stream>>>(cfg, det_data,
+      <<<grid_size, block_size, shared_mem_size, stream>>>(cfg, det_data_ptr,
                                                            field_data, payload);
 }
 }  // namespace traccc::cuda

--- a/Traccc/device/sycl/include/traccc/sycl/finding/combinatorial_kalman_filter_algorithm.hpp
+++ b/Traccc/device/sycl/include/traccc/sycl/finding/combinatorial_kalman_filter_algorithm.hpp
@@ -159,12 +159,15 @@ class combinatorial_kalman_filter_algorithm
   /// @param n_threads The number of threads to launch the kernel with
   /// @param config The track finding configuration
   /// @param det The detector object
+  /// @param device_detector The device detector built by
+  ///                        @c create_device_detector
   /// @param bfield The magnetic field object
   /// @param payload The payload for the kernel
   ///
   void propagate_to_next_surface_kernel(
       unsigned int n_threads, const finding_config& config,
-      const detector_buffer& det, const magnetic_field& bfield,
+      const detector_buffer& det, const move_only_any& device_detector,
+      const magnetic_field& bfield,
       const device::propagate_to_next_surface_payload& payload) const override;
 
   /// Launch the @c gather_best_tips_per_measurement kernel
@@ -206,6 +209,11 @@ class combinatorial_kalman_filter_algorithm
       unsigned int n_threads, bool run_mbf_smoother,
       const measurement_selector::config& calib_cfg,
       const device::build_tracks_payload& payload) const override;
+
+  move_only_any create_device_detector(
+      const detector_buffer& det) const override;
+
+  void synchronize() const override;
 
   /// @}
 

--- a/Traccc/device/sycl/src/finding/combinatorial_kalman_filter_algorithm.sycl
+++ b/Traccc/device/sycl/src/finding/combinatorial_kalman_filter_algorithm.sycl
@@ -35,12 +35,18 @@
 #include "traccc/finding/device/propagate_to_next_surface.hpp"
 #include "traccc/finding/device/remove_duplicates.hpp"
 #include "traccc/finding/device/update_tip_length_buffer.hpp"
+#include "traccc/geometry/detector_buffer.hpp"
 #include "traccc/geometry/detector_type_list.hpp"
 #include "traccc/utils/detector_buffer_bfield_visitor.hpp"
 #include "traccc/utils/propagation.hpp"
 
 // VecMem include(s).
 #include <vecmem/utils/sycl/local_accessor.hpp>
+
+// System include(s).
+#include <new>
+#include <type_traits>
+#include <utility>
 
 namespace traccc::sycl {
 namespace kernels {
@@ -61,6 +67,9 @@ struct progressive_kalman_filter {};
 
 template <typename detector_t, typename bfield_t>
 struct propagate_to_next_surface {};
+
+template <typename detector_t>
+struct create_device_detector {};
 
 struct gather_best_tips_per_measurement {};
 
@@ -327,7 +336,8 @@ void combinatorial_kalman_filter_algorithm::sort_param_ids_by_keys(
 
 void combinatorial_kalman_filter_algorithm::propagate_to_next_surface_kernel(
     unsigned int n_threads, const finding_config& config,
-    const detector_buffer& detector, const magnetic_field& field,
+    const detector_buffer& detector, const move_only_any& device_detector,
+    const magnetic_field& field,
     const device::propagate_to_next_surface_payload& payload) const {
   ::sycl::queue& squeue = details::get_queue(queue());
   squeue.throw_asynchronous();
@@ -335,13 +345,15 @@ void combinatorial_kalman_filter_algorithm::propagate_to_next_surface_kernel(
                                          sycl::bfield_type_list<scalar>>(
       detector, field,
       [&]<typename detector_traits_t, typename bfield_view_t>(
-          const typename detector_traits_t::view& det,
+          const typename detector_traits_t::view&,
           const bfield_view_t& bfield) {
-        // Copy the detector data to device memory.
-        vecmem::data::vector_buffer<typename detector_traits_t::view>
-            device_det(1u, mr().main);
-        copy().setup(device_det)->ignore();
-        copy()({1u, &det}, device_det)->ignore();
+        // The detector was already built in global memory by
+        // create_device_detector, which dispatched over the same detector
+        // type list, so this is the type it stored there.
+        const vecmem::data::vector_buffer<typename detector_traits_t::device>&
+            device_detector_buffer =
+                device_detector.as<vecmem::data::vector_buffer<
+                    typename detector_traits_t::device>>();
 
         // Launch the kernel to propagate all active tracks to the next
         // surface.
@@ -350,15 +362,45 @@ void combinatorial_kalman_filter_algorithm::propagate_to_next_surface_kernel(
               detector_tag_selector_t<detector_traits_t>,
               bfield_tag_selector_t<typename bfield_view_t::backend_t>>>(
               details::calculate1DimNdRange(n_threads, warp_size() * 4),
-              [config, det = device_det.ptr(), bfield,
+              [config, det = device_detector_buffer.ptr(), bfield,
                payload](::sycl::nd_item<1> item) {
                 device::propagate_to_next_surface<
                     traccc::details::ckf_propagator_t<
                         typename detector_traits_t::device, bfield_view_t>,
-                    bfield_view_t>(details::global_index(item), config, *det,
+                    bfield_view_t>(details::global_index(item), config, det,
                                    bfield, payload);
               });
         });
+      });
+}
+
+move_only_any combinatorial_kalman_filter_algorithm::create_device_detector(
+    const detector_buffer& det) const {
+  ::sycl::queue& squeue = details::get_queue(queue());
+  squeue.throw_asynchronous();
+  return detector_buffer_visitor<detector_type_list>(
+      det, [&]<typename detector_traits_t>(
+               const typename detector_traits_t::view& det_view) {
+        using device_detector_t = typename detector_traits_t::device;
+
+        static_assert(
+            std::is_trivially_destructible_v<device_detector_t>,
+            "the detector is placement-constructed and never destroyed, so it "
+            "must not need a destructor");
+
+        vecmem::data::vector_buffer<device_detector_t> buffer(1u, mr().main);
+
+        // Build the detector once, in global memory, rather than in every
+        // thread of every propagation kernel.
+        squeue.submit([&](::sycl::handler& h) {
+          h.single_task<kernels::create_device_detector<
+              detector_tag_selector_t<detector_traits_t>>>(
+              [det_view, out = buffer.ptr()]() {
+                new (out) device_detector_t(det_view);
+              });
+        });
+
+        return move_only_any{std::move(buffer)};
       });
 }
 
@@ -423,6 +465,10 @@ void combinatorial_kalman_filter_algorithm::build_tracks_kernel(
                                calib_cfg, payload);
         });
   });
+}
+
+void combinatorial_kalman_filter_algorithm::synchronize() const {
+  details::get_queue(queue()).wait_and_throw();
 }
 
 }  // namespace traccc::sycl


### PR DESCRIPTION
This commit refactors the CKF code to initialize the device dectector in global memory once. This means that we no longer need to allocate local memory for the entire device detector in every thread anymore.