### PR TITLE
chore: oneAPI / Modern Clang Compatibility, main branch (2026.08.20.)

### DIFF
--- a/Core/include/Acts/Material/MaterialSlab.hpp
+++ b/Core/include/Acts/Material/MaterialSlab.hpp
@@ -22,6 +22,7 @@
 
 #if defined(__clang__) && defined(__x86_64__)
 #pragma float_control(push)
+#pragma float_control(precise, on)
 #pragma float_control(except, on)
 #endif
 


### PR DESCRIPTION
This is to make the build work with oneAPI-2026.1.0.

The oneAPI releases are usually on the latest LLVM versions. So this should be useful for not just the closed source Intel compiler as well.

With oneAPI-2026.1.0, I see the following error with the current code:

```
[build] In file included from /home/krasznaa/ATLAS/projects/acts/acts/Core/src/EventData/PrintParameters.cpp:12:
[build] In file included from /home/krasznaa/ATLAS/projects/acts/acts/Core/include/Acts/Surfaces/Surface.hpp:19:
[build] /home/krasznaa/ATLAS/projects/acts/acts/Core/include/Acts/Material/MaterialSlab.hpp:25:9: error: '#pragma float_control(except, on)' is illegal when precise is disabled
[build]    25 | #pragma float_control(except, on)
[build]       |         ^
```

Apparently one can only explicitly ask for FPEs with precise FP calculations. Which oneAPI doesn't do by default. (But I assume LLVM/clang does.)

Having pondered for a little bit, I thought this could be an acceptable solution here. But I'm not fully-fully clear on this...