### PR TITLE
fix: Clang (+CUDA) Fixes, main branch (2026.08.19.)

### DIFF
--- a/Detray/core/include/detray/utils/tuple.hpp
+++ b/Detray/core/include/detray/utils/tuple.hpp
@@ -17,8 +17,17 @@
 
 namespace detray {
 
+/// Default tuple type
+///
+/// Serving as the final node in the recursive implementation of this tuple
+/// type.
+///
 template <typename... Ts>
-struct tuple {};
+struct tuple {
+  // As long as we did everything correctly, this should only get instantiated
+  // with an empty parameter list, for the implementation to work correctly.
+  static_assert(sizeof...(Ts) == 0, "There's a coding error in detray::tuple!");
+};
 
 template <typename T, typename... Ts>
 struct tuple<T, Ts...> {
@@ -87,7 +96,7 @@ struct tuple<T, Ts...> {
   }
 
   T v;
-  tuple<Ts...> r{};
+  tuple<Ts...> r;
 };
 
 template <typename T1, typename T2>

--- a/Traccc/device/alpaka/src/finding/combinatorial_kalman_filter_algorithm.cpp
+++ b/Traccc/device/alpaka/src/finding/combinatorial_kalman_filter_algorithm.cpp
@@ -61,10 +61,11 @@ struct find_tracks {
 
     device::find_tracks<detector_t>(
         thread_id, barrier, cfg, *det_data, payload,
-        {.shared_num_out_params = shared_num_out_params,
-         .shared_insertion_mutex = shared_insertion_mutex,
-         .shared_candidates = shared_candidates,
-         .shared_candidates_size = shared_candidates_size});
+        device::find_tracks_shared_payload{
+            .shared_num_out_params = shared_num_out_params,
+            .shared_insertion_mutex = shared_insertion_mutex,
+            .shared_candidates = shared_candidates,
+            .shared_candidates_size = shared_candidates_size});
   }
 };
 


### PR DESCRIPTION
While trying to build the project with CUDA using Clang as the host compiler, I ran into these issues.
  - Without the modification in `detray::tuple`, I saw:

```
[build] In file included from /home/krasznaa/ATLAS/projects/acts/acts/Traccc/performance/src/performance/kalman_filter_comparison.cpp:10:
[build] In file included from /home/krasznaa/ATLAS/projects/acts/acts/Traccc/core/include/traccc/fitting/kalman_filter/kalman_actor.hpp:12:
[build] In file included from /home/krasznaa/ATLAS/projects/acts/acts/Traccc/core/include/traccc/edm/measurement_collection.hpp:15:
[build] In file included from /home/krasznaa/ATLAS/projects/acts/acts/Detray/core/include/detray/geometry/identifier.hpp:14:
[build] In file included from /home/krasznaa/ATLAS/projects/acts/acts/Detray/core/include/detray/definitions/indexing.hpp:12:
[build] In file included from /home/krasznaa/ATLAS/projects/acts/acts/Detray/core/include/detray/core/detail/indexing.hpp:12:
[build] In file included from /home/krasznaa/ATLAS/projects/acts/acts/Detray/core/include/detray/definitions/containers.hpp:14:
[build] /home/krasznaa/ATLAS/projects/acts/acts/Detray/core/include/detray/utils/tuple.hpp:99:17: error: call to implicitly-deleted default constructor of 'tuple<traccc::kalman_actor_state<detray::array<float>, detray::surface_descriptor<detray::detail::typed_index<detray::default_metadata<detray::array<float>>::mask_id, detray::detail::index_range<unsigned int, true, unsigned int, 268435200, 255>, unsigned int, 4026531840, 268435455>, detray::detail::typed_index<detray::default_metadata<detray::array<float>>::material_id, unsigned int, unsigned int, 4026531840, 268435455>, unsigned int, unsigned short>>>'
[build]    99 |   tuple<Ts...> r{};
[build]       |                 ^~
[build] /home/krasznaa/ATLAS/projects/acts/acts/Detray/core/include/detray/utils/tuple.hpp:34:13: note: in instantiation of default member initializer 'detray::tuple<detray::actor::pointwise_material_interactor<detray::array<float>>::state, traccc::kalman_actor_state<detray::array<float>, detray::surface_descriptor<detray::detail::typed_index<detray::default_metadata<detray::array<float>>::mask_id, detray::detail::index_range<unsigned int, true, unsigned int, 268435200, 255>, unsigned int, 4026531840, 268435455>, detray::detail::typed_index<detray::default_metadata<detray::array<float>>::material_id, unsigned int, unsigned int, 4026531840, 268435455>>>>::r' requested here
[build]    34 |   constexpr tuple() = default;
[build]       |             ^
[build] /home/krasznaa/ATLAS/projects/acts/acts/Detray/core/include/detray/utils/tuple.hpp:99:17: note: in evaluation of exception specification for 'detray::tuple<detray::actor::pointwise_material_interactor<detray::array<float>>::state, traccc::kalman_actor_state<detray::array<float>, detray::surface_descriptor<detray::detail::typed_index<detray::default_metadata<detray::array<float>>::mask_id, detray::detail::index_range<unsigned int, true, unsigned int, 268435200, 255>, unsigned int, 4026531840, 268435455>, detray::detail::typed_index<detray::default_metadata<detray::array<float>>::material_id, unsigned int, unsigned int, 4026531840, 268435455>>>>::tuple' needed here
[build]    99 |   tuple<Ts...> r{};
[build]       |                 ^
[build] /home/krasznaa/ATLAS/projects/acts/acts/Detray/core/include/detray/utils/tuple.hpp:34:13: note: in instantiation of default member initializer 'detray::tuple<detray::actor::parameter_updater_state<detray::array<float>>, detray::actor::pointwise_material_interactor<detray::array<float>>::state, traccc::kalman_actor_state<detray::array<float>, detray::surface_descriptor<detray::detail::typed_index<detray::default_metadata<detray::array<float>>::mask_id, detray::detail::index_range<unsigned int, true, unsigned int, 268435200, 255>, unsigned int, 4026531840, 268435455>, detray::detail::typed_index<detray::default_metadata<detray::array<float>>::material_id, unsigned int, unsigned int, 4026531840, 268435455>>>>::r' requested here
[build]    34 |   constexpr tuple() = default;
[build]       |             ^
```

  - The (CUDA backended) Alpaka build in the meanwhile produced this weird warning:

```
[build] /home/krasznaa/ATLAS/projects/acts/acts/Traccc/device/alpaka/src/finding/combinatorial_kalman_filter_algorithm.cpp:62:79: warning: use of GNU old-style field designator extension [-Wgnu-designator]
[build]    62 | __T0::find_tracks< detector_t> (thread_id, barrier, cfg, *det_data, payload, {shared_num_out_params: shared_num_out_params, shared_insertion_mutex: shared_insertion_mutex, shared_candidates: shared_candidates, shared_candidates_size: shared_candidates_size}); 
[build]       |                                                                               ^~~~~~~~~~~~~~~~~~~~~~
[build]       |                                                                               .shared_num_out_params = 
[build] /home/krasznaa/ATLAS/projects/acts/acts/Traccc/device/alpaka/src/finding/combinatorial_kalman_filter_algorithm.cpp:62:125: warning: use of GNU old-style field designator extension [-Wgnu-designator]
[build]    62 | __T0::find_tracks< detector_t> (thread_id, barrier, cfg, *det_data, payload, {shared_num_out_params: shared_num_out_params, shared_insertion_mutex: shared_insertion_mutex, shared_candidates: shared_candidates, shared_candidates_size: shared_candidates_size}); 
[build]       |                                                                                                                             ^~~~~~~~~~~~~~~~~~~~~~~
[build]       |                                                                                                                             .shared_insertion_mutex = 
[build] /home/krasznaa/ATLAS/projects/acts/acts/Traccc/device/alpaka/src/finding/combinatorial_kalman_filter_algorithm.cpp:62:173: warning: use of GNU old-style field designator extension [-Wgnu-designator]
[build]    62 | __T0::find_tracks< detector_t> (thread_id, barrier, cfg, *det_data, payload, {shared_num_out_params: shared_num_out_params, shared_insertion_mutex: shared_insertion_mutex, shared_candidates: shared_candidates, shared_candidates_size: shared_candidates_size}); 
[build]       |                                                                                                                                                                             ^~~~~~~~~~~~~~~~~~
[build]       |                                                                                                                                                                             .shared_candidates = 
[build] /home/krasznaa/ATLAS/projects/acts/acts/Traccc/device/alpaka/src/finding/combinatorial_kalman_filter_algorithm.cpp:62:211: warning: use of GNU old-style field designator extension [-Wgnu-designator]
[build]    62 | __T0::find_tracks< detector_t> (thread_id, barrier, cfg, *det_data, payload, {shared_num_out_params: shared_num_out_params, shared_insertion_mutex: shared_insertion_mutex, shared_candidates: shared_candidates, shared_candidates_size: shared_candidates_size}); 
[build]       |                                                                                                                                                                                                                   ^~~~~~~~~~~~~~~~~~~~~~~
[build]       |                                                                                                                                                                                                                   .shared_candidates_size = 
```

This latter one I don't actually fully understand. But this "fix" seems to be simple enough, so I'm contempt with just applying it.