### PR TITLE
refactor: split cluster/cell output out of the ROOT measurement writer

### DIFF
--- a/Examples/Algorithms/Digitization/src/DigitizationAlgorithm.cpp
+++ b/Examples/Algorithms/Digitization/src/DigitizationAlgorithm.cpp
@@ -296,6 +296,7 @@ ProcessCode DigitizationAlgorithm::execute(const AlgorithmContext& ctx) const {
               auto measurement =
                   createMeasurement(measurements, moduleGeoId, dParameters);
 
+              dParameters.cluster.geometryId = moduleGeoId;
               dParameters.cluster.globalPosition = measurementGlobalPosition(
                   dParameters, *surfacePtr, ctx.geoContext);
               clusters.emplace_back(std::move(dParameters.cluster));

--- a/Examples/Framework/include/ActsExamples/EventData/Cluster.hpp
+++ b/Examples/Framework/include/ActsExamples/EventData/Cluster.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "Acts/Definitions/Algebra.hpp"
+#include "Acts/Geometry/GeometryIdentifier.hpp"
 #include "ActsFatras/Digitization/Segmentizer.hpp"
 
 #include <numeric>
@@ -19,6 +20,8 @@ namespace ActsExamples {
 /// Simple struct holding cluster information.
 struct Cluster {
   using Cell = ActsFatras::Segmentizer::ChannelSegment;
+  /// The module the cluster was formed on
+  Acts::GeometryIdentifier geometryId;
   std::size_t sizeLoc0 = 0;
   std::size_t sizeLoc1 = 0;
   std::vector<Cell> channels;

--- a/Examples/Io/Arrow/src/ColliderMLRelease1InputConverter.cpp
+++ b/Examples/Io/Arrow/src/ColliderMLRelease1InputConverter.cpp
@@ -502,6 +502,7 @@ ProcessCode ColliderMLRelease1InputConverter::execute(
       const Acts::Vector2& lp = localResult.value();
 
       DigitizedParameters dParams;
+      dParams.cluster.geometryId = geoId;
       dParams.cluster.globalPosition = globalPos;
       for (const auto& [idx, sigma] : sigmaIt->second) {
         dParams.indices.push_back(idx);

--- a/Examples/Io/Csv/src/CsvMeasurementReader.cpp
+++ b/Examples/Io/Csv/src/CsvMeasurementReader.cpp
@@ -138,6 +138,7 @@ ClusterContainer makeClusters(
 
     for (auto it = begin; it != end; ++it) {
       const auto& cellData = it->second;
+      cluster.geometryId = Acts::GeometryIdentifier(cellData.geometry_id);
       ActsFatras::Segmentizer::Segment2D dummySegment = {Acts::Vector2::Zero(),
                                                          Acts::Vector2::Zero()};
 

--- a/Examples/Io/Root/CMakeLists.txt
+++ b/Examples/Io/Root/CMakeLists.txt
@@ -1,5 +1,6 @@
 acts_add_library(
     ExamplesIoRoot
+    src/RootClusterWriter.cpp
     src/RootMeasurementWriter.cpp
     src/RootMaterialWriter.cpp
     src/RootMaterialTrackReader.cpp

--- a/Examples/Io/Root/include/ActsExamples/Io/Root/RootClusterWriter.hpp
+++ b/Examples/Io/Root/include/ActsExamples/Io/Root/RootClusterWriter.hpp
@@ -1,0 +1,116 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include "Acts/Utilities/Logger.hpp"
+#include "ActsExamples/EventData/Cluster.hpp"
+#include "ActsExamples/Framework/ProcessCode.hpp"
+#include "ActsExamples/Framework/WriterT.hpp"
+
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <vector>
+
+class TFile;
+class TTree;
+
+namespace ActsExamples {
+
+/// @class RootClusterWriter
+///
+/// Write out the clusters and their cells, one entry per cluster.
+///
+/// The written `cluster_id` is the index into the cluster container. Clusters
+/// are in a one-to-one relation with the measurements formed from them, so it
+/// is also the `measurement_id` of the RootMeasurementWriter tree and thus the
+/// key to join the two on.
+///
+/// Safe to use from multiple writer threads - uses a std::mutex lock.
+class RootClusterWriter final : public WriterT<ClusterContainer> {
+ public:
+  struct Config {
+    /// Which cluster collection to write.
+    std::string inputClusters;
+
+    /// path of the output file
+    std::string filePath = "";
+    /// file access mode
+    std::string fileMode = "RECREATE";
+    /// The tree name
+    std::string treeName = "clusters";
+  };
+
+  /// Constructor with
+  /// @param config configuration struct
+  /// @param level logging level
+  RootClusterWriter(const Config& config, Acts::Logging::Level level);
+
+  /// Virtual destructor
+  ~RootClusterWriter() override;
+
+  /// End-of-run hook
+  ProcessCode finalize() override;
+
+  /// Get const access to the config
+  const Config& config() const { return m_cfg; }
+
+ protected:
+  /// This implementation holds the actual writing method
+  /// and is called by the WriterT<>::write interface
+  ///
+  /// @param ctx The Algorithm context with per event information
+  /// @param clusters is the data to be written out
+  ProcessCode writeT(const AlgorithmContext& ctx,
+                     const ClusterContainer& clusters) override;
+
+ private:
+  Config m_cfg;
+  /// protect multi-threaded writes
+  std::mutex m_writeMutex;
+  /// the output file
+  TFile* m_outputFile = nullptr;
+  /// the output tree
+  TTree* m_outputTree = nullptr;
+
+  // Identification
+  int m_eventNr = 0;
+  std::uint64_t m_clusterId = 0;
+  int m_volumeId = 0;
+  int m_layerId = 0;
+  int m_surfaceId = 0;
+  int m_extraId = 0;
+
+  // Cell information
+  int m_clusterSize = 0;
+  int m_clusterSizeLoc0 = 0;
+  int m_clusterSizeLoc1 = 0;
+  std::vector<int> m_channelLoc0 = {};
+  std::vector<int> m_channelLoc1 = {};
+  std::vector<float> m_channelValue = {};
+
+  // Cluster position and shape
+  float m_globalX = 0.f;
+  float m_globalY = 0.f;
+  float m_globalZ = 0.f;
+  float m_localDirectionX = 0.f;
+  float m_localDirectionY = 0.f;
+  float m_localDirectionZ = 0.f;
+  float m_lengthDirectionX = 0.f;
+  float m_lengthDirectionY = 0.f;
+  float m_lengthDirectionZ = 0.f;
+  float m_localEta = 0.f;
+  float m_localPhi = 0.f;
+  float m_globalEta = 0.f;
+  float m_globalPhi = 0.f;
+  float m_etaAngle = 0.f;
+  float m_phiAngle = 0.f;
+};
+
+}  // namespace ActsExamples

--- a/Examples/Io/Root/include/ActsExamples/Io/Root/RootMeasurementWriter.hpp
+++ b/Examples/Io/Root/include/ActsExamples/Io/Root/RootMeasurementWriter.hpp
@@ -11,7 +11,6 @@
 #include "Acts/Definitions/TrackParametrization.hpp"
 #include "Acts/Geometry/GeometryIdentifier.hpp"
 #include "Acts/Utilities/Logger.hpp"
-#include "ActsExamples/EventData/Cluster.hpp"
 #include "ActsExamples/EventData/Measurement.hpp"
 #include "ActsExamples/EventData/SimHit.hpp"
 #include "ActsExamples/EventData/TruthMatching.hpp"
@@ -38,8 +37,8 @@ namespace ActsExamples {
 
 /// @class RootMeasurementWriter
 ///
-/// Write out a planar cluster collection into a root file
-/// to avoid immense long vectors, each cluster is one entry
+/// Write out a measurement collection into a root file
+/// to avoid immense long vectors, each measurement is one entry
 /// in the root file for optimised data writing speed
 /// The event number is part of the written data.
 ///
@@ -52,17 +51,12 @@ class RootMeasurementWriter final : public WriterT<MeasurementContainer> {
   struct Config {
     /// Which measurement collection to write.
     std::string inputMeasurements;
-    /// Which cluster collection to write (optional)
-    std::string inputClusters;
     /// Which simulated (truth) hits collection to use.
     std::string inputSimHits;
     /// Input collection to map measured hits to simulated hits.
     std::string inputMeasurementSimHitsMap;
     /// Dimensionality of the measurements to write
     std::vector<Acts::BoundIndices> boundIndices = {
-        Acts::eBoundLoc0, Acts::eBoundLoc1, Acts::eBoundTime};
-    /// And cluster indices (if available)
-    std::vector<Acts::BoundIndices> clusterIndices = {
         Acts::eBoundLoc0, Acts::eBoundLoc1, Acts::eBoundTime};
 
     /// path of the output file
@@ -117,7 +111,6 @@ class RootMeasurementWriter final : public WriterT<MeasurementContainer> {
   /// the output tree
   std::unique_ptr<ActsPlugins::RootMeasurementIo> m_measurementIo;
 
-  ReadDataHandle<ClusterContainer> m_inputClusters{this, "InputClusters"};
   ReadDataHandle<SimHitContainer> m_inputSimHits{this, "InputSimHits"};
   ReadDataHandle<MeasurementSimHitsMap> m_inputMeasurementSimHitsMap{
       this, "InputMeasurementSimHitsMap"};

--- a/Examples/Io/Root/src/RootAthenaDumpReader.cpp
+++ b/Examples/Io/Root/src/RootAthenaDumpReader.cpp
@@ -459,6 +459,7 @@ RootAthenaDumpReader::readMeasurements(
     ACTS_VERBOSE("Add measurement with index " << measIndex);
     imIdxMap.emplace(im, measIndex);
     createMeasurement(measurements, geoId, digiPars);
+    cluster.geometryId = geoId;
     clusters.push_back(cluster);
 
     if (!m_cfg.noTruth) {

--- a/Examples/Io/Root/src/RootClusterWriter.cpp
+++ b/Examples/Io/Root/src/RootClusterWriter.cpp
@@ -1,0 +1,133 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "ActsExamples/Io/Root/RootClusterWriter.hpp"
+
+#include "ActsExamples/EventData/Index.hpp"
+#include "ActsExamples/Framework/AlgorithmContext.hpp"
+
+#include <ios>
+
+#include <TFile.h>
+#include <TTree.h>
+
+namespace ActsExamples {
+
+RootClusterWriter::RootClusterWriter(const RootClusterWriter::Config& config,
+                                     Acts::Logging::Level level)
+    : WriterT(config.inputClusters, "RootClusterWriter", level), m_cfg(config) {
+  // Input container for clusters is already checked by base constructor
+
+  // Setup ROOT File
+  m_outputFile = TFile::Open(m_cfg.filePath.c_str(), m_cfg.fileMode.c_str());
+  if (m_outputFile == nullptr) {
+    throw std::ios_base::failure("Could not open '" + m_cfg.filePath + "'");
+  }
+
+  m_outputFile->cd();
+  m_outputTree = new TTree(m_cfg.treeName.c_str(), "Clusters");
+
+  m_outputTree->Branch("event_nr", &m_eventNr);
+  m_outputTree->Branch("cluster_id", &m_clusterId);
+  m_outputTree->Branch("volume_id", &m_volumeId);
+  m_outputTree->Branch("layer_id", &m_layerId);
+  m_outputTree->Branch("surface_id", &m_surfaceId);
+  m_outputTree->Branch("extra_id", &m_extraId);
+
+  m_outputTree->Branch("clus_size", &m_clusterSize);
+  m_outputTree->Branch("clus_size_loc0", &m_clusterSizeLoc0);
+  m_outputTree->Branch("clus_size_loc1", &m_clusterSizeLoc1);
+  m_outputTree->Branch("channel_loc0", &m_channelLoc0);
+  m_outputTree->Branch("channel_loc1", &m_channelLoc1);
+  m_outputTree->Branch("channel_value", &m_channelValue);
+
+  m_outputTree->Branch("clus_gx", &m_globalX);
+  m_outputTree->Branch("clus_gy", &m_globalY);
+  m_outputTree->Branch("clus_gz", &m_globalZ);
+
+  // Only filled for digitization inputs that provide the cluster shape,
+  // e.g. the Athena dump reader
+  m_outputTree->Branch("loc_direction_x", &m_localDirectionX);
+  m_outputTree->Branch("loc_direction_y", &m_localDirectionY);
+  m_outputTree->Branch("loc_direction_z", &m_localDirectionZ);
+  m_outputTree->Branch("length_direction_x", &m_lengthDirectionX);
+  m_outputTree->Branch("length_direction_y", &m_lengthDirectionY);
+  m_outputTree->Branch("length_direction_z", &m_lengthDirectionZ);
+  m_outputTree->Branch("loc_eta", &m_localEta);
+  m_outputTree->Branch("loc_phi", &m_localPhi);
+  m_outputTree->Branch("glob_eta", &m_globalEta);
+  m_outputTree->Branch("glob_phi", &m_globalPhi);
+  m_outputTree->Branch("eta_angle", &m_etaAngle);
+  m_outputTree->Branch("phi_angle", &m_phiAngle);
+}
+
+RootClusterWriter::~RootClusterWriter() {
+  if (m_outputFile != nullptr) {
+    m_outputFile->Close();
+  }
+}
+
+ProcessCode RootClusterWriter::finalize() {
+  m_outputFile->cd();
+  m_outputTree->Write();
+  m_outputFile->Close();
+
+  return ProcessCode::SUCCESS;
+}
+
+ProcessCode RootClusterWriter::writeT(const AlgorithmContext& ctx,
+                                      const ClusterContainer& clusters) {
+  // Exclusive access to the tree while writing
+  std::lock_guard<std::mutex> lock(m_writeMutex);
+
+  for (Index clusterIdx = 0u; clusterIdx < clusters.size(); ++clusterIdx) {
+    const Cluster& cluster = clusters[clusterIdx];
+
+    m_eventNr = static_cast<int>(ctx.eventNumber);
+    m_clusterId = clusterIdx;
+    m_volumeId = static_cast<int>(cluster.geometryId.volume());
+    m_layerId = static_cast<int>(cluster.geometryId.layer());
+    m_surfaceId = static_cast<int>(cluster.geometryId.sensitive());
+    m_extraId = static_cast<int>(cluster.geometryId.extra());
+
+    m_clusterSize = static_cast<int>(cluster.channels.size());
+    m_clusterSizeLoc0 = static_cast<int>(cluster.sizeLoc0);
+    m_clusterSizeLoc1 = static_cast<int>(cluster.sizeLoc1);
+    for (const auto& channel : cluster.channels) {
+      m_channelLoc0.push_back(static_cast<int>(channel.bin[0]));
+      m_channelLoc1.push_back(static_cast<int>(channel.bin[1]));
+      m_channelValue.push_back(static_cast<float>(channel.activation));
+    }
+
+    m_globalX = static_cast<float>(cluster.globalPosition.x());
+    m_globalY = static_cast<float>(cluster.globalPosition.y());
+    m_globalZ = static_cast<float>(cluster.globalPosition.z());
+    m_localDirectionX = static_cast<float>(cluster.localDirection.x());
+    m_localDirectionY = static_cast<float>(cluster.localDirection.y());
+    m_localDirectionZ = static_cast<float>(cluster.localDirection.z());
+    m_lengthDirectionX = static_cast<float>(cluster.lengthDirection.x());
+    m_lengthDirectionY = static_cast<float>(cluster.lengthDirection.y());
+    m_lengthDirectionZ = static_cast<float>(cluster.lengthDirection.z());
+    m_localEta = cluster.localEta;
+    m_localPhi = cluster.localPhi;
+    m_globalEta = cluster.globalEta;
+    m_globalPhi = cluster.globalPhi;
+    m_etaAngle = cluster.etaAngle;
+    m_phiAngle = cluster.phiAngle;
+
+    m_outputTree->Fill();
+
+    m_channelLoc0.clear();
+    m_channelLoc1.clear();
+    m_channelValue.clear();
+  }
+
+  return ProcessCode::SUCCESS;
+}
+
+}  // namespace ActsExamples

--- a/Examples/Io/Root/src/RootMeasurementWriter.cpp
+++ b/Examples/Io/Root/src/RootMeasurementWriter.cpp
@@ -44,16 +44,6 @@ prepareBoundMeasurement(const ConstVariableBoundMeasurementProxy& m) {
   return {measurements, variances, subspaceIndex};
 }
 
-std::vector<std::tuple<int, int, float>> prepareChannels(const Cluster& c) {
-  std::vector<std::tuple<int, int, float>> channels = {};
-  for (auto ch : c.channels) {
-    channels.emplace_back(static_cast<int>(ch.bin[0]),
-                          static_cast<int>(ch.bin[1]),
-                          static_cast<float>(ch.activation));
-  }
-  return channels;
-}
-
 }  // namespace
 
 RootMeasurementWriter::RootMeasurementWriter(
@@ -69,7 +59,6 @@ RootMeasurementWriter::RootMeasurementWriter(
         "Missing hit-to-simulated-hits map input collection");
   }
 
-  m_inputClusters.maybeInitialize(m_cfg.inputClusters);
   m_inputSimHits.initialize(m_cfg.inputSimHits);
   m_inputMeasurementSimHitsMap.initialize(m_cfg.inputMeasurementSimHitsMap);
 
@@ -91,8 +80,7 @@ RootMeasurementWriter::RootMeasurementWriter(
   m_outputTree->Branch("particles_generation", &m_particleGeneration);
   m_outputTree->Branch("particles_sub_particle", &m_particleSubParticle);
 
-  ActsPlugins::RootMeasurementIo::Config treeCfg{m_cfg.boundIndices,
-                                                 m_cfg.clusterIndices};
+  ActsPlugins::RootMeasurementIo::Config treeCfg{m_cfg.boundIndices};
   m_measurementIo = std::make_unique<ActsPlugins::RootMeasurementIo>(treeCfg);
   m_measurementIo->connectForWrite(*m_outputTree);
 }
@@ -117,11 +105,6 @@ ProcessCode RootMeasurementWriter::writeT(
   const auto& simHits = m_inputSimHits(ctx);
   const auto& hitSimHitsMap = m_inputMeasurementSimHitsMap(ctx);
 
-  const ClusterContainer* clusters = nullptr;
-  if (!m_cfg.inputClusters.empty()) {
-    clusters = &m_inputClusters(ctx);
-  }
-
   // Exclusive access to the tree while writing
   std::lock_guard<std::mutex> lock(m_writeMutex);
 
@@ -139,7 +122,7 @@ ProcessCode RootMeasurementWriter::writeT(
 
     // Fill the identification
     m_measurementIo->fillIdentification(static_cast<int>(ctx.eventNumber),
-                                        geoId);
+                                        hitIdx, geoId);
 
     // Find the contributing simulated hits
     auto indices = makeRange(hitSimHitsMap.equal_range(hitIdx));
@@ -162,16 +145,9 @@ ProcessCode RootMeasurementWriter::writeT(
     }
     m_measurementIo->fillTruthParameters(local, pos4, dir, angles);
 
-    // Fill the measurement parameters & clusters still
+    // Fill the measurement parameters
     auto [msm, vcs, ssi] = prepareBoundMeasurement(meas);
     m_measurementIo->fillBoundMeasurement(msm, vcs, ssi);
-
-    // Fill the cluster information if available
-    if (clusters != nullptr) {
-      const auto& cluster = (*clusters)[hitIdx];
-      m_measurementIo->fillGlobalPosition(cluster.globalPosition);
-      m_measurementIo->fillCluster(prepareChannels(cluster));
-    }
 
     m_outputTree->Fill();
     m_particleVertexPrimary.clear();

--- a/Examples/Scripts/Digitization/error_parameterisation.py
+++ b/Examples/Scripts/Digitization/error_parameterisation.py
@@ -14,8 +14,20 @@ import os
 from pathlib import Path
 
 
+def read_flat(tree):
+    """Read the scalar branches of a tree into a data frame, the per cell
+    branches are of no use here and would pull in awkward arrays"""
+    flat = [
+        key
+        for key in tree.keys()
+        if not isinstance(tree[key].interpretation, uproot.AsJagged)
+    ]
+    return tree.arrays(flat, library="pd")
+
+
 def run_error_parametriation(
     rfile,
+    cfile,
     digi_cfg,
     volumes,
     output_dir=Path.cwd(),
@@ -47,16 +59,27 @@ def run_error_parametriation(
 
     var_entries = []
 
-    measurements = rfile["measurements"].arrays(library="pd")
+    # Measurements and clusters are written into separate trees, a measurement
+    # is formed from the cluster of the same index within the event
+    measurements = read_flat(rfile["measurements"])
+    clusters = read_flat(cfile["clusters"]).rename(
+        columns={"cluster_id": "measurement_id"}
+    )
+    measurements = measurements.merge(
+        clusters.drop(columns=["volume_id", "layer_id", "surface_id", "extra_id"]),
+        on=["event_nr", "measurement_id"],
+        validate="one_to_one",
+    )
+
     # Make a new column with g_r = sqrt(x^2+y^2)
-    measurements["rec_gr"] = np.sqrt(
-        measurements["rec_gx"] ** 2 + measurements["rec_gy"] ** 2
+    measurements["clus_gr"] = np.sqrt(
+        measurements["clus_gx"] ** 2 + measurements["clus_gy"] ** 2
     )
     measurements["true_r"] = np.sqrt(
         measurements["true_x"] ** 2 + measurements["true_y"] ** 2
     )
 
-    plt.scatter(x=measurements["rec_gz"], y=measurements["rec_gr"], s=1, alpha=0.1)
+    plt.scatter(x=measurements["clus_gz"], y=measurements["clus_gr"], s=1, alpha=0.1)
     plt.xlabel("z [mm]")
     plt.ylabel("r [mm]")
     plt.title("Reconstructed hit positions")
@@ -382,6 +405,7 @@ if "__main__" == __name__:
     # Parse the command line arguments
     p = argparse.ArgumentParser(description="Hit parameterisation")
     p.add_argument("--root")
+    p.add_argument("--clusters")
     p.add_argument("--json-in")
     p.add_argument("--json-out")
     p.add_argument("--plot-pulls", action="store_true")
@@ -409,8 +433,9 @@ if "__main__" == __name__:
     )
     args = p.parse_args()
 
-    # Open the root file
+    # Open the root files
     rfile = uproot.open(args.root)
+    cfile = uproot.open(args.clusters)
 
     # For the current ODD this would be
     if len(args.volumes_ids) != len(args.volume_names):
@@ -432,6 +457,7 @@ if "__main__" == __name__:
 
     run_error_parametriation(
         rfile,
+        cfile,
         digi_cfg,
         volumes,
         Path.cwd() / "output",

--- a/Plugins/Root/include/ActsPlugins/Root/RootMeasurementIo.hpp
+++ b/Plugins/Root/include/ActsPlugins/Root/RootMeasurementIo.hpp
@@ -12,7 +12,7 @@
 #include "Acts/Definitions/TrackParametrization.hpp"
 
 #include <array>
-#include <tuple>
+#include <cstdint>
 #include <vector>
 
 class TTree;
@@ -25,17 +25,13 @@ namespace ActsPlugins {
 /// @addtogroup root_plugin
 /// @{
 
-/// @brief Helper class to manage the I/O of measurements and associated clusters
-/// to and from ROOT files.
+/// @brief Helper class to manage the I/O of measurements to and from ROOT files.
 class RootMeasurementIo {
  public:
   /// Configuration struct for measurement I/O
   struct Config {
     /// Indicate the reconstruction indices to be stored
     std::vector<Acts::BoundIndices>& recoIndices;
-
-    /// Indicate the cluster indices to be stored
-    std::vector<Acts::BoundIndices>& clusterIndices;
   };
 
   /// Constructor from configuration struct
@@ -51,8 +47,10 @@ class RootMeasurementIo {
   /// Convenience function to register identification
   ///
   /// @param evnt The event number
+  /// @param measurementId The index of the measurement within the event
   /// @param geoId The geometry identifier of the measurement
-  void fillIdentification(int evnt, const Acts::GeometryIdentifier& geoId);
+  void fillIdentification(int evnt, std::uint64_t measurementId,
+                          const Acts::GeometryIdentifier& geoId);
 
   /// Convenience function to register the truth parameters
   ///
@@ -74,17 +72,6 @@ class RootMeasurementIo {
                             const std::vector<double>& variances,
                             const std::vector<unsigned int>& subspaceIndex);
 
-  /// Fill global information of the cluster/measurement
-  ///
-  /// @param pos The global position of the cluster
-  void fillGlobalPosition(const Acts::Vector3& pos);
-
-  /// Convenience function to fill the cluster information
-  ///  - abstracted to be used in different contexts
-  ///
-  /// @param channels The channel information
-  void fillCluster(const std::vector<std::tuple<int, int, float>>& channels);
-
   /// Clear the payload
   void clear();
 
@@ -99,6 +86,7 @@ class RootMeasurementIo {
   struct MeasurementPayload {
     // Identification parameters
     int eventNr = 0;
+    std::uint64_t measurementID = 0;
     int volumeID = 0;
     int layerID = 0;
     int surfaceID = 0;
@@ -107,10 +95,6 @@ class RootMeasurementIo {
     // Reconstructed information
     std::array<float, Acts::eBoundSize> recBound = {};
     std::array<float, Acts::eBoundSize> varBound = {};
-
-    float recGx = 0.;
-    float recGy = 0.;
-    float recGz = 0.;
 
     // Truth parameters
     std::array<float, Acts::eBoundSize> trueBound = {};
@@ -125,16 +109,7 @@ class RootMeasurementIo {
     std::array<float, Acts::eBoundSize> pull = {};
   };
 
-  struct ClusterPayload {
-    // Cluster information
-    int nch = 0;
-    std::array<int, 2> clusterSize = {0, 0};
-    std::array<std::vector<int>, 2> chId;
-    std::vector<float> chValue = {};
-  };
-
   MeasurementPayload m_measurementPayload;
-  ClusterPayload m_clusterPayload;
 };
 /// @}
 }  // namespace ActsPlugins

--- a/Plugins/Root/src/RootMeasurementIo.cpp
+++ b/Plugins/Root/src/RootMeasurementIo.cpp
@@ -23,6 +23,7 @@ ActsPlugins::RootMeasurementIo::RootMeasurementIo(const Config& config)
 
 void ActsPlugins::RootMeasurementIo::connectForWrite(TTree& measurementTree) {
   measurementTree.Branch("event_nr", &m_measurementPayload.eventNr);
+  measurementTree.Branch("measurement_id", &m_measurementPayload.measurementID);
   measurementTree.Branch("volume_id", &m_measurementPayload.volumeID);
   measurementTree.Branch("layer_id", &m_measurementPayload.layerID);
   measurementTree.Branch("surface_id", &m_measurementPayload.surfaceID);
@@ -35,22 +36,6 @@ void ActsPlugins::RootMeasurementIo::connectForWrite(TTree& measurementTree) {
   for (auto ib : m_cfg.recoIndices) {
     measurementTree.Branch(("var_" + bNames[ib]).c_str(),
                            &m_measurementPayload.varBound[ib]);
-  }
-
-  measurementTree.Branch("rec_gx", &m_measurementPayload.recGx);
-  measurementTree.Branch("rec_gy", &m_measurementPayload.recGy);
-  measurementTree.Branch("rec_gz", &m_measurementPayload.recGz);
-
-  measurementTree.Branch("clus_size", &m_clusterPayload.nch);
-  measurementTree.Branch("channel_value", &m_clusterPayload.chValue);
-  // Both are allocated, but only relevant ones are set
-  for (auto ib : m_cfg.clusterIndices) {
-    if (static_cast<unsigned int>(ib) < 2) {
-      measurementTree.Branch(("channel_" + bNames[ib]).c_str(),
-                             &m_clusterPayload.chId[ib]);
-      measurementTree.Branch(("clus_size_" + bNames[ib]).c_str(),
-                             &m_clusterPayload.clusterSize[ib]);
-    }
   }
 
   for (unsigned int ib = 0; ib < eBoundSize; ++ib) {
@@ -77,8 +62,9 @@ void ActsPlugins::RootMeasurementIo::connectForWrite(TTree& measurementTree) {
 }
 
 void ActsPlugins::RootMeasurementIo::fillIdentification(
-    int evnt, const GeometryIdentifier& geoId) {
+    int evnt, std::uint64_t measurementId, const GeometryIdentifier& geoId) {
   m_measurementPayload.eventNr = evnt;
+  m_measurementPayload.measurementID = measurementId;
   m_measurementPayload.volumeID = static_cast<int>(geoId.volume());
   m_measurementPayload.layerID = static_cast<int>(geoId.layer());
   m_measurementPayload.surfaceID = static_cast<int>(geoId.sensitive());
@@ -125,30 +111,6 @@ void ActsPlugins::RootMeasurementIo::fillBoundMeasurement(
   }
 }
 
-void ActsPlugins::RootMeasurementIo::fillGlobalPosition(const Vector3& pos) {
-  m_measurementPayload.recGx = pos.x();
-  m_measurementPayload.recGy = pos.y();
-  m_measurementPayload.recGz = pos.z();
-}
-
-void ActsPlugins::RootMeasurementIo::fillCluster(
-    const std::vector<std::tuple<int, int, float>>& channels) {
-  m_clusterPayload.nch = static_cast<int>(channels.size());
-  if (m_clusterPayload.nch == 0) {
-    return;
-  }
-  for (auto [ch0, ch1, chv] : channels) {
-    m_clusterPayload.chId[0].push_back(ch0);
-    m_clusterPayload.chId[1].push_back(ch1);
-    m_clusterPayload.chValue.push_back(chv);
-  }
-  // Calculate cluster size in 0 and 1 direction
-  auto [min0, max0] = std::ranges::minmax_element(m_clusterPayload.chId[0]);
-  auto [min1, max1] = std::ranges::minmax_element(m_clusterPayload.chId[1]);
-  m_clusterPayload.clusterSize[0] = (*max0 - *min0 + 1);
-  m_clusterPayload.clusterSize[1] = (*max1 - *min1 + 1);
-}
-
 void ActsPlugins::RootMeasurementIo::clear() {
   for (unsigned int ib = 0; ib < eBoundSize; ++ib) {
     m_measurementPayload.trueBound[ib] =
@@ -158,19 +120,9 @@ void ActsPlugins::RootMeasurementIo::clear() {
     m_measurementPayload.residual[ib] = std::numeric_limits<float>::quiet_NaN();
     m_measurementPayload.pull[ib] = std::numeric_limits<float>::quiet_NaN();
   }
-  m_measurementPayload.recGx = std::numeric_limits<float>::quiet_NaN();
-  m_measurementPayload.recGy = std::numeric_limits<float>::quiet_NaN();
-  m_measurementPayload.recGz = std::numeric_limits<float>::quiet_NaN();
   m_measurementPayload.trueGx = std::numeric_limits<float>::quiet_NaN();
   m_measurementPayload.trueGy = std::numeric_limits<float>::quiet_NaN();
   m_measurementPayload.trueGz = std::numeric_limits<float>::quiet_NaN();
   m_measurementPayload.incidentPhi = std::numeric_limits<float>::quiet_NaN();
   m_measurementPayload.incidentTheta = std::numeric_limits<float>::quiet_NaN();
-
-  m_clusterPayload.nch = 0;
-  m_clusterPayload.clusterSize[0] = 0;
-  m_clusterPayload.clusterSize[1] = 0;
-  m_clusterPayload.chId[0].clear();
-  m_clusterPayload.chId[1].clear();
-  m_clusterPayload.chValue.clear();
 }

--- a/Python/Examples/python/simulation.py
+++ b/Python/Examples/python/simulation.py
@@ -847,7 +847,6 @@ def addDigitization(
             outputDirRoot.mkdir()
         rmwConfig = acts.examples.root.RootMeasurementWriter.Config(
             inputMeasurements=digiAlg.config.outputMeasurements,
-            inputClusters=digiAlg.config.outputClusters,
             inputSimHits=digiAlg.config.inputSimHits,
             inputMeasurementSimHitsMap=digiAlg.config.outputMeasurementSimHitsMap,
             filePath=str(outputDirRoot / f"{digiAlg.config.outputMeasurements}.root"),
@@ -856,6 +855,11 @@ def addDigitization(
         s.addWriter(
             acts.examples.root.RootMeasurementWriter(rmwConfig, customLogLevel())
         )
+        rcwConfig = acts.examples.root.RootClusterWriter.Config(
+            inputClusters=digiAlg.config.outputClusters,
+            filePath=str(outputDirRoot / f"{digiAlg.config.outputClusters}.root"),
+        )
+        s.addWriter(acts.examples.root.RootClusterWriter(rcwConfig, customLogLevel()))
         rmpwConfig = acts.examples.root.RootMeasurementPerformanceWriter.Config(
             inputMeasurements=digiAlg.config.outputMeasurements,
             inputSimHits=digiAlg.config.inputSimHits,

--- a/Python/Examples/src/plugins/Root.cpp
+++ b/Python/Examples/src/plugins/Root.cpp
@@ -11,6 +11,7 @@
 #include "ActsExamples/Io/Root/RootAthenaDumpWriter.hpp"
 #include "ActsExamples/Io/Root/RootAthenaNTupleReader.hpp"
 #include "ActsExamples/Io/Root/RootBFieldWriter.hpp"
+#include "ActsExamples/Io/Root/RootClusterWriter.hpp"
 #include "ActsExamples/Io/Root/RootFileHasher.hpp"
 #include "ActsExamples/Io/Root/RootMaterialTrackReader.hpp"
 #include "ActsExamples/Io/Root/RootMaterialTrackWriter.hpp"
@@ -214,9 +215,21 @@ PYBIND11_MODULE(ActsExamplesPythonBindingsRoot, root) {
 
       auto c = py::class_<Writer::Config>(w, "Config").def(py::init<>());
 
-      ACTS_PYTHON_STRUCT(c, inputMeasurements, inputClusters, inputSimHits,
+      ACTS_PYTHON_STRUCT(c, inputMeasurements, inputSimHits,
                          inputMeasurementSimHitsMap, filePath, fileMode,
                          surfaceByIdentifier);
+    }
+
+    {
+      using Writer = RootClusterWriter;
+      auto w = py::class_<Writer, IWriter, std::shared_ptr<Writer>>(
+                   root, "RootClusterWriter")
+                   .def(py::init<const Writer::Config&, Logging::Level>(),
+                        py::arg("config"), py::arg("level"));
+
+      auto c = py::class_<Writer::Config>(w, "Config").def(py::init<>());
+
+      ACTS_PYTHON_STRUCT(c, inputClusters, filePath, fileMode, treeName);
     }
 
     {

--- a/Python/Examples/tests/test_examples.py
+++ b/Python/Examples/tests/test_examples.py
@@ -539,8 +539,10 @@ def test_digitization_example(trk_geo, tmp_path, assert_root_hash, digi_config_f
 
     csv_dir = tmp_path / "csv"
     root_file = tmp_path / "measurements.root"
+    cluster_file = tmp_path / "clusters.root"
 
     assert not root_file.exists()
+    assert not cluster_file.exists()
     assert not csv_dir.exists()
 
     field = acts.ConstantBField(acts.Vector3(0, 0, 2 * u.T))
@@ -551,12 +553,14 @@ def test_digitization_example(trk_geo, tmp_path, assert_root_hash, digi_config_f
     s.run()
 
     assert root_file.exists()
+    assert cluster_file.exists()
     assert csv_dir.exists()
 
     assert len(list(csv_dir.iterdir())) == 3 * s.config.events
     assert all(f.stat().st_size > 50 for f in csv_dir.iterdir())
 
     assert_root_hash(root_file.name, root_file)
+    assert_root_hash(cluster_file.name, cluster_file)
 
 
 @pytest.mark.parametrize(
@@ -629,8 +633,10 @@ def test_digitization_example_input(
 
     csv_dir = tmp_path / "csv"
     root_file = tmp_path / "measurements.root"
+    cluster_file = tmp_path / "clusters.root"
 
     assert not root_file.exists()
+    assert not cluster_file.exists()
     assert not csv_dir.exists()
 
     assert_root_hash(
@@ -652,12 +658,14 @@ def test_digitization_example_input(
     s.run()
 
     assert root_file.exists()
+    assert cluster_file.exists()
     assert csv_dir.exists()
 
     assert len(list(csv_dir.iterdir())) == 3 * pgs.config.events
     assert all(f.stat().st_size > 50 for f in csv_dir.iterdir())
 
     assert_root_hash(root_file.name, root_file)
+    assert_root_hash(cluster_file.name, cluster_file)
 
 
 def test_digitization_config_example(trk_geo, tmp_path):

--- a/Python/Examples/tests/test_writer.py
+++ b/Python/Examples/tests/test_writer.py
@@ -178,7 +178,6 @@ def test_root_meas_writer(tmp_path, fatras, trk_geo, assert_root_hash):
 
     config = RootMeasurementWriter.Config(
         inputMeasurements=digiAlg.config.outputMeasurements,
-        inputClusters=digiAlg.config.outputClusters,
         inputSimHits=simAlg.config.outputSimHits,
         inputMeasurementSimHitsMap=digiAlg.config.outputMeasurementSimHitsMap,
         filePath=str(out),
@@ -189,6 +188,29 @@ def test_root_meas_writer(tmp_path, fatras, trk_geo, assert_root_hash):
 
     assert out.exists()
     assert out.stat().st_size > 40000
+    assert_root_hash(out.name, out)
+
+
+@pytest.mark.root
+def test_root_clusters_writer(tmp_path, fatras, assert_root_hash):
+    from acts.examples.root import RootClusterWriter
+
+    s = Sequencer(numThreads=1, events=10)
+    evGen, simAlg, digiAlg = fatras(s)
+
+    out = tmp_path / "clusters.root"
+
+    assert not out.exists()
+
+    config = RootClusterWriter.Config(
+        inputClusters=digiAlg.config.outputClusters,
+        filePath=str(out),
+    )
+    s.addWriter(RootClusterWriter(level=acts.logging.INFO, config=config))
+    s.run()
+
+    assert out.exists()
+    assert out.stat().st_size > 10000
     assert_root_hash(out.name, out)
 
 
@@ -314,6 +336,7 @@ def test_csv_simhits_writer(tmp_path, fatras, conf_const):
         "RootTrackParameterWriter",
         "RootMaterialTrackWriter",
         "RootMeasurementWriter",
+        "RootClusterWriter",
         "RootMaterialWriter",
         "RootSimHitWriter",
         "RootTrackStatesWriter",

--- a/Tests/UnitTests/Plugins/Root/RootMeasurementIoTests.cpp
+++ b/Tests/UnitTests/Plugins/Root/RootMeasurementIoTests.cpp
@@ -32,8 +32,7 @@ BOOST_AUTO_TEST_CASE(RootMeasurementIoTestsWrite) {
 
   // Create the configuration
   std::vector<BoundIndices> recoIndices = {eBoundLoc0, eBoundLoc1};
-  std::vector<BoundIndices> clusterIndices = {eBoundLoc0, eBoundLoc1};
-  RootMeasurementIo::Config cfg{recoIndices, clusterIndices};
+  RootMeasurementIo::Config cfg{recoIndices};
   RootMeasurementIo accessor(cfg);
 
   const std::filesystem::path filePath =
@@ -53,14 +52,11 @@ BOOST_AUTO_TEST_CASE(RootMeasurementIoTestsWrite) {
                    .withSensitive(4)
                    .withExtra(5);
 
-  accessor.fillIdentification(1, geoId);
+  accessor.fillIdentification(1, 42, geoId);
   accessor.fillTruthParameters(Vector2(0.1, 0.2), Vector4(1.1, 2.2, 3.3, 4.4),
                                Vector3(0.1, 0.2, 0.3),
                                std::make_pair(0.01, 0.02));
   accessor.fillBoundMeasurement({0.11, 0.22}, {0.01, 0.02}, {0, 1});
-  accessor.fillGlobalPosition(Vector3(1.0, 2.0, 3.0));
-  accessor.fillCluster(std::vector<std::tuple<int, int, float>>{
-      {1, 2, 0.5}, {2, 3, 1.5}, {3, 4, 2.5}});
 
   measurementTree.Fill();
   measurementTree.Write();
@@ -79,8 +75,7 @@ BOOST_AUTO_TEST_CASE(RootMeasurementIoTestsWrite) {
 BOOST_AUTO_TEST_CASE(RootMeasurementIoExceptions) {
   // Create the configuration
   std::vector<BoundIndices> recoIndices = {eBoundLoc0};
-  std::vector<BoundIndices> clusterIndices = {eBoundLoc0};
-  RootMeasurementIo::Config cfg{recoIndices, clusterIndices};
+  RootMeasurementIo::Config cfg{recoIndices};
   RootMeasurementIo accessor(cfg);
 
   BOOST_CHECK_THROW(accessor.fillBoundMeasurement({0.1, 0.2}, {0.01}, {0, 1}),


### PR DESCRIPTION
Clusters and cells are not measurements, so they get their own
`RootClusterWriter` instead of riding along in the measurement tree.

- `ActsExamples::Cluster` carries its `geometryId`, set where the cluster is
  formed, so the cluster output does not depend on the measurements
- `RootMeasurementWriter` drops `inputClusters` and the `clus_*`, `channel_*`
  and `rec_g*` branches, and gains a `measurement_id`
- the trees are joined on `measurement_id == cluster_id` within an event,
  `error_parameterisation.py` does so and takes the cluster file as `--clusters`

The ROOT file hashes of the measurement output change accordingly.
