### PR TITLE
refactor: Replace std::cout in GBTS with the ACTS logger

### DIFF
--- a/Core/include/Acts/Seeding/GbtsGeometry.hpp
+++ b/Core/include/Acts/Seeding/GbtsGeometry.hpp
@@ -11,6 +11,7 @@
 #include "Acts/Seeding/GbtsLayerConnection.hpp"
 #include "Acts/Seeding/GbtsLayerDescription.hpp"
 #include "Acts/Seeding/detail/GbtsLayer.hpp"
+#include "Acts/Utilities/Logger.hpp"
 
 #include <cstdint>
 #include <map>
@@ -28,8 +29,10 @@ class GbtsGeometry final {
   /// Constructor
   /// @param layerDescriptions Layer descriptions for the layers
   /// @param layerConnections Layer connections map
+  /// @param logger Logging instance, only used during construction
   GbtsGeometry(const std::vector<GbtsLayerDescription>& layerDescriptions,
-               const GbtsLayerConnectionMap& layerConnections);
+               const GbtsLayerConnectionMap& layerConnections,
+               const Logger& logger = getDummyLogger());
 
  private:
   // The layer binning is shared only with the classes that build the graph.

--- a/Core/include/Acts/Seeding/GbtsTrackingFilter.hpp
+++ b/Core/include/Acts/Seeding/GbtsTrackingFilter.hpp
@@ -11,6 +11,7 @@
 #include "Acts/Definitions/Units.hpp"
 #include "Acts/Seeding/GbtsLayerDescription.hpp"
 #include "Acts/Seeding/detail/GbtsFilterTypes.hpp"
+#include "Acts/Utilities/Logger.hpp"
 
 #include <cstdint>
 #include <memory>
@@ -57,8 +58,11 @@ class GbtsTrackingFilter final {
 
   /// @param config Configuration for seed finder
   /// @param geometry GBTS geometry for layer information
+  /// @param logger Logging instance
   GbtsTrackingFilter(const Config& config,
-                     const std::shared_ptr<const GbtsGeometry>& geometry);
+                     const std::shared_ptr<const GbtsGeometry>& geometry,
+                     std::unique_ptr<const Logger> logger = getDefaultLogger(
+                         "GbtsTrackingFilter", Logging::Level::INFO));
 
  private:
   // Only the seeder walks the edge graph.
@@ -82,6 +86,13 @@ class GbtsTrackingFilter final {
 
   /// GBTS geometry for layer information
   std::shared_ptr<const GbtsGeometry> m_geometry;
+
+  /// Logging instance
+  std::unique_ptr<const Logger> m_logger;
+
+  /// Access the logging instance
+  /// @return Logger reference
+  const Logger& logger() const { return *m_logger; }
 
   /// Propagate edge state
   /// @param state Tracking filter state

--- a/Core/src/Seeding/GbtsGeometry.cpp
+++ b/Core/src/Seeding/GbtsGeometry.cpp
@@ -13,7 +13,6 @@
 #include <algorithm>
 #include <cmath>
 #include <cstring>
-#include <iostream>
 #include <unordered_map>
 
 namespace Acts::Experimental::detail {
@@ -324,7 +323,7 @@ using BinConnections =
 
 GbtsGeometry::GbtsGeometry(
     const std::vector<GbtsLayerDescription>& layerDescriptions,
-    const GbtsLayerConnectionMap& layerConnections)
+    const GbtsLayerConnectionMap& layerConnections, const Logger& logger)
     : m_etaBinWidth(layerConnections.etaBinWidth) {
   // TODO configurable z0 range
   const float minZ0 = -168.0f;
@@ -348,11 +347,11 @@ GbtsGeometry::GbtsGeometry(
       const detail::GbtsLayer* pL1 = layerById(dst);
       const detail::GbtsLayer* pL2 = layerById(src);
       if (pL1 == nullptr) {
-        std::cout << " skipping invalid dst layer " << dst << std::endl;
+        ACTS_WARNING("Skipping invalid dst layer " << dst);
         continue;
       }
       if (pL2 == nullptr) {
-        std::cout << " skipping invalid src layer " << src << std::endl;
+        ACTS_WARNING("Skipping invalid src layer " << src);
         continue;
       }
 

--- a/Core/src/Seeding/GbtsTrackingFilter.cpp
+++ b/Core/src/Seeding/GbtsTrackingFilter.cpp
@@ -12,7 +12,8 @@
 
 #include <algorithm>
 #include <cmath>
-#include <iostream>
+#include <memory>
+#include <utility>
 
 namespace Acts::Experimental::detail {
 
@@ -68,8 +69,9 @@ void detail::GbtsEdgeState::initialize(const detail::GbtsEdge& pS,
 namespace Acts::Experimental {
 
 GbtsTrackingFilter::GbtsTrackingFilter(
-    const Config& config, const std::shared_ptr<const GbtsGeometry>& geometry)
-    : m_cfg(config), m_geometry(geometry) {}
+    const Config& config, const std::shared_ptr<const GbtsGeometry>& geometry,
+    std::unique_ptr<const Logger> logger)
+    : m_cfg(config), m_geometry(geometry), m_logger(std::move(logger)) {}
 
 detail::GbtsEdgeState GbtsTrackingFilter::followTrack(
     State& state, const detail::GbtsNodeView& nodeView,
@@ -185,11 +187,11 @@ bool GbtsTrackingFilter::update(const detail::GbtsNodeView& nodeView,
                                 const detail::GbtsEdge& pS,
                                 detail::GbtsEdgeState& ts) const {
   if (ts.cx[2][2] < 0 || ts.cx[1][1] < 0 || ts.cx[0][0] < 0) {
-    std::cout << "Negative cov_x" << std::endl;
+    ACTS_WARNING("Negative cov_x");
   }
 
   if (ts.cy[1][1] < 0 || ts.cy[0][0] < 0) {
-    std::cout << "Negative cov_y" << std::endl;
+    ACTS_WARNING("Negative cov_y");
   }
 
   // add ms.

--- a/Core/src/Seeding/GbtsTrackingFilter.cpp
+++ b/Core/src/Seeding/GbtsTrackingFilter.cpp
@@ -187,11 +187,11 @@ bool GbtsTrackingFilter::update(const detail::GbtsNodeView& nodeView,
                                 const detail::GbtsEdge& pS,
                                 detail::GbtsEdgeState& ts) const {
   if (ts.cx[2][2] < 0 || ts.cx[1][1] < 0 || ts.cx[0][0] < 0) {
-    ACTS_WARNING("Negative cov_x");
+    ACTS_DEBUG("Negative cov_x");
   }
 
   if (ts.cy[1][1] < 0 || ts.cy[0][0] < 0) {
-    ACTS_WARNING("Negative cov_y");
+    ACTS_DEBUG("Negative cov_y");
   }
 
   // add ms.

--- a/Examples/Algorithms/TrackFinding/src/GraphBasedSeedingAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFinding/src/GraphBasedSeedingAlgorithm.cpp
@@ -60,7 +60,7 @@ GraphBasedSeedingAlgorithm::GraphBasedSeedingAlgorithm(
   // initialise the object that holds all the geometry information needed for
   // the algorithm
   auto geometry = std::make_shared<Acts::Experimental::GbtsGeometry>(
-      layerGeometry, layerConnectionMap);
+      layerGeometry, layerConnectionMap, this->logger());
 
   // ROI file:Defines what region in detector we are interested in, currently
   // set to entire detector
@@ -75,8 +75,9 @@ GraphBasedSeedingAlgorithm::GraphBasedSeedingAlgorithm(
           m_cfg.seedFinderConfig),
       geometry, this->logger().cloneWithSuffix("GbtsFinder"));
 
-  m_filter = Acts::Experimental::GbtsTrackingFilter(m_cfg.trackingFilterConfig,
-                                                    geometry);
+  m_filter = Acts::Experimental::GbtsTrackingFilter(
+      m_cfg.trackingFilterConfig, geometry,
+      this->logger().cloneWithSuffix("GbtsFilter"));
 
   printConfig();
 }

--- a/Tests/UnitTests/Core/Seeding/GbtsSeedingTests.cpp
+++ b/Tests/UnitTests/Core/Seeding/GbtsSeedingTests.cpp
@@ -299,7 +299,8 @@ SeederSetup makeSeeder(const ToyDetector& detector) {
           Experimental::GraphBasedTrackSeeder::DerivedConfig(config), geometry,
           getDefaultLogger("GbtsTest", Logging::Level::WARNING)),
       .filter = Experimental::GbtsTrackingFilter(
-          Experimental::GbtsTrackingFilter::Config{}, geometry),
+          Experimental::GbtsTrackingFilter::Config{}, geometry,
+          getDefaultLogger("GbtsTest", Logging::Level::WARNING)),
       .roi = Experimental::GbtsRoiDescriptor(-4.5, 4.5, -kBarrelHalfZ,
                                              kBarrelHalfZ),
       .options = Experimental::GraphBasedTrackSeeder::Options(2_T),


### PR DESCRIPTION
Replaces the four unconditional `std::cout` prints in the GBTS seeding code with logger calls.

`GbtsTrackingFilter` gains an owning logger, since it logs from `update()` during seeding. `GbtsGeometry` only logs while building the bin tables, so it takes the logger by reference and keeps no state. Both default to a dummy / default logger, and the examples algorithm passes its own logger down.