### PR TITLE
refactor: Adopt actsvg 0.4.57, deprecating the removed sheet converters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -311,7 +311,7 @@ endif()
 # minimal dependency versions. they are defined here in a single place so
 # they can be easily upgraded, although they might not be used if the
 # dependency is included via `add_subdirectory(...)`.
-set(_acts_actsvg_version 0.4.56)
+set(_acts_actsvg_version 0.4.57)
 set(_acts_boost_version 1.78.0)
 set(_acts_dd4hep_version 1.26)
 set(_acts_geant4_version 11.1.3)

--- a/Examples/Io/Svg/include/ActsExamples/Io/Svg/SvgDefaults.hpp
+++ b/Examples/Io/Svg/include/ActsExamples/Io/Svg/SvgDefaults.hpp
@@ -88,8 +88,6 @@ backgroundGeometryOptions() {
   lOptions.name = "layer";
   lOptions.surfaceStyles = Acts::GeometryHierarchyMap<ActsPlugins::Svg::Style>(
       {{geoID, backgroundStyle()}});
-  lOptions.moduleInfo = false;
-  lOptions.gridInfo = false;
   lOptions.zRange = {-100, 100};
   lOptions.phiRange = {-0.2, 0.2};
 

--- a/Plugins/ActSVG/include/ActsPlugins/ActSVG/LayerSvgConverter.hpp
+++ b/Plugins/ActSVG/include/ActsPlugins/ActSVG/LayerSvgConverter.hpp
@@ -56,9 +56,14 @@ struct Options {
   /// The phi limit for projections
   std::array<double, 2> phiRange = noLimitPhi;
   /// Configuration of the views
-  bool gridInfo = true;
+  /// @deprecated actsvg 0.4.57 removed the grid sheet display. Kept so the
+  /// option still compiles; convert() throws if it is switched on. No
+  /// [[deprecated]] attribute: on a data member it also fires on every copy
+  /// of Options, which says nothing about whether the option is used.
+  bool gridInfo = false;
   /// Include module information
-  bool moduleInfo = true;
+  /// @deprecated actsvg 0.4.57 removed the module sheet display; see gridInfo.
+  bool moduleInfo = false;
   /// Include projection information
   bool projectionInfo = true;
   /// Label checks

--- a/Plugins/ActSVG/include/ActsPlugins/ActSVG/SurfaceSvgConverter.hpp
+++ b/Plugins/ActSVG/include/ActsPlugins/ActSVG/SurfaceSvgConverter.hpp
@@ -14,6 +14,8 @@
 #include <actsvg/core.hpp>
 #include <actsvg/meta.hpp>
 
+#include <stdexcept>
+
 namespace Acts {
 
 class Surface;
@@ -115,9 +117,17 @@ namespace Sheet {
 /// @param identification is the to be translated id_ for actsvg
 ///
 /// @return an svg object that can be written out directly to disc
-static inline actsvg::svg::object xy(const ProtoSurface& pSurface,
-                                     const std::string& identification) {
-  return actsvg::display::surface_sheet_xy(identification, pSurface);
+///
+/// @deprecated actsvg 0.4.57 removed display::surface_sheet_xy and offers no
+/// replacement, so this always throws. Use View::xy for a plain projection.
+[[deprecated(
+    "actsvg removed the surface sheet display in 0.4.57; this always throws")]]
+static inline actsvg::svg::object xy(
+    [[maybe_unused]] const ProtoSurface& pSurface,
+    [[maybe_unused]] const std::string& identification) {
+  throw std::runtime_error(
+      "ActsPlugins::Svg::Sheet::xy: actsvg removed the surface sheet display "
+      "in 0.4.57 and offers no replacement");
 }
 
 }  // namespace Sheet

--- a/Plugins/ActSVG/src/LayerSvgConverter.cpp
+++ b/Plugins/ActSVG/src/LayerSvgConverter.cpp
@@ -13,6 +13,8 @@
 #include "ActsPlugins/ActSVG/SurfaceArraySvgConverter.hpp"
 #include "ActsPlugins/ActSVG/SurfaceSvgConverter.hpp"
 
+#include <stdexcept>
+
 using namespace Acts;
 
 std::vector<actsvg::svg::object> ActsPlugins::Svg::LayerConverter::convert(
@@ -36,36 +38,19 @@ std::vector<actsvg::svg::object> ActsPlugins::Svg::LayerConverter::convert(
     volume._grid_associations = {associations};
   }
 
-  // The sheet
+  // The sheet. module_sheet and grid_sheet stay undefined: actsvg 0.4.57
+  // removed the displays that filled them, and every consumer already skips
+  // undefined sheets, which is what the moduleInfo/gridInfo options produced
+  // when switched off.
   actsvg::svg::object module_sheet;
   actsvg::svg::object grid_sheet;
   actsvg::svg::object xy_layer;
   actsvg::svg::object zr_layer;
 
-  // The module / grid information
-  const auto& layerSurface = layer.surfaceRepresentation();
-  if (layerSurface.type() == Surface::Disc) {
-    if (cOptions.moduleInfo) {
-      module_sheet = actsvg::display::endcap_sheet(
-          cOptions.name + "_modules", volume, {800, 800},
-          actsvg::display::e_module_info);
-    }
-    if (cOptions.gridInfo) {
-      grid_sheet = actsvg::display::endcap_sheet(cOptions.name + "_grid",
-                                                 volume, {800, 800},
-                                                 actsvg::display::e_grid_info);
-    }
-  } else if (layerSurface.type() == Surface::Cylinder) {
-    if (cOptions.moduleInfo) {
-      module_sheet = actsvg::display::barrel_sheet(
-          cOptions.name + "_modules", volume, {800, 800},
-          actsvg::display::e_module_info);
-    }
-    if (cOptions.gridInfo) {
-      grid_sheet = actsvg::display::barrel_sheet(cOptions.name + "_grid",
-                                                 volume, {800, 800},
-                                                 actsvg::display::e_grid_info);
-    }
+  if (cOptions.moduleInfo || cOptions.gridInfo) {
+    throw std::invalid_argument(
+        "LayerConverter: the module and grid sheets were removed in actsvg "
+        "0.4.57 and cannot be produced");
   }
 
   // The z_r view of things

--- a/Tests/UnitTests/Plugins/ActSVG/SurfaceSvgConverterTests.cpp
+++ b/Tests/UnitTests/Plugins/ActSVG/SurfaceSvgConverterTests.cpp
@@ -17,6 +17,7 @@
 #include "Acts/Surfaces/RadialBounds.hpp"
 #include "Acts/Surfaces/RectangleBounds.hpp"
 #include "Acts/Surfaces/TrapezoidBounds.hpp"
+#include "Acts/Utilities/Diagnostics.hpp"
 #include "ActsPlugins/ActSVG/SurfaceSvgConverter.hpp"
 #include "ActsPlugins/ActSVG/SvgUtils.hpp"
 
@@ -57,12 +58,18 @@ void runPlanarTests(const Surface& surface, const Svg::Style& style,
                             static_cast<double>(xyObject._y_range[1]));
 
   Svg::toFile({xyObject, xyAxes}, xyObject._id + ".svg");
-  // As sheet
-  auto svgSheet = Svg::Sheet::xy(svgTemplate, identification + "_sheet");
-  Svg::toFile({svgSheet}, svgSheet._id + ".svg");
 }
 
 BOOST_AUTO_TEST_SUITE(ActSvg)
+
+// actsvg 0.4.57 removed the sheet displays; the entry point is kept as a
+// deprecated stub so callers get a diagnostic rather than a missing symbol.
+BOOST_AUTO_TEST_CASE(SurfaceSheetThrows) {
+  Svg::ProtoSurface pSurface;
+  ACTS_PUSH_IGNORE_DEPRECATED()
+  BOOST_CHECK_THROW(Svg::Sheet::xy(pSurface, "sheet"), std::runtime_error);
+  ACTS_POP_IGNORE_DEPRECATED()
+}
 
 BOOST_AUTO_TEST_CASE(PlanarSurfaces) {
   // Planar style

--- a/cmake/ActsExternSources.cmake
+++ b/cmake/ActsExternSources.cmake
@@ -1,5 +1,5 @@
 set(ACTS_ACTSVG_SOURCE
-    "URL;https://github.com/acts-project/actsvg/archive/refs/tags/v${_acts_actsvg_version}.tar.gz;URL_HASH;SHA256=75944cbc4444d3099764f19f6fa5fbf9f2b81e3ac776b5874746add74a7cd0f8"
+    "URL;https://github.com/acts-project/actsvg/archive/refs/tags/v${_acts_actsvg_version}.tar.gz;URL_HASH;SHA256=0f428fba284abbed60614633a68ea2e7e490bedf8f7ec9b2f3cb7c14caa70107"
     CACHE STRING
     "Source to take ACTSVG from"
 )


### PR DESCRIPTION
<!-- jjp:description -->
actsvg 0.4.57 deletes meta/include/actsvg/display/sheets.hpp along with its
tests: surface_sheet_xy, endcap_sheet, barrel_sheet and the e_module_info /
e_grid_info selectors are gone, with no replacement offered upstream.

ACTS was the last thing here pinning 0.4.56. Detray already asks for 0.4.57
(Detray/CMakeLists.txt:386), and the CI dependency stack ships it from
v24.0.3, so any build combining the two -- traccc, or an ACTS build taking
actsvg from the environment -- compiles the plugin against headers that no
longer declare what it calls.

The floor therefore moves to 0.4.57, but nothing goes from the ACTS API:

- Svg::Sheet::xy keeps its signature, is marked [[deprecated]], and throws.
  There is nothing left to call, so a diagnostic at compile time and a clear
  message at run time is as close to the old behaviour as it gets.
- LayerConverter::Sheets keeps all four enumerators and convert() still
  returns four objects. The module and grid slots are simply left undefined,
  which is exactly what moduleInfo/gridInfo = false produced before, and every
  consumer already skips undefined sheets
  (TrackingGeometrySvgConverter.cpp:79). Indices into the returned vector
  therefore do not move.
- moduleInfo and gridInfo stay as options, now defaulting to false, and
  convert() throws std::invalid_argument when either is switched on: an
  explicit request for a sheet fails loudly instead of silently yielding
  nothing. They carry no [[deprecated]] attribute, because on a data member it
  also fires on every copy of Options (TrackingGeometrySvgConverter.cpp:72),
  which says nothing about whether the option is used.

The examples writer already set both options to false, so its output does not
change.
<!-- /jjp:description -->
<!-- jjp:body-fp 324dedb5c0bb31fa -->

<!-- jjp:stack-nav -->
**Stack** (bottom to top):

- ~~#5923 refactor/actsvg-0.4.57~~ (merged)  👈
- ~~#5907 ci/gpu-jobs-spack-deps~~ (merged)
- ~~#5908 ci/traccc-hip-leg~~ (merged)
- #5906 ci/traccc-gpu-alpaka
- #5905 ci/ubuntu2604-deps-v24
<!-- /jjp:stack-nav -->
