### PR TITLE
perf: Pack the sympy stepper state so a step touches one run of cache lines

### DIFF
--- a/Core/include/Acts/Propagator/SympyStepper.hpp
+++ b/Core/include/Acts/Propagator/SympyStepper.hpp
@@ -77,30 +77,38 @@ class SympyStepper final {
     State(const Options& optionsIn, MagneticFieldProvider::Cache fieldCacheIn)
         : options(optionsIn), fieldCache(std::move(fieldCacheIn)) {}
 
+    // Declaration order is deliberate: everything a single step touches comes
+    // first, in one contiguous run of cache lines, and everything only a
+    // surface crossing touches comes last.  `cov` and `jacobian` are 288 bytes
+    // each and are not read or written by `step()`, so leaving them in the
+    // middle pushed 576 bytes -- nine cache lines -- between `pars` and
+    // `jacToGlobal`.
+
     /// Configuration options for the stepper
     Options options;
 
     /// Internal free vector parameters
     FreeVector pars = FreeVector::Zero();
 
-    /// Particle hypothesis
-    ParticleHypothesis particleHypothesis = ParticleHypothesis::pion();
-
-    /// Covariance matrix (and indicator)
-    /// associated with the initial error on track parameters
-    bool covTransport = false;
-    /// Covariance matrix for error propagation
-    Covariance cov = Covariance::Zero();
-
-    /// The full jacobian of the transport entire transport
-    Jacobian jacobian = Jacobian::Identity();
+    /// The propagation derivative
+    FreeVector derivative = FreeVector::Zero();
 
     /// Bound-to-free jacobian from the last reference surface, transported
     /// along with the track.
     BoundToFreeMatrix jacToGlobal = BoundToFreeMatrix::Zero();
 
-    /// The propagation derivative
-    FreeVector derivative = FreeVector::Zero();
+    /// Covariance matrix (and indicator)
+    /// associated with the initial error on track parameters
+    bool covTransport = false;
+
+    /// Particle hypothesis
+    ParticleHypothesis particleHypothesis = ParticleHypothesis::pion();
+
+    /// Adaptive step size of the runge-kutta integration
+    ConstrainedStep stepSize;
+
+    /// Last performed step (for overstep limit calculation)
+    double previousStepSize = 0.;
 
     /// Accumulated path length state
     double pathAccumulated = 0.;
@@ -111,22 +119,24 @@ class SympyStepper final {
     /// Totoal number of attempted steps
     std::size_t nStepTrials = 0;
 
-    /// Adaptive step size of the runge-kutta integration
-    ConstrainedStep stepSize;
+    /// Statistics of the stepper
+    StepperStatistics statistics;
 
-    /// Last performed step (for overstep limit calculation)
-    double previousStepSize = 0.;
+    /// Accumulator for material effects along the trajectory
+    detail::MaterialEffectsAccumulator materialEffectsAccumulator;
 
     /// This caches the current magnetic field cell and stays
     /// (and interpolates) within it as long as this is valid.
     /// See step() code for details.
     MagneticFieldProvider::Cache fieldCache;
 
-    /// Statistics of the stepper
-    StepperStatistics statistics;
+    // --- below here: only touched when transporting to a surface ---
 
-    /// Accumulator for material effects along the trajectory
-    detail::MaterialEffectsAccumulator materialEffectsAccumulator;
+    /// Covariance matrix for error propagation
+    Covariance cov = Covariance::Zero();
+
+    /// The full jacobian of the transport entire transport
+    Jacobian jacobian = Jacobian::Identity();
   };
 
   /// Constructor requires knowledge of the detector's magnetic field

--- a/Core/include/Acts/Propagator/SympyStepper.hpp
+++ b/Core/include/Acts/Propagator/SympyStepper.hpp
@@ -77,12 +77,8 @@ class SympyStepper final {
     State(const Options& optionsIn, MagneticFieldProvider::Cache fieldCacheIn)
         : options(optionsIn), fieldCache(std::move(fieldCacheIn)) {}
 
-    // Declaration order is deliberate: everything a single step touches comes
-    // first, in one contiguous run of cache lines, and everything only a
-    // surface crossing touches comes last.  `cov` and `jacobian` are 288 bytes
-    // each and are not read or written by `step()`, so leaving them in the
-    // middle pushed 576 bytes -- nine cache lines -- between `pars` and
-    // `jacToGlobal`.
+    // Declaration order matters: members used by `step()` are kept in one
+    // contiguous run of cache lines, the rest come last.
 
     /// Configuration options for the stepper
     Options options;
@@ -130,7 +126,7 @@ class SympyStepper final {
     /// See step() code for details.
     MagneticFieldProvider::Cache fieldCache;
 
-    // --- below here: only touched when transporting to a surface ---
+    // Only used when transporting to a surface:
 
     /// Covariance matrix for error propagation
     Covariance cov = Covariance::Zero();


### PR DESCRIPTION
`cov` and `jacobian` are 288 bytes each and are neither read nor written by
`step()`, yet they sat between `pars` and `jacToGlobal`, pushing 576 bytes --
nine cache lines -- into the middle of everything a step does touch. That split
the hot members into two regions, at offsets 96..193 and 784..1976; they are now
one contiguous run from 0 to 1392 with both matrices at the end.
`sizeof(State)` drops from 1984 to 1968.

Not measurable on a single track: one state is 2 KB against a 128 KB L1, so
everything is resident and there is nothing to win. Stepping several tracks
round robin, which is what makes the working set real, it is worth about 1.8 ns
per step with covariance transport once the set outgrows L1 (-2.15, -2.41, -1.83
and -2.96 ns over four repeats at 256 tracks, against an `AtlasStepper` control
that moved -0.51, -0.32, -1.38 and +0.20). Nothing at all without covariance
transport, which is the right signature: such a step never touches the 384 byte
`jacToGlobal`.

Header only, and no longer stacked on the rest of the sympy PRs.
