### PR TITLE
ci: Build the alpaka backend on the traccc CUDA and HIP legs

### DIFF
--- a/.github/workflows/traccc.yml
+++ b/.github/workflows/traccc.yml
@@ -124,7 +124,8 @@ jobs:
           #
           # TRACCC_BUILD_ALPAKA is additive as on the CUDA leg above; the
           # flavor's alpaka is built `backend=serial,hip`. RelWithDebInfo
-          # because gcc-hosted ROCm 7 crashes on device/alpaka at -O3 (#5877).
+          # because ROCm 7's device compiler crashes on device/alpaka at -O3
+          # (#5877, ROCm/llvm-project#3995).
           - platform:
               name: "HIP"
               container: ghcr.io/acts-project/ubuntu2604:91
@@ -132,18 +133,18 @@ jobs:
               run_tests: false
               flavor: rocm7
             build: RelWithDebInfo
-          # Same leg at Release, so -O3 stays covered.
-          #
-          # Clang-hosted: alpaka's HIP backend wants a clang *host* compiler,
-          # and #5877's ICE reproduces only against the gcc-hosted lockfile.
-          - platform:
-              name: "HIP"
-              container: ghcr.io/acts-project/ubuntu2604_clang22:91
-              compiler: clang++-22
-              options: --preset hip-fp32-ci -DCMAKE_HIP_PLATFORM=amd -DCMAKE_HIP_ARCHITECTURES=gfx90a -DTRACCC_USE_SYSTEM_ROCTHRUST=ON -DTRACCC_BUILD_ALPAKA=ON -Dalpaka_ACC_GPU_HIP_ENABLE=ON -Dalpaka_DISABLE_VENDOR_RNG=ON -DCMAKE_HIP_COMPILE_FEATURES=hip_std_20 -DCMAKE_C_COMPILER=clang-22 -DCMAKE_CXX_COMPILER=clang++-22
-              run_tests: false
-              flavor: rocm7
-            build: Release
+          # Same leg at Release, clang-hosted because alpaka's HIP backend
+          # wants a clang *host* compiler. Disabled: the -O3 ICE is in ROCm's
+          # own LLVM regardless of host, fixed upstream by llvm 4a77ce7c6f51
+          # (llvm/llvm-project#201263) but in no released ROCm yet.
+          # - platform:
+          #     name: "HIP"
+          #     container: ghcr.io/acts-project/ubuntu2604_clang22:91
+          #     compiler: clang++-22
+          #     options: --preset hip-fp32-ci -DCMAKE_HIP_PLATFORM=amd -DCMAKE_HIP_ARCHITECTURES=gfx90a -DTRACCC_USE_SYSTEM_ROCTHRUST=ON -DTRACCC_BUILD_ALPAKA=ON -Dalpaka_ACC_GPU_HIP_ENABLE=ON -Dalpaka_DISABLE_VENDOR_RNG=ON -DCMAKE_HIP_COMPILE_FEATURES=hip_std_20 -DCMAKE_C_COMPILER=clang-22 -DCMAKE_CXX_COMPILER=clang++-22
+          #     run_tests: false
+          #     flavor: rocm7
+          #   build: Release
           - platform:
               name: "ALPAKA_CPU"
               container: ghcr.io/acts-project/ubuntu2604:91

--- a/.github/workflows/traccc.yml
+++ b/.github/workflows/traccc.yml
@@ -166,10 +166,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           env_file: .env
 
-      # vecmem, covfie and alpaka come from spack on every leg: the host
+      # vecmem, covfie, alpaka and TBB come from spack on every leg: the host
       # lockfile carries them and each flavor overlays its own build, so no
       # per-leg gating is needed. TRACCC_USE_SYSTEM_ALPAKA is unconditional
       # because traccc only acts on it under TRACCC_SETUP_ALPAKA.
+      #
+      # TBB too: the FetchContent oneTBB turns IPO on, which under a clang
+      # host is ThinLTO, leaving bitcode the ROCm linker cannot read.
 
       - name: Configure
         run: |
@@ -185,6 +188,7 @@ jobs:
             -DTRACCC_USE_SYSTEM_VECMEM=ON \
             -DTRACCC_USE_SYSTEM_COVFIE=ON \
             -DTRACCC_USE_SYSTEM_ALPAKA=ON \
+            -DTRACCC_USE_SYSTEM_TBB=ON \
             -DDETRAY_USE_SYSTEM_NLOHMANN=ON \
             -DDETRAY_USE_SYSTEM_GOOGLETEST=ON \
             -DTRACCC_USE_SYSTEM_GOOGLETEST_DEFAULT=ON \

--- a/.github/workflows/traccc.yml
+++ b/.github/workflows/traccc.yml
@@ -84,10 +84,14 @@ jobs:
           # tests strictly need: this leg pays for their device code either
           # way, and trimming would drop the toy-detector CKF tests from the
           # GPU run.
+          #
+          # TRACCC_BUILD_ALPAKA is additive: alpaka's targets are gated on it
+          # alone, so the alpaka backend rides along without a second baseline
+          # build. The flavor's alpaka is built `backend=serial,cuda`.
           - platform:
               name: CUDA
               container: ghcr.io/acts-project/ubuntu2604:91
-              options: --preset cuda-fp32
+              options: --preset cuda-fp32 -DTRACCC_BUILD_ALPAKA=ON -Dalpaka_ACC_GPU_CUDA_ENABLE=ON
               run_tests: false
               upload_build: true
               flavor: cuda13
@@ -117,10 +121,22 @@ jobs:
           # Compile check: no runner has an AMD GPU, but tests/hip is built.
           # TRACCC_USE_SYSTEM_ROCTHRUST keeps Thrust matched to the flavor's
           # hip; CMAKE_HIP_ARCHITECTURES narrows the gfx list to gfx90a.
+          #
+          # TRACCC_BUILD_ALPAKA is additive as on the CUDA leg above; the
+          # flavor's alpaka is built `backend=serial,hip`. RelWithDebInfo
+          # because gcc-hosted ROCm 7 crashes on device/alpaka at -O3 (#5877).
           - platform:
               name: "HIP"
               container: ghcr.io/acts-project/ubuntu2604:91
-              options: --preset hip-fp32 -DCMAKE_HIP_PLATFORM=amd -DCMAKE_HIP_ARCHITECTURES=gfx90a -DTRACCC_USE_SYSTEM_ROCTHRUST=ON
+              options: --preset hip-fp32 -DCMAKE_HIP_PLATFORM=amd -DCMAKE_HIP_ARCHITECTURES=gfx90a -DTRACCC_USE_SYSTEM_ROCTHRUST=ON -DTRACCC_BUILD_ALPAKA=ON -Dalpaka_ACC_GPU_HIP_ENABLE=ON -Dalpaka_DISABLE_VENDOR_RNG=ON -DCMAKE_HIP_COMPILE_FEATURES=hip_std_20
+              run_tests: false
+              flavor: rocm7
+            build: RelWithDebInfo
+          # Same leg at Release, so -O3 stays covered.
+          - platform:
+              name: "HIP"
+              container: ghcr.io/acts-project/ubuntu2604:91
+              options: --preset hip-fp32 -DCMAKE_HIP_PLATFORM=amd -DCMAKE_HIP_ARCHITECTURES=gfx90a -DTRACCC_USE_SYSTEM_ROCTHRUST=ON -DTRACCC_BUILD_ALPAKA=ON -Dalpaka_ACC_GPU_HIP_ENABLE=ON -Dalpaka_DISABLE_VENDOR_RNG=ON -DCMAKE_HIP_COMPILE_FEATURES=hip_std_20
               run_tests: false
               flavor: rocm7
             build: Release
@@ -131,19 +147,6 @@ jobs:
               run_tests: true
               flavor: ""
             build: Release
-          # ACTS_ENABLE_CUDA spelled out: this leg rides the alpaka preset,
-          # so it misses the cuda-* presets that carry it.
-          - platform:
-              name: "ALPAKA_CUDA"
-              container: ghcr.io/acts-project/ubuntu2604:91
-              options: --preset alpaka-fp32 -Dalpaka_ACC_GPU_CUDA_ENABLE=ON -DTRACCC_FAIL_ON_WARNINGS=OFF -DTRACCC_BUILD_CUDA_UTILS=ON -DACTS_ENABLE_CUDA=ON
-              run_tests: false
-              flavor: cuda13
-            build: Release
-          # ALPAKA_HIP is dropped here: it's still on the pre-spack
-          # ubuntu2404_rocm image (no `flavor`, so it never gets a dependency
-          # install this PR would touch), and the HIP alpaka migration lands
-          # in a later PR in this stack.
     # Use BASH as the shell from the images.
     defaults:
       run:

--- a/.github/workflows/traccc.yml
+++ b/.github/workflows/traccc.yml
@@ -91,7 +91,7 @@ jobs:
           - platform:
               name: CUDA
               container: ghcr.io/acts-project/ubuntu2604:91
-              options: --preset cuda-fp32 -DTRACCC_BUILD_ALPAKA=ON -Dalpaka_ACC_GPU_CUDA_ENABLE=ON
+              options: --preset cuda-fp32-ci -DTRACCC_BUILD_ALPAKA=ON -Dalpaka_ACC_GPU_CUDA_ENABLE=ON
               run_tests: false
               upload_build: true
               flavor: cuda13
@@ -103,7 +103,7 @@ jobs:
           - platform:
               name: CUDA
               container: ghcr.io/acts-project/ubuntu2604:91
-              options: --preset cuda-fp32 -DTRACCC_BUILD_TESTING=FALSE
+              options: --preset cuda-fp32-ci -DTRACCC_BUILD_TESTING=FALSE
               run_tests: false
               flavor: cuda13
             build: Debug
@@ -114,7 +114,7 @@ jobs:
           - platform:
               name: CUDA_FP64
               container: ghcr.io/acts-project/ubuntu2604:91
-              options: --preset cuda-fp64 -DTRACCC_BUILD_TESTING=FALSE
+              options: --preset cuda-fp64-ci -DTRACCC_BUILD_TESTING=FALSE
               run_tests: false
               flavor: cuda13
             build: Release
@@ -128,7 +128,7 @@ jobs:
           - platform:
               name: "HIP"
               container: ghcr.io/acts-project/ubuntu2604:91
-              options: --preset hip-fp32 -DCMAKE_HIP_PLATFORM=amd -DCMAKE_HIP_ARCHITECTURES=gfx90a -DTRACCC_USE_SYSTEM_ROCTHRUST=ON -DTRACCC_BUILD_ALPAKA=ON -Dalpaka_ACC_GPU_HIP_ENABLE=ON -Dalpaka_DISABLE_VENDOR_RNG=ON -DCMAKE_HIP_COMPILE_FEATURES=hip_std_20
+              options: --preset hip-fp32-ci -DCMAKE_HIP_PLATFORM=amd -DCMAKE_HIP_ARCHITECTURES=gfx90a -DTRACCC_USE_SYSTEM_ROCTHRUST=ON -DTRACCC_BUILD_ALPAKA=ON -Dalpaka_ACC_GPU_HIP_ENABLE=ON -Dalpaka_DISABLE_VENDOR_RNG=ON -DCMAKE_HIP_COMPILE_FEATURES=hip_std_20
               run_tests: false
               flavor: rocm7
             build: RelWithDebInfo
@@ -136,7 +136,7 @@ jobs:
           - platform:
               name: "HIP"
               container: ghcr.io/acts-project/ubuntu2604:91
-              options: --preset hip-fp32 -DCMAKE_HIP_PLATFORM=amd -DCMAKE_HIP_ARCHITECTURES=gfx90a -DTRACCC_USE_SYSTEM_ROCTHRUST=ON -DTRACCC_BUILD_ALPAKA=ON -Dalpaka_ACC_GPU_HIP_ENABLE=ON -Dalpaka_DISABLE_VENDOR_RNG=ON -DCMAKE_HIP_COMPILE_FEATURES=hip_std_20
+              options: --preset hip-fp32-ci -DCMAKE_HIP_PLATFORM=amd -DCMAKE_HIP_ARCHITECTURES=gfx90a -DTRACCC_USE_SYSTEM_ROCTHRUST=ON -DTRACCC_BUILD_ALPAKA=ON -Dalpaka_ACC_GPU_HIP_ENABLE=ON -Dalpaka_DISABLE_VENDOR_RNG=ON -DCMAKE_HIP_COMPILE_FEATURES=hip_std_20
               run_tests: false
               flavor: rocm7
             build: Release

--- a/.github/workflows/traccc.yml
+++ b/.github/workflows/traccc.yml
@@ -133,10 +133,14 @@ jobs:
               flavor: rocm7
             build: RelWithDebInfo
           # Same leg at Release, so -O3 stays covered.
+          #
+          # Clang-hosted: alpaka's HIP backend wants a clang *host* compiler,
+          # and #5877's ICE reproduces only against the gcc-hosted lockfile.
           - platform:
               name: "HIP"
-              container: ghcr.io/acts-project/ubuntu2604:91
-              options: --preset hip-fp32-ci -DCMAKE_HIP_PLATFORM=amd -DCMAKE_HIP_ARCHITECTURES=gfx90a -DTRACCC_USE_SYSTEM_ROCTHRUST=ON -DTRACCC_BUILD_ALPAKA=ON -Dalpaka_ACC_GPU_HIP_ENABLE=ON -Dalpaka_DISABLE_VENDOR_RNG=ON -DCMAKE_HIP_COMPILE_FEATURES=hip_std_20
+              container: ghcr.io/acts-project/ubuntu2604_clang22:91
+              compiler: clang++-22
+              options: --preset hip-fp32-ci -DCMAKE_HIP_PLATFORM=amd -DCMAKE_HIP_ARCHITECTURES=gfx90a -DTRACCC_USE_SYSTEM_ROCTHRUST=ON -DTRACCC_BUILD_ALPAKA=ON -Dalpaka_ACC_GPU_HIP_ENABLE=ON -Dalpaka_DISABLE_VENDOR_RNG=ON -DCMAKE_HIP_COMPILE_FEATURES=hip_std_20 -DCMAKE_C_COMPILER=clang-22 -DCMAKE_CXX_COMPILER=clang++-22
               run_tests: false
               flavor: rocm7
             build: Release
@@ -159,7 +163,7 @@ jobs:
       - name: Install dependencies
         uses: ./.github/actions/dependencies
         with:
-          compiler: g++
+          compiler: ${{ matrix.platform.compiler || 'g++' }}
           flavor: ${{ matrix.platform.flavor }}
           # Ahead of the repo default: flavors need v24.0.0 or newer.
           DEPENDENCY_TAG: v24.1.0

--- a/CI/dependencies/setup.sh
+++ b/CI/dependencies/setup.sh
@@ -441,7 +441,16 @@ set_env PATH "${venv_dir}/bin:${view_dir}/bin/:${PATH}"
 # need it on the search path too.
 set_env LD_LIBRARY_PATH "${venv_dir}/lib:${view_dir}/lib:${view_dir}/lib64:${view_dir}/lib/root"
 set_env DYLD_LIBRARY_PATH "${venv_dir}/lib:${view_dir}/lib:${view_dir}/lib64:${view_dir}/lib/root"
-set_env CMAKE_PREFIX_PATH "${venv_dir}:${view_dir}"
+# CCCL's CMake configs (Thrust, CUB, libcudacxx) sit under
+# targets/<arch>-linux/lib/cmake, which CMake does not search below a prefix,
+# so find_package(Thrust) misses them. The glob is a no-op without a flavor.
+cmake_prefix_path="${venv_dir}:${view_dir}"
+for cuda_cmake_dir in "${view_dir}"/targets/*/lib/cmake; do
+  if [ -d "${cuda_cmake_dir}" ]; then
+    cmake_prefix_path="${cmake_prefix_path}:${cuda_cmake_dir}"
+  fi
+done
+set_env CMAKE_PREFIX_PATH "${cmake_prefix_path}"
 set_env ROOT_SETUP_SCRIPT "${view_dir}/bin/thisroot.sh"
 set_env ROOT_INCLUDE_PATH "${view_dir}/include"
 # cleanup setup-python mess

--- a/Traccc/CMakePresets.json
+++ b/Traccc/CMakePresets.json
@@ -47,6 +47,16 @@
             }
         },
         {
+            "name": "cuda-fp32-ci",
+            "displayName": "CUDA FP32, vecmem from the environment",
+            "inherits": [
+                "cuda-fp32"
+            ],
+            "cacheVariables": {
+                "VECMEM_BUILD_CUDA_LIBRARY": null
+            }
+        },
+        {
             "name": "cuda-fp64",
             "displayName": "CUDA FP64 Code Development",
             "inherits": [
@@ -60,6 +70,16 @@
             }
         },
         {
+            "name": "cuda-fp64-ci",
+            "displayName": "CUDA FP64, vecmem from the environment",
+            "inherits": [
+                "cuda-fp64"
+            ],
+            "cacheVariables": {
+                "VECMEM_BUILD_CUDA_LIBRARY": null
+            }
+        },
+        {
             "name": "hip-fp32",
             "displayName": "HIP FP32 Code Development",
             "inherits": [
@@ -69,6 +89,16 @@
                 "TRACCC_BUILD_HIP": "TRUE",
                 "VECMEM_BUILD_HIP_LIBRARY": "TRUE",
                 "TRACCC_SETUP_ROCTHRUST": "TRUE"
+            }
+        },
+        {
+            "name": "hip-fp32-ci",
+            "displayName": "HIP FP32, vecmem from the environment",
+            "inherits": [
+                "hip-fp32"
+            ],
+            "cacheVariables": {
+                "VECMEM_BUILD_HIP_LIBRARY": null
             }
         },
         {

--- a/Traccc/CMakePresets.json
+++ b/Traccc/CMakePresets.json
@@ -93,12 +93,13 @@
         },
         {
             "name": "hip-fp32-ci",
-            "displayName": "HIP FP32, vecmem from the environment",
+            "displayName": "HIP FP32, dependencies from the environment",
             "inherits": [
                 "hip-fp32"
             ],
             "cacheVariables": {
-                "VECMEM_BUILD_HIP_LIBRARY": null
+                "VECMEM_BUILD_HIP_LIBRARY": null,
+                "TRACCC_SETUP_THRUST": "FALSE"
             }
         },
         {

--- a/Traccc/CMakePresets.json
+++ b/Traccc/CMakePresets.json
@@ -48,12 +48,13 @@
         },
         {
             "name": "cuda-fp32-ci",
-            "displayName": "CUDA FP32, vecmem from the environment",
+            "displayName": "CUDA FP32, dependencies from the environment",
             "inherits": [
                 "cuda-fp32"
             ],
             "cacheVariables": {
-                "VECMEM_BUILD_CUDA_LIBRARY": null
+                "VECMEM_BUILD_CUDA_LIBRARY": null,
+                "TRACCC_USE_SYSTEM_THRUST": "TRUE"
             }
         },
         {
@@ -71,12 +72,13 @@
         },
         {
             "name": "cuda-fp64-ci",
-            "displayName": "CUDA FP64, vecmem from the environment",
+            "displayName": "CUDA FP64, dependencies from the environment",
             "inherits": [
                 "cuda-fp64"
             ],
             "cacheVariables": {
-                "VECMEM_BUILD_CUDA_LIBRARY": null
+                "VECMEM_BUILD_CUDA_LIBRARY": null,
+                "TRACCC_USE_SYSTEM_THRUST": "TRUE"
             }
         },
         {

--- a/Traccc/device/alpaka/src/utils/utils.hpp
+++ b/Traccc/device/alpaka/src/utils/utils.hpp
@@ -7,7 +7,12 @@
 
 #pragma once
 
+// alpaka aliases CUDA/HIP builtin vector types (ulonglong4 and friends) that
+// newer toolkits deprecate: the warning is about alpaka's header, not ours.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #include <alpaka/alpaka.hpp>
+#pragma GCC diagnostic pop
 
 namespace traccc::alpaka {
 

--- a/Traccc/tests/alpaka/alpaka_basic.cpp
+++ b/Traccc/tests/alpaka/alpaka_basic.cpp
@@ -15,8 +15,14 @@
 #include <vecmem/containers/vector.hpp>
 
 // Alpaka include(s).
+//
+// alpaka aliases CUDA/HIP builtin vector types (ulonglong4 and friends) that
+// newer toolkits deprecate: the warning is about alpaka's header, not ours.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #include <alpaka/alpaka.hpp>
 #include <alpaka/example/ExampleDefaultAcc.hpp>
+#pragma GCC diagnostic pop
 
 // GoogleTest include(s).
 #include <gtest/gtest.h>


### PR DESCRIPTION
<!-- jjp:description -->
Builds traccc's alpaka backend on the CUDA and HIP legs instead of in separate jobs, and takes more of the dependency stack from the spack flavors.

**Alpaka on the GPU legs.** Each flavor ships an alpaka built for its accelerator (`backend=serial,cuda` for cuda13, `backend=serial,hip` for rocm7), so the CUDA and HIP legs now enable `TRACCC_BUILD_ALPAKA` on top of their native backend. The standalone `ALPAKA_CUDA` leg is dropped: alpaka's targets are gated on `TRACCC_BUILD_ALPAKA` and `alpaka_ACC_GPU_CUDA_ENABLE` alone, so the merged leg compiles everything it did plus `examples/run/cuda`. The comment #5908 left pointing here goes with it.

**Warning suppression.** alpaka's `CudaHipCommon.hpp` aliases CUDA builtin vector types that the toolkit now deprecates. That is a warning in alpaka's header, not in traccc, so it is silenced with a diagnostic push/pop around the two direct includes of `<alpaka/alpaka.hpp>`; `TRACCC_FAIL_ON_WARNINGS` stays on.

**Dependencies from the environment.**
- New `-ci` presets unset the `VECMEM_BUILD_*` switches so the flavor's vecmem is used.
- CCCL is no longer fetched: Thrust comes from the CUDA toolkit, and the HIP legs use `TRACCC_USE_SYSTEM_ROCTHRUST`.
- TBB comes from the flavor's `intel-tbb`. The FetchContent oneTBB turns IPO on, which under a clang host is ThinLTO and leaves bitcode the ROCm linker cannot read.

**HIP at -O3.** A clang-hosted `HIP-Release` leg was added on the `llvm@22.1.8_cxx20_rocm7` lockfile, since alpaka's HIP backend wants a clang host compiler, and the dependencies step grew a per-leg host compiler defaulting to `g++`. That leg is now commented out: ROCm 7's device compiler segfaults in the greedy register allocator on `combinatorial_kalman_filter_algorithm.cpp` at `-O3` regardless of host (#5877, ROCm/llvm-project#3995). The upstream fix is llvm `4a77ce7c6f51` (llvm/llvm-project#201263), which no released ROCm carries yet. `HIP-RelWithDebInfo` keeps the compile check at `-O2` until it does.
<!-- /jjp:description -->
<!-- jjp:body-fp 1265647b4c31a5d0 -->

<!-- jjp:stack-nav -->
**Stack** (bottom to top):

- ~~#5923 refactor/actsvg-0.4.57~~ (merged)
- ~~#5907 ci/gpu-jobs-spack-deps~~ (merged)
- ~~#5908 ci/traccc-hip-leg~~ (merged)
- #5906 ci/traccc-gpu-alpaka  👈
- #5905 ci/ubuntu2604-deps-v24
<!-- /jjp:stack-nav -->






