### PR TITLE
fix: non-critical sonar could fixes in EventData

### DIFF
--- a/Core/include/Acts/EventData/BoundTrackParameters.hpp
+++ b/Core/include/Acts/EventData/BoundTrackParameters.hpp
@@ -58,7 +58,8 @@ class BoundTrackParameters {
   static Result<BoundTrackParameters> create(
       const GeometryContext& geoCtx, std::shared_ptr<const Surface> surface,
       const Vector4& pos4, const Vector3& dir, double qOverP,
-      std::optional<BoundMatrix> cov, ParticleHypothesis particleHypothesis,
+      std::optional<BoundMatrix> cov,
+      const ParticleHypothesis& particleHypothesis,
       double tolerance = s_onSurfaceTolerance) {
     Result<BoundVector> bound =
         transformFreeToBoundParameters(pos4.segment<3>(ePos0), pos4[eTime], dir,
@@ -82,7 +83,8 @@ class BoundTrackParameters {
   /// @return Curvilinear bound track parameters
   static BoundTrackParameters createCurvilinear(
       const Vector4& pos4, const Vector3& dir, double qOverP,
-      std::optional<BoundMatrix> cov, ParticleHypothesis particleHypothesis) {
+      std::optional<BoundMatrix> cov,
+      const ParticleHypothesis& particleHypothesis) {
     return BoundTrackParameters(
         CurvilinearSurface(pos4.segment<3>(ePos0), dir).surface(),
         transformFreeToCurvilinearParameters(pos4[eTime], dir, qOverP),
@@ -100,7 +102,8 @@ class BoundTrackParameters {
   /// @return Curvilinear bound track parameters
   static BoundTrackParameters createCurvilinear(
       const Vector4& pos4, double phi, double theta, double qOverP,
-      std::optional<BoundMatrix> cov, ParticleHypothesis particleHypothesis) {
+      std::optional<BoundMatrix> cov,
+      const ParticleHypothesis& particleHypothesis) {
     return BoundTrackParameters(
         CurvilinearSurface(pos4.segment<3>(ePos0),
                            makeDirectionFromPhiTheta(phi, theta))
@@ -124,7 +127,7 @@ class BoundTrackParameters {
   BoundTrackParameters(std::shared_ptr<const Surface> surface,
                        const BoundVector& params,
                        std::optional<BoundMatrix> cov,
-                       ParticleHypothesis particleHypothesis)
+                       const ParticleHypothesis& particleHypothesis)
       : m_params(params),
         m_cov(std::move(cov)),
         m_surface(std::move(surface)),

--- a/Core/include/Acts/EventData/MultiComponentTrackParameters.hpp
+++ b/Core/include/Acts/EventData/MultiComponentTrackParameters.hpp
@@ -66,7 +66,7 @@ class MultiComponentBoundTrackParameters {
   static MultiComponentBoundTrackParameters createCurvilinear(
       const GeometryContext& geoCtx,
       const std::vector<ConstructionTuple>& curvi,
-      ParticleHypothesis particleHypothesis) {
+      const ParticleHypothesis& particleHypothesis) {
     // Construct and average surface
     Vector3 avgPos = Vector3::Zero();
     Vector3 avgDir = Vector3::Zero();
@@ -112,9 +112,9 @@ class MultiComponentBoundTrackParameters {
   /// @param surface Reference surface the parameters are defined on
   /// @param hasCovariance Flag indicating if covariance matrices will be provided for the
   /// @param particleHypothesis Particle hypothesis for the parameters
-  MultiComponentBoundTrackParameters(std::shared_ptr<const Surface> surface,
-                                     bool hasCovariance,
-                                     ParticleHypothesis particleHypothesis)
+  MultiComponentBoundTrackParameters(
+      std::shared_ptr<const Surface> surface, bool hasCovariance,
+      const ParticleHypothesis& particleHypothesis)
       : m_surface(std::move(surface)),
         m_particleHypothesis(particleHypothesis),
         m_hasCovariance(hasCovariance) {}
@@ -124,10 +124,10 @@ class MultiComponentBoundTrackParameters {
   /// @param params Bound parameters vector
   /// @param cov Bound parameters covariance matrix
   /// @param particleHypothesis Particle hypothesis for these parameters
-  MultiComponentBoundTrackParameters(std::shared_ptr<const Surface> surface,
-                                     const BoundVector& params,
-                                     std::optional<BoundMatrix> cov,
-                                     ParticleHypothesis particleHypothesis)
+  MultiComponentBoundTrackParameters(
+      std::shared_ptr<const Surface> surface, const BoundVector& params,
+      std::optional<BoundMatrix> cov,
+      const ParticleHypothesis& particleHypothesis)
       : m_surface(std::move(surface)),
         m_particleHypothesis(particleHypothesis) {
     m_weights.push_back(1.);
@@ -144,10 +144,9 @@ class MultiComponentBoundTrackParameters {
   /// @param proj Projector to use for the parameters
   /// @param particleHypothesis Particle hypothesis for the parameters
   template <std::ranges::range component_range_t, typename projector_t>
-  MultiComponentBoundTrackParameters(std::shared_ptr<const Surface> surface,
-                                     const component_range_t& cmps,
-                                     const projector_t& proj,
-                                     ParticleHypothesis particleHypothesis)
+  MultiComponentBoundTrackParameters(
+      std::shared_ptr<const Surface> surface, const component_range_t& cmps,
+      const projector_t& proj, const ParticleHypothesis& particleHypothesis)
     requires detail::ComponentRangeAndProjectorWithoutCovarianceConcept<
                  component_range_t, projector_t>
       : m_surface(std::move(surface)),
@@ -171,10 +170,9 @@ class MultiComponentBoundTrackParameters {
   /// @param proj Projector to use for the parameters
   /// @param particleHypothesis Particle hypothesis for the parameters
   template <std::ranges::range component_range_t, typename projector_t>
-  MultiComponentBoundTrackParameters(std::shared_ptr<const Surface> surface,
-                                     const component_range_t& cmps,
-                                     const projector_t& proj,
-                                     ParticleHypothesis particleHypothesis)
+  MultiComponentBoundTrackParameters(
+      std::shared_ptr<const Surface> surface, const component_range_t& cmps,
+      const projector_t& proj, const ParticleHypothesis& particleHypothesis)
     requires detail::ComponentRangeAndProjectorWithCovarianceConcept<
                  component_range_t, projector_t>
       : m_surface(std::move(surface)),

--- a/Core/include/Acts/EventData/MultiTrajectory.hpp
+++ b/Core/include/Acts/EventData/MultiTrajectory.hpp
@@ -291,20 +291,17 @@ class MultiTrajectory {
 
     while (true) {
       auto ts = getTrackState(iendpoint);
+      bool proceed = true;
       if constexpr (std::is_same_v<std::invoke_result_t<F, TrackStateProxy>,
                                    bool>) {
-        bool proceed = callable(ts);
-        // this point has no parent and ends the trajectory, or a break was
-        // requested
-        if (!proceed || !ts.hasPrevious()) {
-          break;
-        }
+        proceed = callable(ts);
       } else {
         callable(ts);
-        // this point has no parent and ends the trajectory
-        if (!ts.hasPrevious()) {
-          break;
-        }
+      }
+      // this point has no parent and ends the trajectory, or a break was
+      // requested
+      if (!proceed || !ts.hasPrevious()) {
+        break;
       }
       iendpoint = ts.previous();
     }

--- a/Core/include/Acts/EventData/MultiTrajectory.ipp
+++ b/Core/include/Acts/EventData/MultiTrajectory.ipp
@@ -30,20 +30,17 @@ void MultiTrajectory<D>::visitBackwards(IndexType iendpoint, F&& callable) const
 
   while (true) {
     auto ts = getTrackState(iendpoint);
+    bool proceed = true;
     if constexpr (std::is_same_v<std::invoke_result_t<F, ConstTrackStateProxy>,
                                  bool>) {
-      bool proceed = callable(ts);
-      // this point has no parent and ends the trajectory, or a break was
-      // requested
-      if (!proceed || !ts.hasPrevious()) {
-        break;
-      }
+      proceed = callable(ts);
     } else {
       callable(ts);
-      // this point has no parent and ends the trajectory
-      if (!ts.hasPrevious()) {
-        break;
-      }
+    }
+    // this point has no parent and ends the trajectory, or a break was
+    // requested
+    if (!proceed || !ts.hasPrevious()) {
+      break;
     }
     iendpoint = ts.previous();
   }

--- a/Core/include/Acts/EventData/MultiTrajectoryHelpers.hpp
+++ b/Core/include/Acts/EventData/MultiTrajectoryHelpers.hpp
@@ -118,8 +118,7 @@ VolumeTrajectoryStateContainer trajectoryState(
     auto& trajState = trajStateContainer[volume];
     trajState.nStates++;
     trajState.NDF += state.calibratedSize();
-    auto typeFlags = state.typeFlags();
-    if (typeFlags.isHole()) {
+    if (auto typeFlags = state.typeFlags(); typeFlags.isHole()) {
       trajState.nHoles++;
     } else if (typeFlags.isOutlier()) {
       trajState.nOutliers++;

--- a/Core/include/Acts/EventData/SeedProxy.hpp
+++ b/Core/include/Acts/EventData/SeedProxy.hpp
@@ -76,9 +76,7 @@ class SeedProxy {
   SeedProxy &operator=(SeedProxy<false> &&other) noexcept
     requires ReadOnly
   {
-    m_container = &other.container();
-    m_index = other.index();
-    return *this;
+    return *this = other;
   }
 
   /// Returns a const proxy of the seed.
@@ -276,17 +274,20 @@ class SeedProxy {
 
     friend constexpr SpacePointIterator operator+(SpacePointIterator it,
                                                   difference_type n) noexcept {
-      return it += n;
+      it += n;
+      return it;
     }
 
     friend constexpr SpacePointIterator operator+(
         difference_type n, SpacePointIterator it) noexcept {
-      return it += n;
+      it += n;
+      return it;
     }
 
     friend constexpr SpacePointIterator operator-(SpacePointIterator it,
                                                   difference_type n) noexcept {
-      return it -= n;
+      it -= n;
+      return it;
     }
 
     friend constexpr difference_type operator-(

--- a/Core/include/Acts/EventData/SourceLink.hpp
+++ b/Core/include/Acts/EventData/SourceLink.hpp
@@ -126,19 +126,19 @@ struct SourceLinkAdapterIterator {
   /// Equality comparison operator
   /// @param other Iterator to compare with
   /// @return True if iterators are equal
-  bool operator==(const SourceLinkAdapterIterator& other) const {
-    return m_iterator == other.m_iterator;
-  }
+  bool operator==(const SourceLinkAdapterIterator& other) const = default;
 
   /// Dereference operator
   /// @return Wrapped source link
   Acts::SourceLink operator*() const { return Acts::SourceLink{*m_iterator}; }
 
   /// Difference operator
+  /// @param lhs Iterator to compute difference from
   /// @param other Iterator to compute difference with
   /// @return Distance between iterators
-  auto operator-(const SourceLinkAdapterIterator& other) const {
-    return m_iterator - other.m_iterator;
+  friend auto operator-(const SourceLinkAdapterIterator& lhs,
+                        const SourceLinkAdapterIterator& other) {
+    return lhs.m_iterator - other.m_iterator;
   }
 
   /// Underlying iterator

--- a/Core/include/Acts/EventData/SpacePointColumnProxy.hpp
+++ b/Core/include/Acts/EventData/SpacePointColumnProxy.hpp
@@ -59,7 +59,9 @@ class SpacePointColumnProxy {
 
   /// Returns the number of entries in the space point column.
   /// @return The size of the space point column.
-  std::uint32_t size() const noexcept { return column().size(); }
+  std::uint32_t size() const noexcept {
+    return static_cast<std::uint32_t>(column().size());
+  }
 
   /// Returns a const proxy of the space point column.
   /// @return A const proxy of the space point column.

--- a/Core/include/Acts/EventData/SpacePointContainer.hpp
+++ b/Core/include/Acts/EventData/SpacePointContainer.hpp
@@ -20,12 +20,14 @@
 #include "Acts/Utilities/detail/ContainerSubset.hpp"
 
 #include <cassert>
+#include <functional>
 #include <limits>
 #include <memory>
 #include <optional>
 #include <ranges>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <type_traits>
 #include <unordered_map>
 #include <vector>
@@ -589,11 +591,24 @@ class SpacePointContainer {
   template <typename T>
   using ColumnHolder = detail::sp::ColumnHolder<T>;
 
+  /// Transparent hasher allowing heterogeneous lookup (e.g. by
+  /// std::string_view) in the string-keyed column maps below without
+  /// constructing a temporary std::string.
+  struct TransparentStringHash {
+    using is_transparent = void;
+    std::size_t operator()(std::string_view sv) const noexcept {
+      return std::hash<std::string_view>{}(sv);
+    }
+  };
+
   std::uint32_t m_size{0};
 
-  std::unordered_map<std::string, ColumnHolderBase *> m_allColumns;
+  std::unordered_map<std::string, ColumnHolderBase *, TransparentStringHash,
+                     std::equal_to<>>
+      m_allColumns;
   SpacePointColumns m_knownColumns{SpacePointColumns::None};
-  std::unordered_map<std::string, std::unique_ptr<ColumnHolderBase>>
+  std::unordered_map<std::string, std::unique_ptr<ColumnHolderBase>,
+                     TransparentStringHash, std::equal_to<>>
       m_dynamicColumns;
 
   std::vector<SourceLink> m_sourceLinks;

--- a/Core/include/Acts/EventData/SpacePointProxy.hpp
+++ b/Core/include/Acts/EventData/SpacePointProxy.hpp
@@ -84,9 +84,7 @@ class SpacePointProxy {
   SpacePointProxy &operator=(SpacePointProxy<false> &&other) noexcept
     requires ReadOnly
   {
-    m_container = &other.container();
-    m_index = other.index();
-    return *this;
+    return *this = other;
   }
 
   /// Returns a const proxy of the space point.

--- a/Core/include/Acts/EventData/SubspaceHelpers.hpp
+++ b/Core/include/Acts/EventData/SubspaceHelpers.hpp
@@ -40,16 +40,18 @@ inline static bool checkSubspaceIndices(const index_range_t& indexRange,
   if (subspaceSize > fullSize) {
     return false;
   }
-  if (static_cast<std::size_t>(indexRange.size()) != subspaceSize) {
+  if (static_cast<std::size_t>(std::ranges::size(indexRange)) != subspaceSize) {
     return false;
   }
-  for (auto it = indexRange.begin(); it != indexRange.end();) {
+  for (auto it = std::ranges::begin(indexRange);
+       it != std::ranges::end(indexRange);) {
     auto index = *it;
     if (index >= fullSize) {
       return false;
     }
     ++it;
-    if (const auto tail = std::ranges::subrange(it, indexRange.end());
+    if (const auto tail =
+            std::ranges::subrange(it, std::ranges::end(indexRange));
         std::ranges::find(tail, index) != tail.end()) {
       return false;
     }

--- a/Core/include/Acts/EventData/TrackStateProxy.hpp
+++ b/Core/include/Acts/EventData/TrackStateProxy.hpp
@@ -535,12 +535,14 @@ class TrackStateProxy
       }
 
       if (ACTS_CHECK_BIT(src, PM::Calibrated)) {
-        visit_measurement(other.calibratedSize(), [&](auto N) {
-          constexpr int measdim = decltype(N)::value;
-          allocateCalibrated(
-              other.template calibrated<measdim>().eval(),
-              other.template calibratedCovariance<measdim>().eval());
-        });
+        visit_measurement(
+            other.calibratedSize(),
+            [&]<std::size_t measdim>(
+                std::integral_constant<std::size_t, measdim>) {
+              allocateCalibrated(
+                  other.template calibrated<measdim>().eval(),
+                  other.template calibratedCovariance<measdim>().eval());
+            });
 
         setProjectorSubspaceIndices(other.projectorSubspaceIndices());
       }
@@ -580,12 +582,14 @@ class TrackStateProxy
       // may be not yet allocated
       if (ACTS_CHECK_BIT(mask, PM::Calibrated) &&
           other.template has<detail_tsp::kCalibratedKey>()) {
-        visit_measurement(other.calibratedSize(), [&](auto N) {
-          constexpr int measdim = decltype(N)::value;
-          allocateCalibrated(
-              other.template calibrated<measdim>().eval(),
-              other.template calibratedCovariance<measdim>().eval());
-        });
+        visit_measurement(
+            other.calibratedSize(),
+            [&]<std::size_t measdim>(
+                std::integral_constant<std::size_t, measdim>) {
+              allocateCalibrated(
+                  other.template calibrated<measdim>().eval(),
+                  other.template calibratedCovariance<measdim>().eval());
+            });
 
         setProjectorSubspaceIndices(other.projectorSubspaceIndices());
       }

--- a/Core/include/Acts/EventData/TrackStateProxyCommon.hpp
+++ b/Core/include/Acts/EventData/TrackStateProxyCommon.hpp
@@ -381,22 +381,22 @@ class TrackStateProxyCommon {
   ///       during fitting the mask grows as the track state is filled.
   /// @return Bit mask of available properties.
   TrackStatePropMask getMask() const {
-    using PM = TrackStatePropMask;
-    PM mask = PM::None;
+    using enum TrackStatePropMask;
+    TrackStatePropMask mask = None;
     if (hasPredicted()) {
-      mask |= PM::Predicted;
+      mask |= Predicted;
     }
     if (hasFiltered()) {
-      mask |= PM::Filtered;
+      mask |= Filtered;
     }
     if (hasSmoothed()) {
-      mask |= PM::Smoothed;
+      mask |= Smoothed;
     }
     if (hasJacobian()) {
-      mask |= PM::Jacobian;
+      mask |= Jacobian;
     }
     if (hasCalibrated()) {
-      mask |= PM::Calibrated;
+      mask |= Calibrated;
     }
     return mask;
   }
@@ -526,8 +526,7 @@ class TrackStateProxyCommon {
              Eigen::PlainObjectBase<val_t>::RowsAtCompileTime <=
                  static_cast<std::underlying_type_t<BoundIndices>>(eBoundSize))
   {
-    constexpr std::size_t measdim =
-        static_cast<std::size_t>(val_t::RowsAtCompileTime);
+    constexpr auto measdim = static_cast<std::size_t>(val_t::RowsAtCompileTime);
     derived().allocateCalibrated(measdim);
     calibrated<measdim>() = val;
     calibratedCovariance<measdim>() = cov;

--- a/Core/include/Acts/EventData/Types.hpp
+++ b/Core/include/Acts/EventData/Types.hpp
@@ -39,10 +39,6 @@ using SubspaceIndices = std::array<SubspaceIndex, measdim>;
 /// Type alias for bound parameter subspace indices
 using BoundSubspaceIndices = SubspaceIndices<eBoundSize>;
 
-// template <std::size_t measdim>
-/// @brief type alias for indices of bound track parameters subspace
-/// @details used to specify which components of the bound track parameters are being referenced
-// using BoundSubspaceIndices = std::array<std::size_t, eBoundSize>;
 static constexpr BoundSubspaceIndices kBoundSubspaceIndicesInvalid = {
     eBoundSize, eBoundSize, eBoundSize, eBoundSize, eBoundSize, eBoundSize};
 

--- a/Core/include/Acts/EventData/VectorTrackContainer.hpp
+++ b/Core/include/Acts/EventData/VectorTrackContainer.hpp
@@ -224,7 +224,6 @@ class VectorTrackContainer final : public detail_vtc::VectorTrackContainerBase {
   /// @param other Const container to copy from
   explicit VectorTrackContainer(const ConstVectorTrackContainer& other);
 
- public:
   // BEGIN INTERFACE
   /// @cond
 
@@ -308,8 +307,6 @@ class VectorTrackContainer final : public detail_vtc::VectorTrackContainerBase {
 static_assert(TrackContainerBackend<VectorTrackContainer>,
               "VectorTrackContainer does not fulfill TrackContainerBackend");
 
-class ConstVectorTrackContainer;
-
 template <>
 struct IsReadOnlyTrackContainer<ConstVectorTrackContainer> : std::true_type {};
 
@@ -338,7 +335,6 @@ class ConstVectorTrackContainer final
     assert(checkConsistency());
   }
 
- public:
   // BEGIN INTERFACE
 
   /// Get a component from a track

--- a/Core/include/Acts/EventData/detail/DynamicKeyIterator.hpp
+++ b/Core/include/Acts/EventData/detail/DynamicKeyIterator.hpp
@@ -40,9 +40,7 @@ class DynamicKeyIterator {
     return copy;
   }
 
-  bool operator==(const DynamicKeyIterator& other) const {
-    return m_it == other.m_it;
-  }
+  bool operator==(const DynamicKeyIterator& other) const = default;
 
   value_type operator*() const { return m_it->first; }
 

--- a/Core/src/EventData/CorrectedTransformationFreeToBound.cpp
+++ b/Core/src/EventData/CorrectedTransformationFreeToBound.cpp
@@ -41,12 +41,13 @@ detail::CorrectedFreeToBoundTransformer::CorrectedFreeToBoundTransformer(
       m_cosIncidentAngleMaxCutoff(cosIncidentAngleMaxCutoff) {}
 
 detail::CorrectedFreeToBoundTransformer::CorrectedFreeToBoundTransformer(
-    const FreeToBoundCorrection& freeToBoundCorrection) {
-  m_alpha = freeToBoundCorrection.alpha;
-  m_beta = freeToBoundCorrection.beta;
-  m_cosIncidentAngleMinCutoff = freeToBoundCorrection.cosIncidentAngleMinCutoff;
-  m_cosIncidentAngleMaxCutoff = freeToBoundCorrection.cosIncidentAngleMaxCutoff;
-}
+    const FreeToBoundCorrection& freeToBoundCorrection)
+    : m_alpha(freeToBoundCorrection.alpha),
+      m_beta(freeToBoundCorrection.beta),
+      m_cosIncidentAngleMinCutoff(
+          freeToBoundCorrection.cosIncidentAngleMinCutoff),
+      m_cosIncidentAngleMaxCutoff(
+          freeToBoundCorrection.cosIncidentAngleMaxCutoff) {}
 
 std::optional<std::tuple<BoundVector, BoundMatrix>>
 detail::CorrectedFreeToBoundTransformer::operator()(
@@ -57,11 +58,11 @@ detail::CorrectedFreeToBoundTransformer::operator()(
   Vector3 dir = freeParams.segment<3>(eFreeDir0);
   Vector3 normal =
       surface.normal(geoContext, freeParams.segment<3>(eFreePos0), dir);
-  double absCosIncidenceAng = std::abs(dir.dot(normal));
   // No correction if the incidentAngle is small enough (not necessary ) or too
   // large (correction could be invalid). Fall back to nominal free to bound
   // transformation
-  if (absCosIncidenceAng < m_cosIncidentAngleMinCutoff ||
+  if (double absCosIncidenceAng = std::abs(dir.dot(normal));
+      absCosIncidenceAng < m_cosIncidentAngleMinCutoff ||
       absCosIncidenceAng > m_cosIncidentAngleMaxCutoff) {
     ACTS_VERBOSE("Incident angle: " << std::acos(absCosIncidenceAng)
                                     << " is out of range for correction");

--- a/Core/src/EventData/MultiComponentTrackParameters.cpp
+++ b/Core/src/EventData/MultiComponentTrackParameters.cpp
@@ -96,6 +96,9 @@ void MultiComponentBoundTrackParameters::pushComponent(
     const double weight, const ParametersVector& params,
     const std::optional<CovarianceMatrix>& cov) {
   if (hasCovariance() != cov.has_value()) {
+    throw std::logic_error(
+        "Mismatch between MultiComponentBoundTrackParameters covariance "
+        "state and the provided covariance");
   }
 
   m_weights.push_back(weight);

--- a/Core/src/EventData/PrintParameters.cpp
+++ b/Core/src/EventData/PrintParameters.cpp
@@ -13,7 +13,7 @@
 
 #include <array>
 #include <cstddef>
-#include <iomanip>
+#include <format>
 #include <ostream>
 
 namespace Acts {
@@ -77,10 +77,6 @@ void printParametersCovariance(std::ostream& os, const names_container_t& names,
                                const Eigen::MatrixBase<covariance_t>& cov) {
   EIGEN_STATIC_ASSERT_VECTOR_ONLY(parameters_t);
 
-  // save stream formatting state
-  auto flags = os.flags();
-  auto precision = os.precision();
-
   // compute the standard deviations
   auto stddev = cov.diagonal().cwiseSqrt().eval();
 
@@ -90,27 +86,15 @@ void printParametersCovariance(std::ostream& os, const names_container_t& names,
     if (0 < i) {
       os << '\n';
     }
-    // show name
-    os << std::setw(kNamesMaxSize) << std::left << names[nameIndices[i]];
-    // show value
-    os << " ";
-    os << std::defaultfloat << std::setprecision(4);
-    os << std::setw(10) << std::right << params[i];
-    // show standard deviation
-    os << " +- ";
-    os << std::setw(10) << std::left << stddev[i];
+    // show name, value, and standard deviation
+    os << std::format("{:<{}} {:>10.4} +- {:<10.4} ", names[nameIndices[i]],
+                      kNamesMaxSize, params[i], stddev[i]);
     // show lower-triangular part of the correlation matrix
-    os << " ";
-    os << std::fixed << std::setprecision(3);
     for (Eigen::Index j = 0; j <= i; ++j) {
       auto corr = cov(i, j) / (stddev[i] * stddev[j]);
-      os << " " << std::setw(6) << std::right << corr;
+      os << std::format(" {:>6.3f}", corr);
     }
   }
-
-  // restore previous stream formatting state
-  os.flags(flags);
-  os.precision(precision);
 }
 
 /// Print parameters only.
@@ -136,27 +120,16 @@ void printParameters(std::ostream& os, const names_container_t& names,
                      const Eigen::MatrixBase<parameters_t>& params) {
   EIGEN_STATIC_ASSERT_VECTOR_ONLY(parameters_t);
 
-  // save stream formatting state
-  auto flags = os.flags();
-  auto precision = os.precision();
-
   for (Eigen::Index i = 0; i < params.size(); ++i) {
     // no newline after the last line. e.g. the log macros automatically add a
     // newline and having a finishing newline would lead to empty lines.
     if (0 < i) {
       os << '\n';
     }
-    // show name
-    os << std::setw(kNamesMaxSize) << std::left << names[nameIndices[i]];
-    // show value
-    os << " ";
-    os << std::defaultfloat << std::setprecision(4);
-    os << std::setw(10) << std::right << params[i];
+    // show name and value
+    os << std::format("{:<{}} {:>10.4}", names[nameIndices[i]], kNamesMaxSize,
+                      params[i]);
   }
-
-  // restore previous stream formatting state
-  os.flags(flags);
-  os.precision(precision);
 }
 
 using ParametersMap = Eigen::Map<const DynamicVector>;

--- a/Core/src/EventData/SeedContainer.cpp
+++ b/Core/src/EventData/SeedContainer.cpp
@@ -34,7 +34,8 @@ void SeedContainer::reserve(Index size, float averageSpacePoints) noexcept {
   m_spacePointCounts.reserve(size);
   m_qualities.reserve(size);
   m_vertexZs.reserve(size);
-  m_spacePoints.reserve(static_cast<std::size_t>(size * averageSpacePoints));
+  m_spacePoints.reserve(
+      static_cast<std::size_t>(static_cast<float>(size) * averageSpacePoints));
 }
 
 void SeedContainer::clear() noexcept {

--- a/Core/src/EventData/SpacePointContainer.cpp
+++ b/Core/src/EventData/SpacePointContainer.cpp
@@ -142,8 +142,8 @@ void SpacePointContainer::moveColumns(SpacePointContainer &other) noexcept {
 void SpacePointContainer::reserve(std::uint32_t size,
                                   float averageSourceLinks) noexcept {
   if (hasColumns(SpacePointColumns::SourceLinks)) {
-    m_sourceLinks.reserve(
-        static_cast<std::uint32_t>(size * averageSourceLinks));
+    m_sourceLinks.reserve(static_cast<std::uint32_t>(static_cast<float>(size) *
+                                                     averageSourceLinks));
   }
 
   for (const auto &[name, column] : m_allColumns) {

--- a/Core/src/EventData/VectorMultiTrajectory.cpp
+++ b/Core/src/EventData/VectorMultiTrajectory.cpp
@@ -25,11 +25,11 @@ namespace Acts {
 auto VectorMultiTrajectory::addTrackState_impl(TrackStatePropMask mask,
                                                IndexType iprevious)
     -> IndexType {
-  using PropMask = TrackStatePropMask;
+  using enum TrackStatePropMask;
 
   m_index.emplace_back();
   IndexData& p = m_index.back();
-  IndexType index = static_cast<IndexType>(m_index.size() - 1);
+  auto index = static_cast<IndexType>(m_index.size() - 1);
   m_previous.emplace_back(iprevious);
   m_next.emplace_back(kInvalid);
 
@@ -40,19 +40,19 @@ auto VectorMultiTrajectory::addTrackState_impl(TrackStatePropMask mask,
 
   assert(m_params.size() == m_cov.size());
 
-  if (ACTS_CHECK_BIT(mask, PropMask::Predicted)) {
+  if (ACTS_CHECK_BIT(mask, Predicted)) {
     m_params.emplace_back();
     m_cov.emplace_back();
     p.ipredicted = static_cast<IndexType>(m_params.size() - 1);
   }
 
-  if (ACTS_CHECK_BIT(mask, PropMask::Filtered)) {
+  if (ACTS_CHECK_BIT(mask, Filtered)) {
     m_params.emplace_back();
     m_cov.emplace_back();
     p.ifiltered = static_cast<IndexType>(m_params.size() - 1);
   }
 
-  if (ACTS_CHECK_BIT(mask, PropMask::Smoothed)) {
+  if (ACTS_CHECK_BIT(mask, Smoothed)) {
     m_params.emplace_back();
     m_cov.emplace_back();
     p.ismoothed = static_cast<IndexType>(m_params.size() - 1);
@@ -60,7 +60,7 @@ auto VectorMultiTrajectory::addTrackState_impl(TrackStatePropMask mask,
 
   assert(m_params.size() == m_cov.size());
 
-  if (ACTS_CHECK_BIT(mask, PropMask::Jacobian)) {
+  if (ACTS_CHECK_BIT(mask, Jacobian)) {
     m_jac.emplace_back();
     p.ijacobian = static_cast<IndexType>(m_jac.size() - 1);
   }
@@ -71,7 +71,7 @@ auto VectorMultiTrajectory::addTrackState_impl(TrackStatePropMask mask,
   m_measOffset.push_back(kInvalid);
   m_measCovOffset.push_back(kInvalid);
 
-  if (ACTS_CHECK_BIT(mask, PropMask::Calibrated)) {
+  if (ACTS_CHECK_BIT(mask, Calibrated)) {
     m_sourceLinks.emplace_back(std::nullopt);
     p.iCalibratedSourceLink = static_cast<IndexType>(m_sourceLinks.size() - 1);
 
@@ -141,27 +141,26 @@ void VectorMultiTrajectory::addTrackStateComponents_impl(
 void VectorMultiTrajectory::shareFrom_impl(IndexType iself, IndexType iother,
                                            TrackStatePropMask shareSource,
                                            TrackStatePropMask shareTarget) {
-  // auto other = getTrackState(iother);
   IndexData& self = m_index[iself];
   const IndexData& other = m_index[iother];
 
   assert(ACTS_CHECK_BIT(getTrackState(iother).getMask(), shareSource) &&
          "Source has incompatible allocation");
 
-  using PM = TrackStatePropMask;
+  using enum TrackStatePropMask;
 
   IndexType sourceIndex{kInvalid};
   switch (shareSource) {
-    case PM::Predicted:
+    case Predicted:
       sourceIndex = other.ipredicted;
       break;
-    case PM::Filtered:
+    case Filtered:
       sourceIndex = other.ifiltered;
       break;
-    case PM::Smoothed:
+    case Smoothed:
       sourceIndex = other.ismoothed;
       break;
-    case PM::Jacobian:
+    case Jacobian:
       sourceIndex = other.ijacobian;
       break;
     default:
@@ -171,20 +170,20 @@ void VectorMultiTrajectory::shareFrom_impl(IndexType iself, IndexType iother,
   assert(sourceIndex != kInvalid);
 
   switch (shareTarget) {
-    case PM::Predicted:
-      assert(shareSource != PM::Jacobian);
+    case Predicted:
+      assert(shareSource != Jacobian);
       self.ipredicted = sourceIndex;
       break;
-    case PM::Filtered:
-      assert(shareSource != PM::Jacobian);
+    case Filtered:
+      assert(shareSource != Jacobian);
       self.ifiltered = sourceIndex;
       break;
-    case PM::Smoothed:
-      assert(shareSource != PM::Jacobian);
+    case Smoothed:
+      assert(shareSource != Jacobian);
       self.ismoothed = sourceIndex;
       break;
-    case PM::Jacobian:
-      assert(shareSource == PM::Jacobian);
+    case Jacobian:
+      assert(shareSource == Jacobian);
       self.ijacobian = sourceIndex;
       break;
     default:
@@ -194,22 +193,22 @@ void VectorMultiTrajectory::shareFrom_impl(IndexType iself, IndexType iother,
 
 void VectorMultiTrajectory::unset_impl(TrackStatePropMask target,
                                        IndexType istate) {
-  using PM = TrackStatePropMask;
+  using enum TrackStatePropMask;
 
   switch (target) {
-    case PM::Predicted:
+    case Predicted:
       m_index[istate].ipredicted = kInvalid;
       break;
-    case PM::Filtered:
+    case Filtered:
       m_index[istate].ifiltered = kInvalid;
       break;
-    case PM::Smoothed:
+    case Smoothed:
       m_index[istate].ismoothed = kInvalid;
       break;
-    case PM::Jacobian:
+    case Jacobian:
       m_index[istate].ijacobian = kInvalid;
       break;
-    case PM::Calibrated:
+    case Calibrated:
       m_measOffset[istate] = kInvalid;
       m_measCovOffset[istate] = kInvalid;
       m_index[istate].measdim = kInvalid;
@@ -248,12 +247,15 @@ void detail_vmt::VectorMultiTrajectoryBase::Statistics::toStream(
   const auto& column_axis = axis::get<cat>(h.axis(0));
   const auto& type_axis = axis::get<axis::category<>>(h.axis(1));
 
-  auto p = [&](const auto& key, const auto v, std::string_view suffix = "") {
-    if constexpr (std::is_same_v<std::decay_t<decltype(v)>, double>) {
-      os << std::format("{:>20}: {:8.2f}{}", key, v / n, suffix) << std::endl;
-    } else {
-      os << std::format("{:>20}: {:8.2f}{}", key, static_cast<double>(v) / n,
+  auto p = [&]<typename T>(const auto& key, const T v,
+                           std::string_view suffix = "") {
+    if constexpr (std::is_same_v<std::decay_t<T>, double>) {
+      os << std::format("{:>20}: {:8.2f}{}", key, v / static_cast<double>(n),
                         suffix)
+         << std::endl;
+    } else {
+      os << std::format("{:>20}: {:8.2f}{}", key,
+                        static_cast<double>(v) / static_cast<double>(n), suffix)
          << std::endl;
     }
   };

--- a/Core/src/EventData/VectorTrackContainer.cpp
+++ b/Core/src/EventData/VectorTrackContainer.cpp
@@ -60,13 +60,13 @@ VectorTrackContainer::IndexType VectorTrackContainer::addTrack_impl() {
   m_nSharedHits.emplace_back();
 
   // dynamic columns
-  for (auto& [key, vec] : m_dynamic) {
+  for (const auto& [key, vec] : m_dynamic) {
     vec->add();
   }
 
   assert(checkConsistency());
 
-  return m_tipIndex.size() - 1;
+  return static_cast<IndexType>(m_tipIndex.size() - 1);
 }
 
 void VectorTrackContainer::removeTrack_impl(IndexType itrack) {
@@ -95,7 +95,7 @@ void VectorTrackContainer::removeTrack_impl(IndexType itrack) {
   erase(m_nOutliers);
   erase(m_nSharedHits);
 
-  for (auto& [key, vec] : m_dynamic) {
+  for (const auto& [key, vec] : m_dynamic) {
     vec->erase(itrack);
   }
 }
@@ -139,7 +139,7 @@ void VectorTrackContainer::reserve(IndexType size) {
   m_nOutliers.reserve(size);
   m_nSharedHits.reserve(size);
 
-  for (auto& [key, vec] : m_dynamic) {
+  for (const auto& [key, vec] : m_dynamic) {
     vec->reserve(size);
   }
 }
@@ -162,7 +162,7 @@ void VectorTrackContainer::clear() {
   m_nOutliers.clear();
   m_nSharedHits.clear();
 
-  for (auto& [key, vec] : m_dynamic) {
+  for (const auto& [key, vec] : m_dynamic) {
     vec->clear();
   }
 }


### PR DESCRIPTION

Addresses the MAJOR- and MINOR-severity SonarCloud findings reported against
`Core/include/Acts/EventData/**` and `Core/src/EventData/**` (the `Acts::EventData`
package) on `main`. Of the 70 open MAJOR/MINOR issues, **60 issue instances across
22 files are fixed**. The remaining 10 are left open deliberately:

15 CRITICAL-severity issues in the same package were **not** touched — out of
scope for this pass, which targeted MAJOR/MINOR only.

No behavior change is intended except for two cases called out explicitly below
(one dead-code bug fix, one std::format modernization of debug-print output).

## Changes by rule

### Correctness fix (not just a style issue)

- **`Core/src/EventData/MultiComponentTrackParameters.cpp:98`** (`cpp:S108`,
  empty compound statement) — `if (hasCovariance() != cov.has_value()) { }` did
  nothing on a genuine state mismatch. Now throws `std::logic_error`, mirroring
  the sibling overload's existing consistency check.

### Pass-by-value → pass-by-const-ref (`cpp:S1238`, 9 instances)

`BoundTrackParameters.hpp` (4) and `MultiComponentTrackParameters.hpp` (5):
`ParticleHypothesis particleHypothesis` parameters changed to
`const ParticleHypothesis&` across factory functions and constructors.

### `std::move` never called on rvalue-ref move-assign (`cpp:S5500`, 2 instances)

`SeedProxy.hpp:76`, `SpacePointProxy.hpp:84` — the cross-type move-assignment
operators (`operator=(Proxy<false>&&)`) only ever copy a pointer + index (no
owned resource to move), so they're now implemented by delegating to the
existing copy-assignment overload (`return *this = other;`) instead of
duplicating the two-line body.

### Assignment-in-return extracted (`cpp:S1121`, 3 instances)

`SeedProxy.hpp:279,284,289` — `return it += n;` split into `it += n; return it;`
in the three `SpacePointIterator` friend arithmetic operators.

### `=default` for trivial comparisons (`cpp:S6230`, 2 instances)

`SourceLink.hpp:129`, `detail/DynamicKeyIterator.hpp:43` — hand-written
member-wise `operator==` replaced with `= default`.

### Hidden friend (`cpp:S2807`, 1 instance)

`SourceLink.hpp:140` — `SourceLinkAdapterIterator::operator-` turned into a
hidden friend (two-parameter friend function) instead of a member operator.

### Implicit narrowing conversions made explicit (`cpp:S5276`, 6 instances)

`SpacePointColumnProxy.hpp:62`, `SeedContainer.cpp:37`,
`SpacePointContainer.cpp:146`, `VectorTrackContainer.cpp:69`,
`VectorMultiTrajectory.cpp:253,255` — added `static_cast` at each
size_t/uint→float/double or size_t→uint32_t/IndexType narrowing site.

### Generic-code free-function lookup (`cpp:S6024`, 1 instance)

`SubspaceHelpers.hpp:36-54` — `indexRange.begin()/end()/size()` replaced with
`std::ranges::begin/end/size(indexRange)` so the templated `index_range_t`
isn't required to expose member functions.

### Redundant explicit type → `auto` (`cpp:S5827`, 2 instances)

`TrackStateProxyCommon.hpp:529`, `VectorMultiTrajectory.cpp:32` — variable type
already fully determined by an adjacent `static_cast`.

### `auto` lambda param → explicit template parameter (`cpp:S6189`, 3 instances)

`TrackStateProxy.hpp:538,583` — `[&](auto N)` → `[&]<std::size_t measdim>(std::integral_constant<std::size_t, measdim>)`.
`VectorMultiTrajectory.cpp:251` — same treatment for the value-type parameter of
the debug-print lambda, which also let the `if constexpr` branch use the named
type `T` instead of `decltype(v)`.

### `using enum` for verbose qualified access (`cpp:S6177`, 4 instances)

`TrackStateProxyCommon.hpp:383` (`getMask()`),
`VectorMultiTrajectory.cpp:28,150,196` (`addTrackState_impl`, `shareFrom_impl`,
`unset_impl`) — `using PM = TrackStatePropMask;` + `PM::X` replaced with
`using enum TrackStatePropMask;` + bare `X`. Left the alias in
`VectorMultiTrajectory.cpp:92` (`addTrackStateComponents_impl`) unchanged since
`PropMask` there is also used as a variable's *type*, which `using enum` cannot
provide.

### Nested `break` reduced to one (`cpp:S924`, 2 instances)

`MultiTrajectory.hpp:292`, `MultiTrajectory.ipp:31` — `visitBackwards`/
`applyBackwards`'s `if constexpr`/`else` each had their own `break`; merged into
a single `bool proceed` flag with one `break` after the `if constexpr`.

### `if`-init-statement (`cpp:S6004`, 2 instances)

`MultiTrajectoryHelpers.hpp:122`, `CorrectedTransformationFreeToBound.cpp:64` —
locals scoped strictly to the following `if`/`else if` chain moved into the
`if (...; cond)` init-statement.

### Member-initializer-list instead of constructor-body assignment (`cpp:S3230`, 4 instances)

`CorrectedTransformationFreeToBound.cpp:44-49` — the
`CorrectedFreeToBoundTransformer(const FreeToBoundCorrection&)` constructor now
initializes all four members in the init-list.

### `std::format` instead of stream manipulators (`cpp:S6495`, 6 instances)

`PrintParameters.cpp` — `printParametersCovariance`/`printParameters` rewritten
to build each line with `std::format` (width/precision as format-spec args)
instead of `std::setw`/`std::left`/`std::right`/`std::fixed`/`std::defaultfloat`
+ manual flag save/restore. No golden-string tests exist for this debug-print
output; verified by inspection that the format specs reproduce the original
field widths/alignment/precision.

### Transparent hash for string-keyed maps (`cpp:S6045`, 2 instances)

`SpacePointContainer.hpp:594,596` — `m_allColumns`/`m_dynamicColumns`
(`unordered_map<std::string, ...>`) gained a transparent `TransparentStringHash`
+ `std::equal_to<>`, enabling heterogeneous `find`/`contains`/`count` with
`std::string_view` (valid since C++20's P0919) without constructing a temporary
`std::string`. **Left `m_allColumns.erase(std::string(name))` in
`SpacePointContainer.cpp:248` unchanged** — heterogeneous `erase` for
`unordered_map` is C++23 (P2077), and this project targets C++20.

### `const auto&` for read-only structured bindings (`cpp:S5350`, 4 instances)

`VectorTrackContainer.cpp:63,98,142,165` — four `for (auto& [key, vec] : m_dynamic)`
loops that only call methods through the `unique_ptr` value changed to
`const auto&`.

### Dead code removed (`cpp:S125`, 3 instances)

`Types.hpp:42-45` (commented-out type alias), `VectorMultiTrajectory.cpp:144`
(commented-out `getTrackState` call).

### Redundant declarations removed (`cpp:S3539` / `cpp:S3231`, 3 instances)

`VectorTrackContainer.hpp:227,341` (two redundant `public:` labels already
public from the enclosing class), `:311` (duplicate forward declaration of
`ConstVectorTrackContainer`, already forward-declared at line 208).

## Not done / left for follow-up

- The 9 `cpp:S1448`/`cpp:S1820` "class too large" findings on the core proxy
  types — needs a maintainer decision (accept as a deliberate design tradeoff,
  or scope a real class-splitting redesign).
- The 15 CRITICAL-severity findings in the same package (mostly `cpp:S5008`
  `void*` type-erasure in `AnyTrackStateProxy.hpp`, `cpp:S5425` forwarding-ref
  `std::forward` in `SpacePointProxy.hpp`/`SeedProxy.hpp`/`SpacePointContainer.hpp`,
  `cpp:S3624` destructor customization) — out of scope for this pass.
- SonarCloud itself hasn't re-scanned this diff yet (scan lags the push by a
  full CI build); the fix count above is based on matching each edit back t
