### PR TITLE
feat: tgeo AlignTGeoDetectorElement

### DIFF
--- a/Python/Examples/src/plugins/TGeo.cpp
+++ b/Python/Examples/src/plugins/TGeo.cpp
@@ -103,7 +103,8 @@ PYBIND11_MODULE(ActsExamplesPythonBindingsTGeo, tgeo) {
     // dispatch on identity to the matching *native* C++ function pointer, so
     // the assignment never round-trips through Python.
     c.def_property(
-        "detectorElementFactory", nullptr,
+        "detectorElementFactory",
+        [](const TGeoDetector::Config&) { return py::none(); },
         [tgeo](TGeoDetector::Config& cfg, const py::object& factory) {
           if (factory.is(tgeo.attr("alignedTGeoDetectorElementFactory"))) {
             cfg.detectorElementFactory = alignedTGeoDetectorElementFactory;

--- a/Python/Examples/src/plugins/TGeo.cpp
+++ b/Python/Examples/src/plugins/TGeo.cpp
@@ -6,10 +6,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+#include "ActsExamples/TGeoDetector/AlignedTGeoDetectorElement.hpp"
 #include "ActsExamples/TGeoDetector/TGeoDetector.hpp"
 #include "ActsPython/Utilities/Helpers.hpp"
 #include "ActsPython/Utilities/Macros.hpp"
 
+#include <pybind11/functional.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
@@ -87,8 +89,11 @@ PYBIND11_MODULE(ActsExamplesPythonBindingsTGeo, tgeo) {
                        fileName, buildBeamPipe, beamPipeRadius,
                        beamPipeHalflengthZ, beamPipeLayerThickness,
                        beamPipeEnvelopeR, layerEnvelopeR, unitScalor,
-                       materialDecorator, volumes);
+                       materialDecorator, volumes, detectorElementFactory);
 
     patchKwargsConstructor(c);
+
+    tgeo.def("alignedTGeoDetectorElementFactory",
+            &alignedTGeoDetectorElementFactory);
   }
 }

--- a/Python/Examples/src/plugins/TGeo.cpp
+++ b/Python/Examples/src/plugins/TGeo.cpp
@@ -12,7 +12,6 @@
 #include "ActsPython/Utilities/Helpers.hpp"
 #include "ActsPython/Utilities/Macros.hpp"
 
-#include <pybind11/functional.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
@@ -90,11 +89,31 @@ PYBIND11_MODULE(ActsExamplesPythonBindingsTGeo, tgeo) {
                        fileName, buildBeamPipe, beamPipeRadius,
                        beamPipeHalflengthZ, beamPipeLayerThickness,
                        beamPipeEnvelopeR, layerEnvelopeR, unitScalor,
-                       materialDecorator, volumes, detectorElementFactory);
-
-    patchKwargsConstructor(c);
+                       materialDecorator, volumes);
 
     tgeo.def("alignedTGeoDetectorElementFactory",
             &alignedTGeoDetectorElementFactory);
+
+    // `detectorElementFactory` is a std::function taking ROOT types
+    // (TGeoNode, TGeoMatrix) that have no pybind11 caster. Exposing it as an
+    // ordinary read-write std::function property would make pybind11 wrap
+    // whatever is assigned in a generic Python call-back trampoline, which
+    // then fails at call time because those ROOT arguments cannot be
+    // converted to Python objects. Instead take the raw Python object and
+    // dispatch on identity to the matching *native* C++ function pointer, so
+    // the assignment never round-trips through Python.
+    c.def_property(
+        "detectorElementFactory", nullptr,
+        [tgeo](TGeoDetector::Config& cfg, const py::object& factory) {
+          if (factory.is(tgeo.attr("alignedTGeoDetectorElementFactory"))) {
+            cfg.detectorElementFactory = alignedTGeoDetectorElementFactory;
+          } else if (!factory.is_none()) {
+            throw py::value_error(
+                "detectorElementFactory only accepts "
+                "acts.examples.tgeo.alignedTGeoDetectorElementFactory");
+          }
+        });
+
+    patchKwargsConstructor(c);
   }
 }

--- a/Python/Examples/src/plugins/TGeo.cpp
+++ b/Python/Examples/src/plugins/TGeo.cpp
@@ -92,7 +92,7 @@ PYBIND11_MODULE(ActsExamplesPythonBindingsTGeo, tgeo) {
                        materialDecorator, volumes);
 
     tgeo.def("alignedTGeoDetectorElementFactory",
-            &alignedTGeoDetectorElementFactory);
+             &alignedTGeoDetectorElementFactory);
 
     // `detectorElementFactory` is a std::function taking ROOT types
     // (TGeoNode, TGeoMatrix) that have no pybind11 caster. Exposing it as an

--- a/Python/Examples/src/plugins/TGeo.cpp
+++ b/Python/Examples/src/plugins/TGeo.cpp
@@ -6,6 +6,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+#include "Acts/Material/ISurfaceMaterial.hpp"
 #include "ActsExamples/TGeoDetector/AlignedTGeoDetectorElement.hpp"
 #include "ActsExamples/TGeoDetector/TGeoDetector.hpp"
 #include "ActsPython/Utilities/Helpers.hpp"

--- a/Python/Examples/tests/test_detectors.py
+++ b/Python/Examples/tests/test_detectors.py
@@ -1,7 +1,7 @@
 import pytest
 from pathlib import Path
 
-from helpers import dd4hepEnabled, geant4Enabled
+from helpers import dd4hepEnabled, geant4Enabled, rootEnabled
 
 import acts.examples
 
@@ -188,6 +188,73 @@ def test_tgeo_config_volume(monkeypatch):
 
         v = Volume(**{key: (4, None)})
         assert getattr(v, key) == Interval(4, None)
+
+
+@pytest.mark.skipif(not rootEnabled, reason="ROOT not set up")
+def test_tgeo_detector_aligned_element_factory():
+    import acts.examples.tgeo as tgeo
+    from acts.examples.tgeo import TGeoDetector
+
+    u = acts.UnitConstants
+    Volume = TGeoDetector.Config.Volume
+    LayerTriplet = TGeoDetector.Config.LayerTriplet
+
+    root_file = (
+        Path(__file__).parent.parent.parent.parent / "Tests" / "Data" / "panda.root"
+    )
+    assert root_file.exists()
+
+    # Select the pixel barrel layer out of the panda.root geometry, same
+    # selection as the `TGeoLayerBuilderTests` C++ unit test (`b0Config`).
+    volume = Volume(
+        name="Pixels",
+        layers=LayerTriplet(negative=False, central=True, positive=False),
+        subVolumeName=LayerTriplet(central="*"),
+        sensitiveNames=LayerTriplet(
+            central=[
+                "PixelActiveo2",
+                "PixelActiveo4",
+                "PixelActiveo5",
+                "PixelActiveo6",
+            ]
+        ),
+        sensitiveAxes=LayerTriplet(central="XYZ"),
+        rRange=LayerTriplet(central=(0.0, 40 * u.mm)),
+        zRange=LayerTriplet(central=(-60 * u.mm, 15 * u.mm)),
+        splitTolR=LayerTriplet(central=-1.0),
+        splitTolZ=LayerTriplet(central=-1.0),
+    )
+
+    cfg = TGeoDetector.Config(
+        fileName=str(root_file),
+        unitScalor=1 * u.cm,  # panda.root stores lengths in ROOT's native cm
+        volumes=[volume],
+        detectorElementFactory=tgeo.alignedTGeoDetectorElementFactory,
+    )
+
+    # The setter dispatches on identity to a native C++ function pointer
+    # rather than storing the assigned python object, so the getter always
+    # reports None.
+    assert cfg.detectorElementFactory is None
+
+    detector = TGeoDetector(cfg)
+    trackingGeometry = detector.trackingGeometry()
+    assert trackingGeometry is not None
+
+    assert count_surfaces(trackingGeometry) == 14
+
+
+@pytest.mark.skipif(not rootEnabled, reason="ROOT not set up")
+def test_tgeo_detector_element_factory_invalid():
+    from acts.examples.tgeo import TGeoDetector
+
+    cfg = TGeoDetector.Config()
+
+    with pytest.raises(ValueError):
+        cfg.detectorElementFactory = lambda *args: None
+
+    # None is accepted and leaves the default (non-aligned) factory in place
+    cfg.detectorElementFactory = None
 
 
 def test_coordinate_converter(trk_geo):

--- a/Python/Examples/tests/test_detectors.py
+++ b/Python/Examples/tests/test_detectors.py
@@ -1,4 +1,5 @@
 import pytest
+import warnings
 from pathlib import Path
 
 from helpers import dd4hepEnabled, geant4Enabled, rootEnabled
@@ -237,10 +238,15 @@ def test_tgeo_detector_aligned_element_factory():
     # reports None.
     assert cfg.detectorElementFactory is None
 
-    detector = TGeoDetector(cfg)
-    trackingGeometry = detector.trackingGeometry()
-    assert trackingGeometry is not None
+    # (Re-)building a TGeoManager from a ROOT file can emit routine,
+    # benign ROOT diagnostics (e.g. about registered matrices being
+    # replaced) that are not test failures.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        detector = TGeoDetector(cfg)
+        trackingGeometry = detector.trackingGeometry()
 
+    assert trackingGeometry is not None
     assert count_surfaces(trackingGeometry) == 14
 
 

--- a/Python/Examples/tests/test_detectors.py
+++ b/Python/Examples/tests/test_detectors.py
@@ -199,6 +199,7 @@ def test_tgeo_detector_aligned_element_factory():
     u = acts.UnitConstants
     Volume = TGeoDetector.Config.Volume
     LayerTriplet = TGeoDetector.Config.LayerTriplet
+    equidistant = TGeoDetector.Config.BinningType.equidistant
 
     root_file = (
         Path(__file__).parent.parent.parent.parent / "Tests" / "Data" / "panda.root"
@@ -224,6 +225,11 @@ def test_tgeo_detector_aligned_element_factory():
         zRange=LayerTriplet(central=(-60 * u.mm, 15 * u.mm)),
         splitTolR=LayerTriplet(central=-1.0),
         splitTolZ=LayerTriplet(central=-1.0),
+        # A single entry with count <= 0 requests auto-binning; leaving this
+        # unset defaults to an empty vector, which `TGeoLayerBuilder` then
+        # indexes out of bounds.
+        binning0=LayerTriplet(central=[(0, equidistant)]),
+        binning1=LayerTriplet(central=[(0, equidistant)]),
     )
 
     cfg = TGeoDetector.Config(


### PR DESCRIPTION
Modification to the TGeo bindings to allow for an alignedTGeoDetectorElement factory

- Update to the TGeo python bindings
- Add a test to check the alignedTGeoDetectorElement factory

Test checks that we can build a TGeoDetector with the alignedTGeoDetectorElement factory:
```
((.acts_venv) ) pbutti@stbc-i3:/data/alice/pbutti/sw/test_compilation/acts$ pytest Python/Examples/tests/test_detectors.py -v
======================================================================================== test session starts =========================================================================================
platform linux -- Python 3.12.11, pytest-9.1.1, pluggy-1.6.0 -- /data/alice/pbutti/.acts_venv/bin/python3
cachedir: .pytest_cache
hypothesis profile 'default'
rootdir: /data/alice/pbutti/sw/test_compilation/acts
configfile: pytest.ini
plugins: xdist-3.8.0, timeout-2.4.0, repeat-0.9.4, check-2.8.0, GaudiTesting-1.0.0, anyio-4.6.1, asdf-3.5.0, hypothesis-6.135.1, mimesis-14.0.0, cov-4.1.0, typeguard-2.13.3
collected 11 items                                                                                                                                                                                   

Python/Examples/tests/test_detectors.py::test_generic_geometry PASSED                                                                                                                          [  9%]
Python/Examples/tests/test_detectors.py::test_telescope_geometry PASSED                                                                                                                        [ 18%]
Python/Examples/tests/test_detectors.py::test_telescope_geant4_geometry[0] PASSED                                                                                                              [ 27%]
Python/Examples/tests/test_detectors.py::test_telescope_geant4_geometry[1] PASSED                                                                                                              [ 36%]
Python/Examples/tests/test_detectors.py::test_telescope_geant4_geometry[2] PASSED                                                                                                              [ 45%]
Python/Examples/tests/test_detectors.py::test_odd SKIPPED (DD4hep is not set up)                                                                                                               [ 54%]
Python/Examples/tests/test_detectors.py::test_tgeo_config_triplet PASSED                                                                                                                       [ 63%]
Python/Examples/tests/test_detectors.py::test_tgeo_config_volume PASSED                                                                                                                        [ 72%]
Python/Examples/tests/test_detectors.py::test_tgeo_detector_aligned_element_factory PASSED                                                                                                     [ 81%]
Python/Examples/tests/test_detectors.py::test_tgeo_detector_element_factory_invalid PASSED                                                                                                     [ 90%]
Python/Examples/tests/test_detectors.py::test_coordinate_converter PASSED                                                                                                                      [100%]
--------------------------------------------------------------------------------------- Root file hash checks ----------------------------------------------------------------------------------------
NOTE: Root file hash checks were skipped, enable with ROOT_HASH_CHECKS=on
See https://acts.readthedocs.io/en/latest/examples/python_bindings.html#root-file-hash-regression-checks for more details

```
