### PR TITLE
feat: Bind additional geometry methods to Python

### DIFF
--- a/Python/Core/src/Geometry.cpp
+++ b/Python/Core/src/Geometry.cpp
@@ -293,7 +293,8 @@ void addGeometry(py::module_& m) {
         m, "TrackingVolume")
         .def(py::init<const Transform3&, std::shared_ptr<VolumeBounds>,
                       std::string>())
-        .def_property_readonly("volumeName", &TrackingVolume::volumeName);
+        .def_property_readonly("volumeName", &TrackingVolume::volumeName)
+        .def_property_readonly("geometryId", &TrackingVolume::geometryId);
   }
 
   {

--- a/Python/Core/src/GeometryGen1.cpp
+++ b/Python/Core/src/GeometryGen1.cpp
@@ -34,7 +34,14 @@ namespace ActsPython {
 void addGeometryGen1(py::module_ &m) {
   using SurfacePtrVector = std::vector<std::shared_ptr<const Surface>>;
 
-  py::class_<Layer, std::shared_ptr<Layer>>(m, "Layer");
+  //py::class_<Layer, std::shared_ptr<Layer>>(m, "Layer");
+
+  {
+    auto layer = py::class_<Layer, std::shared_ptr<Layer>>(m, "Layer");
+    layer.def_property_readonly(
+        "surfaceRepresentation",
+        py::overload_cast<>(&Layer::surfaceRepresentation, py::const_));
+  }
 
   py::class_<BoundarySurfaceT<TrackingVolume>>(
       m, "BoundarySurfaceT_TrackingVolume");

--- a/Python/Core/src/GeometryGen1.cpp
+++ b/Python/Core/src/GeometryGen1.cpp
@@ -34,8 +34,6 @@ namespace ActsPython {
 void addGeometryGen1(py::module_ &m) {
   using SurfacePtrVector = std::vector<std::shared_ptr<const Surface>>;
 
-  //py::class_<Layer, std::shared_ptr<Layer>>(m, "Layer");
-
   {
     auto layer = py::class_<Layer, std::shared_ptr<Layer>>(m, "Layer");
     layer.def_property_readonly(


### PR DESCRIPTION
Bind Layer::surfaceRepresentation and TrackingVolume::geometryId to Python