### PR TITLE
fix: SonarCloud reported `std::ranges` modernization, Agent A

### DIFF
--- a/Core/include/Acts/EventData/SubspaceHelpers.hpp
+++ b/Core/include/Acts/EventData/SubspaceHelpers.hpp
@@ -40,16 +40,18 @@ inline static bool checkSubspaceIndices(const index_range_t& indexRange,
   if (subspaceSize > fullSize) {
     return false;
   }
-  if (static_cast<std::size_t>(indexRange.size()) != subspaceSize) {
+  if (static_cast<std::size_t>(std::ranges::size(indexRange)) != subspaceSize) {
     return false;
   }
-  for (auto it = indexRange.begin(); it != indexRange.end();) {
+  for (auto it = std::ranges::begin(indexRange);
+       it != std::ranges::end(indexRange);) {
     auto index = *it;
     if (index >= fullSize) {
       return false;
     }
     ++it;
-    if (const auto tail = std::ranges::subrange(it, indexRange.end());
+    if (const auto tail =
+            std::ranges::subrange(it, std::ranges::end(indexRange));
         std::ranges::find(tail, index) != tail.end()) {
       return false;
     }

--- a/Core/include/Acts/Propagator/MultiStepperLoop.hpp
+++ b/Core/include/Acts/Propagator/MultiStepperLoop.hpp
@@ -326,12 +326,13 @@ class MultiStepperLoop final {
       using iterator_category [[maybe_unused]] = std::forward_iterator_tag;
 
       typename decltype(state.components)::iterator it;
-      const State& s;
+      const State* s{};
 
       // clang-format off
       auto& operator++() { ++it; return *this; }
+      auto operator++(int) { auto copy = *this; ++it; return copy; }
       auto operator==(const Iterator& other) const { return it == other.it; }
-      auto operator*() const { return ComponentProxy(*it, s); }
+      auto operator*() const { return ComponentProxy(*it, *s); }
       // clang-format on
     };
 
@@ -339,8 +340,8 @@ class MultiStepperLoop final {
       State& s;
 
       // clang-format off
-      auto begin() { return Iterator{s.components.begin(), s}; }
-      auto end() { return Iterator{s.components.end(), s}; }
+      auto begin() { return Iterator{s.components.begin(), &s}; }
+      auto end() { return Iterator{s.components.end(), &s}; }
       // clang-format on
     };
 
@@ -362,10 +363,11 @@ class MultiStepperLoop final {
       using iterator_category [[maybe_unused]] = std::forward_iterator_tag;
 
       typename decltype(state.components)::const_iterator it;
-      const State& s;
+      const State* s{};
 
       // clang-format off
       auto& operator++() { ++it; return *this; }
+      auto operator++(int) { auto copy = *this; ++it; return copy; }
       auto operator==(const ConstIterator& other) const { return it == other.it; }
       auto operator*() const { return ConstComponentProxy{*it}; }
       // clang-format on
@@ -375,8 +377,8 @@ class MultiStepperLoop final {
       const State& s;
 
       // clang-format off
-      auto begin() const { return ConstIterator{s.components.cbegin(), s}; }
-      auto end() const { return ConstIterator{s.components.cend(), s}; }
+      auto begin() const { return ConstIterator{s.components.cbegin(), &s}; }
+      auto end() const { return ConstIterator{s.components.cend(), &s}; }
       // clang-format on
     };
 

--- a/Core/include/Acts/TrackFitting/detail/GsfUtils.hpp
+++ b/Core/include/Acts/TrackFitting/detail/GsfUtils.hpp
@@ -99,9 +99,8 @@ class ScopedGsfInfoPrinterAndChecker {
 
   void checks(bool onStart) const {
     const auto cmps = m_stepper.constComponentIterable(m_state.stepping);
-    [[maybe_unused]] const bool allFinite =
-        std::all_of(cmps.begin(), cmps.end(),
-                    [](auto cmp) { return std::isfinite(cmp.weight()); });
+    [[maybe_unused]] const bool allFinite = std::ranges::all_of(
+        cmps, [](auto cmp) { return std::isfinite(cmp.weight()); });
     [[maybe_unused]] const bool allNormalized = weightsAreNormalized(
         cmps, [](const auto &cmp) { return cmp.weight(); });
     [[maybe_unused]] const bool zeroComponents =

--- a/Core/include/Acts/Utilities/Zip.hpp
+++ b/Core/include/Acts/Utilities/Zip.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <ranges>
 #include <tuple>
 
 namespace Acts {
@@ -26,10 +27,10 @@ namespace Acts {
 template <typename... R>
 auto zip(R &&...r) {
   struct It {
-    std::tuple<decltype(r.begin())...> iterators;
+    std::tuple<decltype(std::ranges::begin(r))...> iterators;
     static_assert(std::tuple_size_v<decltype(iterators)> > 0);
 
-    using reference = std::tuple<decltype(*r.begin())...>;
+    using reference = std::tuple<decltype(*std::ranges::begin(r))...>;
 
     auto operator++() {
       std::apply([](auto &...args) { (++args, ...); }, iterators);
@@ -53,8 +54,8 @@ auto zip(R &&...r) {
     auto end() { return e; }
   };
 
-  auto begin = std::make_tuple(r.begin()...);
-  auto end = std::make_tuple(r.end()...);
+  auto begin = std::make_tuple(std::ranges::begin(r)...);
+  auto end = std::make_tuple(std::ranges::end(r)...);
   return Zip{It{begin}, It{end}};
 }
 

--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFitter.hpp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFitter.hpp
@@ -21,6 +21,7 @@
 #include "Acts/Vertexing/VertexingOptions.hpp"
 
 #include <algorithm>
+#include <map>
 
 namespace Acts {
 
@@ -76,14 +77,8 @@ class AdaptiveMultiVertexFitter {
     /// Removes a vertex from trackToVerticesMultiMap
     /// @param vtx Vertex to remove from the multimap along with its track associations
     void removeVertexFromMultiMap(const Vertex& vtx) {
-      for (auto iter = trackToVerticesMultiMap.begin();
-           iter != trackToVerticesMultiMap.end();) {
-        if (iter->second == &vtx) {
-          iter = trackToVerticesMultiMap.erase(iter);
-        } else {
-          ++iter;
-        }
-      }
+      std::erase_if(trackToVerticesMultiMap,
+                    [&vtx](const auto& entry) { return entry.second == &vtx; });
     }
 
     /// Remove a vertex from the vertex collection

--- a/Core/src/Geometry/Polyhedron.cpp
+++ b/Core/src/Geometry/Polyhedron.cpp
@@ -25,8 +25,8 @@ void Polyhedron::merge(const Polyhedron& other) {
                   const std::vector<FaceType>& additional) -> void {
     for (const auto& aface : additional) {
       FaceType nface = aface;
-      std::transform(nface.begin(), nface.end(), nface.begin(),
-                     [&](std::size_t x) { return (x + cvert); });
+      std::ranges::transform(nface, nface.begin(),
+                             [&](std::size_t x) { return (x + cvert); });
       existing.push_back(nface);
     }
   };
@@ -36,14 +36,13 @@ void Polyhedron::merge(const Polyhedron& other) {
 }
 
 void Polyhedron::move(const Transform3& transform) {
-  for_each(vertices.begin(), vertices.end(),
-           [&](auto& v) { v = transform * v; });
+  std::ranges::for_each(vertices, [&](auto& v) { v = transform * v; });
 }
 
 Extent Polyhedron::extent(const Transform3& transform) const {
   Extent extent;
   auto vtxs = vertices;
-  std::transform(vtxs.begin(), vtxs.end(), vtxs.begin(), [&](auto& v) {
+  std::ranges::transform(vtxs, vtxs.begin(), [&](auto& v) {
     auto vt = (transform * v);
     extent.extend(vt);
     return (vt);

--- a/Core/src/Geometry/SurfaceArrayCreator.cpp
+++ b/Core/src/Geometry/SurfaceArrayCreator.cpp
@@ -216,8 +216,8 @@ SurfaceArray SurfaceArrayCreator::surfaceArrayOnDisc(
       return matcher(gctx, AxisPhi, a, b);
     };
 
-    std::transform(
-        phiModules.begin(), phiModules.end(), std::back_inserter(nPhiModules),
+    std::ranges::transform(
+        phiModules, std::back_inserter(nPhiModules),
         [&equal,
          this](const std::vector<const Surface*>& surfaces_) -> std::size_t {
           return this->findKeySurfaces(surfaces_, equal).size();
@@ -229,8 +229,7 @@ SurfaceArray SurfaceArrayCreator::surfaceArrayOnDisc(
     // but the rotation is done considering all bins.
     // This might be resolved through bin completion, but not sure.
     // @TODO: check in extrapolation
-    const std::size_t nBinsPhi =
-        *std::min_element(nPhiModules.begin(), nPhiModules.end());
+    const std::size_t nBinsPhi = *std::ranges::min_element(nPhiModules);
     pAxisPhi =
         createEquidistantAxis(gctx, surfacesRaw, AxisBoundaryType::Closed,
                               AxisPhi, protoLayer, fullTransform, nBinsPhi);
@@ -411,11 +410,9 @@ std::unique_ptr<const IAxis> SurfaceArrayCreator::createVariableAxis(
 
   std::vector<double> binEdges;
   if (aDir == AxisPhi) {
-    std::stable_sort(keys.begin(), keys.end(),
-                     [&gctx](const Surface* a, const Surface* b) {
-                       return (phi(a->referencePosition(gctx, AxisPhi)) <
-                               phi(b->referencePosition(gctx, AxisPhi)));
-                     });
+    std::ranges::stable_sort(keys, {}, [&gctx](const Surface* s) {
+      return phi(s->referencePosition(gctx, AxisPhi));
+    });
 
     const double maxPhi =
         0.5 * (phi(keys.at(0)->referencePosition(gctx, AxisPhi)) +

--- a/Core/src/Material/MaterialGridHelper.cpp
+++ b/Core/src/Material/MaterialGridHelper.cpp
@@ -136,13 +136,13 @@ Acts::Grid2D Acts::createGrid2D(
   bool isCartesian = false;
   bool isCylindrical = false;
 
-  for (std::size_t b = 0; b < bu.size(); b++) {
-    if (bu[b].binvalue == Acts::AxisDirection::AxisX ||
-        bu[b].binvalue == Acts::AxisDirection::AxisY) {
+  for (const auto& bd : bu) {
+    if (bd.binvalue == Acts::AxisDirection::AxisX ||
+        bd.binvalue == Acts::AxisDirection::AxisY) {
       isCartesian = true;
     }
-    if (bu[b].binvalue == Acts::AxisDirection::AxisR ||
-        bu[b].binvalue == Acts::AxisDirection::AxisPhi) {
+    if (bd.binvalue == Acts::AxisDirection::AxisR ||
+        bd.binvalue == Acts::AxisDirection::AxisPhi) {
       isCylindrical = true;
     }
   }
@@ -176,13 +176,13 @@ Acts::Grid3D Acts::createGrid3D(
   bool isCartesian = false;
   bool isCylindrical = false;
 
-  for (std::size_t b = 0; b < bu.size(); b++) {
-    if (bu[b].binvalue == Acts::AxisDirection::AxisX ||
-        bu[b].binvalue == Acts::AxisDirection::AxisY) {
+  for (const auto& bd : bu) {
+    if (bd.binvalue == Acts::AxisDirection::AxisX ||
+        bd.binvalue == Acts::AxisDirection::AxisY) {
       isCartesian = true;
     }
-    if (bu[b].binvalue == Acts::AxisDirection::AxisR ||
-        bu[b].binvalue == Acts::AxisDirection::AxisPhi) {
+    if (bd.binvalue == Acts::AxisDirection::AxisR ||
+        bd.binvalue == Acts::AxisDirection::AxisPhi) {
       isCylindrical = true;
     }
   }

--- a/Core/src/Navigation/NavigationStream.cpp
+++ b/Core/src/Navigation/NavigationStream.cpp
@@ -120,8 +120,7 @@ bool NavigationStream::initialize(const GeometryContext& gctx,
 
   /// But but but... What about the surfaces with multiple intersections?
   auto nonUniqueRange = std::ranges::unique(
-      m_candidates.begin(), m_candidates.end(),
-      [](const NavigationTarget& a, const NavigationTarget& b) {
+      m_candidates, [](const NavigationTarget& a, const NavigationTarget& b) {
         return &a.surface() == &b.surface();
       });
   m_candidates.erase(nonUniqueRange.begin(), nonUniqueRange.end());

--- a/Core/src/Seeding/GbtsGeometry.cpp
+++ b/Core/src/Seeding/GbtsGeometry.cpp
@@ -439,7 +439,7 @@ GbtsGeometry::GbtsGeometry(
     }
 
     // order exit bins (important for graph building)
-    std::sort(exitBins.begin(), exitBins.end());
+    std::ranges::sort(exitBins);
 
     // 2b. add a new stage: vector of bin1
 

--- a/Core/src/Surfaces/AnnulusBounds.cpp
+++ b/Core/src/Surfaces/AnnulusBounds.cpp
@@ -164,7 +164,7 @@ std::vector<Vector2> AnnulusBounds::vertices(
         detail::VerticesHelper::segmentVertices<Vector2, Transform2>(
             {get(eMinR), get(eMinR)}, phiMinInner, phiMaxInner, {},
             quarterSegments);
-    std::reverse(rvertices.begin(), rvertices.end());
+    std::ranges::reverse(rvertices);
 
     // Outer bow from phi_min -> phi_max
     auto overtices =

--- a/Core/src/Surfaces/SurfaceArray.cpp
+++ b/Core/src/Surfaces/SurfaceArray.cpp
@@ -449,8 +449,7 @@ struct SurfaceGridLookupImpl final : SurfaceArray::ISurfaceGridLookup {
              detail::MultiAxisHelper::neighborHoodIndices(
                  indices, neighborDistance, m_axes)) {
           const std::vector<const Surface*>& binContent = m_fillingGrid.at(idx);
-          std::copy(binContent.begin(), binContent.end(),
-                    std::back_inserter(surfacePack));
+          std::ranges::copy(binContent, std::back_inserter(surfacePack));
         }
 
         std::ranges::sort(surfacePack);
@@ -492,9 +491,8 @@ struct SurfaceGridLookupImpl final : SurfaceArray::ISurfaceGridLookup {
                                                surfaces.end());
 
     std::set<const Surface*> seenSurface;
-    for (std::size_t globalBin = 0; globalBin < m_fillingGrid.size();
-         ++globalBin) {
-      for (const Surface* surface : m_fillingGrid.at(globalBin)) {
+    for (const std::vector<const Surface*>& binSurfaces : m_fillingGrid) {
+      for (const Surface* surface : binSurfaces) {
         seenSurface.insert(surface);
       }
     }

--- a/Core/src/TrackFitting/GsfMixtureReduction.cpp
+++ b/Core/src/TrackFitting/GsfMixtureReduction.cpp
@@ -13,6 +13,7 @@
 #include <algorithm>
 #include <format>
 #include <iostream>
+#include <vector>
 
 using namespace Acts;
 
@@ -46,11 +47,8 @@ void reduceWithKLDistanceImpl(std::vector<GsfComponent> &cmpCache,
   }
 
   // Remove all components which are labeled with weight -1
-  std::ranges::sort(cmpCache, {}, [&](const auto &c) { return c.weight; });
-  cmpCache.erase(
-      std::remove_if(cmpCache.begin(), cmpCache.end(),
-                     [&](const auto &a) { return a.weight == -1.0; }),
-      cmpCache.end());
+  std::ranges::sort(cmpCache, {}, [](const auto &c) { return c.weight; });
+  std::erase_if(cmpCache, [](const auto &a) { return a.weight == -1.0; });
 
   assert(cmpCache.size() == maxCmpsAfterMerge && "size mismatch");
 }
@@ -66,9 +64,9 @@ void Acts::reduceMixtureLargestWeights(std::vector<GsfComponent> &cmpCache,
     return;
   }
 
-  std::nth_element(
-      cmpCache.begin(), cmpCache.begin() + maxCmpsAfterMerge, cmpCache.end(),
-      [](const auto &a, const auto &b) { return a.weight > b.weight; });
+  std::ranges::nth_element(cmpCache, cmpCache.begin() + maxCmpsAfterMerge,
+                           std::ranges::greater{},
+                           [](const auto &c) { return c.weight; });
   cmpCache.resize(maxCmpsAfterMerge);
 }
 

--- a/Core/src/TrackFitting/GsfUtils.cpp
+++ b/Core/src/TrackFitting/GsfUtils.cpp
@@ -14,6 +14,7 @@
 #include "Acts/EventData/Types.hpp"
 #include "Acts/Material/MaterialSlab.hpp"
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <span>
@@ -48,18 +49,15 @@ void detail::Gsf::removeLowWeightComponents(std::vector<GsfComponent> &cmps,
 
   normalizeWeights(cmps, proj);
 
-  auto newEnd = std::remove_if(cmps.begin(), cmps.end(), [&](auto &cmp) {
-    return proj(cmp) < weightCutoff;
-  });
+  auto removed = std::ranges::remove_if(
+      cmps, [&](auto &cmp) { return proj(cmp) < weightCutoff; });
 
   // In case we would remove all components, keep only the largest
-  if (std::distance(cmps.begin(), newEnd) == 0) {
-    cmps = {*std::max_element(cmps.begin(), cmps.end(), [&](auto &a, auto &b) {
-      return proj(a) < proj(b);
-    })};
+  if (removed.begin() == cmps.begin()) {
+    cmps = {*std::ranges::max_element(cmps, {}, proj)};
     cmps.front().weight = 1.0;
   } else {
-    cmps.erase(newEnd, cmps.end());
+    cmps.erase(removed.begin(), removed.end());
     normalizeWeights(cmps, proj);
   }
 }

--- a/Core/src/Vertexing/AdaptiveGridTrackDensity.cpp
+++ b/Core/src/Vertexing/AdaptiveGridTrackDensity.cpp
@@ -131,10 +131,8 @@ AdaptiveGridTrackDensity::AdaptiveGridTrackDensity(const Config& cfg)
 AdaptiveGridTrackDensity::DensityMap::const_iterator
 AdaptiveGridTrackDensity::highestDensityEntry(
     const DensityMap& densityMap) const {
-  auto maxEntry = std::max_element(
-      std::begin(densityMap), std::end(densityMap),
-      [](const auto& a, const auto& b) { return a.second < b.second; });
-  return maxEntry;
+  return std::ranges::max_element(
+      densityMap, {}, [](const auto& entry) { return entry.second; });
 }
 
 Result<AdaptiveGridTrackDensity::ZTPosition>

--- a/Core/src/Vertexing/AdaptiveMultiVertexFinder.cpp
+++ b/Core/src/Vertexing/AdaptiveMultiVertexFinder.cpp
@@ -13,6 +13,7 @@
 #include "Acts/Vertexing/VertexingError.hpp"
 
 #include <algorithm>
+#include <map>
 
 namespace Acts {
 
@@ -608,15 +609,10 @@ Result<void> AdaptiveMultiVertexFinder::deleteLastVertex(
     return removeResult.error();
   }
 
-  for (auto it = fitterState.tracksAtVerticesMap.begin();
-       it != fitterState.tracksAtVerticesMap.end();) {
-    // Delete all track state for current (bad) vertex
-    if (it->first.second == vtxPtr) {
-      it = fitterState.tracksAtVerticesMap.erase(it);
-    } else {
-      ++it;
-    }
-  }
+  // Delete all track state for current (bad) vertex
+  std::erase_if(fitterState.tracksAtVerticesMap, [vtxPtr](const auto& entry) {
+    return entry.first.second == vtxPtr;
+  });
   fitterState.vtxInfoMap.erase(vtxPtr);
 
   // If no vertices share tracks with vtx we don't need to refit

--- a/Core/src/Vertexing/HoughVertexFinder.cpp
+++ b/Core/src/Vertexing/HoughVertexFinder.cpp
@@ -12,6 +12,7 @@
 #include "Acts/Utilities/AxisDefinitions.hpp"
 #include "Acts/Utilities/Grid.hpp"
 
+#include <algorithm>
 #include <numeric>
 
 namespace Acts {
@@ -195,9 +196,9 @@ Result<double> HoughVertexFinder::findHoughPeak(
     const std::vector<double>& vtxZPositions) const {
   std::uint32_t numZBins = houghZProjection.size();
 
-  auto maxZElement =
-      std::max_element(houghZProjection.begin(), houghZProjection.end());
-  std::uint32_t maxZBin = std::distance(houghZProjection.begin(), maxZElement);
+  auto maxZElement = std::ranges::max_element(houghZProjection);
+  std::uint32_t maxZBin =
+      std::ranges::distance(houghZProjection.begin(), maxZElement);
 
   double avg =
       std::accumulate(houghZProjection.begin(), houghZProjection.end(), 0.) /

--- a/Core/src/Vertexing/IterativeVertexFinder.cpp
+++ b/Core/src/Vertexing/IterativeVertexFinder.cpp
@@ -11,6 +11,8 @@
 #include "Acts/Surfaces/PerigeeSurface.hpp"
 #include "Acts/Vertexing/VertexingError.hpp"
 
+#include <algorithm>
+
 Acts::IterativeVertexFinder::IterativeVertexFinder(
     Config cfg, std::unique_ptr<const Logger> logger)
     : m_cfg(std::move(cfg)), m_logger(std::move(logger)) {
@@ -566,8 +568,7 @@ Acts::Result<bool> Acts::IterativeVertexFinder::reassignTracksToNewVertex(
 
 int Acts::IterativeVertexFinder::countSignificantTracks(
     const Vertex& vtx) const {
-  return std::count_if(vtx.tracks().begin(), vtx.tracks().end(),
-                       [this](const TrackAtVertex& trk) {
-                         return trk.trackWeight > m_cfg.cutOffTrackWeight;
-                       });
+  return std::ranges::count_if(vtx.tracks(), [this](const TrackAtVertex& trk) {
+    return trk.trackWeight > m_cfg.cutOffTrackWeight;
+  });
 }

--- a/Fatras/include/ActsFatras/Kernel/ContinuousProcess.hpp
+++ b/Fatras/include/ActsFatras/Kernel/ContinuousProcess.hpp
@@ -12,6 +12,10 @@
 #include "ActsFatras/EventData/Particle.hpp"
 #include "ActsFatras/Kernel/InteractionList.hpp"
 
+#include <algorithm>
+#include <iterator>
+#include <vector>
+
 namespace ActsFatras {
 
 /// A continuous simulation process based on a physics model plus selectors.
@@ -72,8 +76,8 @@ struct ContinuousProcess {
     // modify particle according to the physics process
     auto children = physics(generator, slab, particle);
     // move selected child particles to the output container
-    std::copy_if(std::begin(children), std::end(children),
-                 std::back_inserter(generated), selectChildParticle);
+    std::ranges::copy_if(children, std::back_inserter(generated),
+                         selectChildParticle);
     // break condition is defined by whether the output particle is still valid
     // or not e.g. because it has fallen below a momentum threshold.
     return !selectOutputParticle(particle);

--- a/Fatras/include/ActsFatras/Kernel/PointLikeProcess.hpp
+++ b/Fatras/include/ActsFatras/Kernel/PointLikeProcess.hpp
@@ -12,7 +12,10 @@
 #include "ActsFatras/EventData/Particle.hpp"
 #include "ActsFatras/Kernel/InteractionList.hpp"
 
+#include <algorithm>
+#include <iterator>
 #include <limits>
+#include <vector>
 
 namespace ActsFatras {
 
@@ -90,8 +93,8 @@ struct PointLikeProcess {
     std::vector<Particle> children;
     physics.run(rng, particle, children);
 
-    std::copy_if(std::begin(children), std::end(children),
-                 std::back_inserter(generatedParticles), selectChildParticle);
+    std::ranges::copy_if(children, std::back_inserter(generatedParticles),
+                         selectChildParticle);
 
     return !selectOutputParticle(particle);
   }

--- a/Plugins/DD4hep/include/ActsPlugins/DD4hep/ConvertDD4hepDetector.hpp
+++ b/Plugins/DD4hep/include/ActsPlugins/DD4hep/ConvertDD4hepDetector.hpp
@@ -41,10 +41,8 @@ namespace ActsPlugins {
 /// Sort function which sorts dd4hep::DetElement by their ID
 /// @param [in,out] det the dd4hep::DetElements to be sorted
 inline void sortDetElementsByID(std::vector<dd4hep::DetElement>& det) {
-  sort(det.begin(), det.end(),
-       [](const dd4hep::DetElement& a, const dd4hep::DetElement& b) {
-         return (a.id() < b.id());
-       });
+  std::ranges::sort(det, {},
+                    [](const dd4hep::DetElement& e) { return e.id(); });
 }
 
 /// @brief Global method which creates the TrackingGeometry from DD4hep input

--- a/Plugins/DD4hep/src/DD4hepLayerBuilder.cpp
+++ b/Plugins/DD4hep/src/DD4hepLayerBuilder.cpp
@@ -97,16 +97,17 @@ const LayerVector DD4hepLayerBuilder::endcapLayers(
         ACTS_VERBOSE("Extent from surfaces: " << ss.str());
 
         std::vector<double> rvalues;
-        std::transform(layerSurfaces.begin(), layerSurfaces.end(),
-                       std::back_inserter(rvalues), [&](const auto& surface) {
-                         return VectorHelpers::perp(surface->center(gctx));
-                       });
+        std::ranges::transform(
+            layerSurfaces, std::back_inserter(rvalues),
+            [&](const auto& surface) {
+              return VectorHelpers::perp(surface->center(gctx));
+            });
         std::ranges::sort(rvalues);
+        const auto duplicates = std::ranges::unique(rvalues);
+        rvalues.erase(duplicates.begin(), duplicates.end());
         std::vector<std::string> locs;
-        std::transform(rvalues.begin(),
-                       std::unique(rvalues.begin(), rvalues.end()),
-                       std::back_inserter(locs),
-                       [](const auto& v) { return std::to_string(v); });
+        std::ranges::transform(rvalues, std::back_inserter(locs),
+                               [](const auto& v) { return std::to_string(v); });
         ACTS_VERBOSE(
             "-> unique r locations: " << boost::algorithm::join(locs, ", "));
       }
@@ -267,16 +268,15 @@ const LayerVector DD4hepLayerBuilder::centralLayers(
         pl.toStream(ss);
         ACTS_VERBOSE("Extent from surfaces: " << ss.str());
         std::vector<double> zvalues;
-        std::transform(layerSurfaces.begin(), layerSurfaces.end(),
-                       std::back_inserter(zvalues), [&](const auto& surface) {
-                         return surface->center(gctx)[eZ];
-                       });
+        std::ranges::transform(
+            layerSurfaces, std::back_inserter(zvalues),
+            [&](const auto& surface) { return surface->center(gctx)[eZ]; });
         std::ranges::sort(zvalues);
+        const auto duplicates = std::ranges::unique(zvalues);
+        zvalues.erase(duplicates.begin(), duplicates.end());
         std::vector<std::string> locs;
-        std::transform(zvalues.begin(),
-                       std::unique(zvalues.begin(), zvalues.end()),
-                       std::back_inserter(locs),
-                       [](const auto& v) { return std::to_string(v); });
+        std::ranges::transform(zvalues, std::back_inserter(locs),
+                               [](const auto& v) { return std::to_string(v); });
         ACTS_VERBOSE(
             "-> unique z locations: " << boost::algorithm::join(locs, ", "));
       }

--- a/Plugins/Geant4/src/Geant4Converters.cpp
+++ b/Plugins/Geant4/src/Geant4Converters.cpp
@@ -152,8 +152,8 @@ ActsPlugins::Geant4ShapeConverter::rectangleBounds(const G4Box& g4Box) {
                                   static_cast<double>(g4Box.GetYHalfLength()),
                                   static_cast<double>(g4Box.GetZHalfLength())};
 
-  auto minAt = std::min_element(hG4XYZ.begin(), hG4XYZ.end());
-  std::size_t minPos = std::distance(hG4XYZ.begin(), minAt);
+  auto minAt = std::ranges::min_element(hG4XYZ);
+  std::size_t minPos = std::ranges::distance(hG4XYZ.begin(), minAt);
   double thickness = 2. * hG4XYZ[minPos];
 
   std::array<int, 2u> rAxes = {};
@@ -190,8 +190,8 @@ ActsPlugins::Geant4ShapeConverter::trapezoidBounds(const G4Trd& g4Trd) {
 
   std::array<double, 3> dXYZ = {(hlX0 + hlX1) * 0.5, (hlY0 + hlY1) * 0.5, hlZ};
 
-  auto minAt = std::min_element(dXYZ.begin(), dXYZ.end());
-  std::size_t minPos = std::distance(dXYZ.begin(), minAt);
+  auto minAt = std::ranges::min_element(dXYZ);
+  std::size_t minPos = std::ranges::distance(dXYZ.begin(), minAt);
   double thickness = 2. * dXYZ[minPos];
 
   double halfLengthXminY = 0.;

--- a/Plugins/GeoModel/src/detail/GeoBoxConverter.cpp
+++ b/Plugins/GeoModel/src/detail/GeoBoxConverter.cpp
@@ -15,6 +15,8 @@
 #include "Acts/Surfaces/Surface.hpp"
 #include "ActsPlugins/GeoModel/GeoModelConversionError.hpp"
 
+#include <algorithm>
+
 #include <GeoModelKernel/GeoBox.h>
 #include <GeoModelKernel/GeoFullPhysVol.h>
 #include <GeoModelKernel/GeoLogVol.h>
@@ -41,8 +43,8 @@ ActsPlugins::detail::GeoBoxConverter::operator()(
                                      geoBox.getYHalfLength(),
                                      geoBox.getZHalfLength()};
   // Create the surface
-  auto minElement = std::min_element(halfLengths.begin(), halfLengths.end());
-  auto zIndex = std::distance(halfLengths.begin(), minElement);
+  auto minElement = std::ranges::min_element(halfLengths);
+  auto zIndex = std::ranges::distance(halfLengths.begin(), minElement);
   std::size_t yIndex = zIndex > 0u ? zIndex - 1u : 2u;
   std::size_t xIndex = yIndex > 0u ? yIndex - 1u : 2u;
 

--- a/Plugins/Json/src/AmbiguityConfigJsonConverter.cpp
+++ b/Plugins/Json/src/AmbiguityConfigJsonConverter.cpp
@@ -11,6 +11,8 @@
 #include "Acts/AmbiguityResolution/ScoreBasedAmbiguityResolution.hpp"
 #include "ActsPlugins/Json/ActsJson.hpp"
 
+#include <algorithm>
+
 void initializeEtaVector(std::vector<std::size_t>& target,
                          const std::vector<std::size_t>& source,
                          std::size_t etaBinSize) {
@@ -21,7 +23,7 @@ void initializeEtaVector(std::vector<std::size_t>& target,
     // Resize target to the required size
     target.resize(etaBinSize - 1);
     // Fill with the single value from source
-    std::fill(target.begin(), target.end(), source[0]);
+    std::ranges::fill(target, source[0]);
   } else {
     throw std::invalid_argument("Invalid cuts size. Expected 1 or " +
                                 std::to_string(etaBinSize - 1) + ", got " +
@@ -57,7 +59,7 @@ void from_json(const nlohmann::json& j, ConfigPair& p) {
     // Validate eta bins
     if (!etaBins.empty()) {
       // Verify monotonically increasing eta bins
-      if (!std::is_sorted(etaBins.begin(), etaBins.end())) {
+      if (!std::ranges::is_sorted(etaBins)) {
         throw std::invalid_argument(
             "Eta bins must be monotonically increasing");
       }

--- a/Plugins/Json/src/MaterialJsonConverter.cpp
+++ b/Plugins/Json/src/MaterialJsonConverter.cpp
@@ -358,11 +358,9 @@ void Acts::to_json(nlohmann::json& j, const surfaceMaterialPointer& material) {
     bUtility = &(psMaterial->binning());
     // Check in the number of bin is different from 1
     auto& binningData = bUtility->binningData();
-    for (std::size_t ibin = 0; ibin < binningData.size(); ++ibin) {
-      if (binningData[ibin].bins() > 1) {
-        jMaterial[Acts::jsonKey().mapkey] = true;
-        break;
-      }
+    if (std::ranges::any_of(binningData,
+                            [](const auto& bd) { return bd.bins() > 1; })) {
+      jMaterial[Acts::jsonKey().mapkey] = true;
     }
     nlohmann::json jBin(*bUtility);
     jMaterial[Acts::jsonKey().binkey] = jBin;
@@ -527,11 +525,9 @@ void Acts::to_json(nlohmann::json& j, const volumeMaterialPointer& material) {
     bUtility = &(pvMaterial->binUtility());
     // Check in the number of bin is different from 1
     auto& binningData = bUtility->binningData();
-    for (std::size_t ibin = 0; ibin < binningData.size(); ++ibin) {
-      if (binningData[ibin].bins() > 1) {
-        jMaterial[Acts::jsonKey().mapkey] = true;
-        break;
-      }
+    if (std::ranges::any_of(binningData,
+                            [](const auto& bd) { return bd.bins() > 1; })) {
+      jMaterial[Acts::jsonKey().mapkey] = true;
     }
     // Write the bin utility
     nlohmann::json jBin(*bUtility);
@@ -566,9 +562,8 @@ void Acts::to_json(nlohmann::json& j, const volumeMaterialPointer& material) {
     // convert the data
     nlohmann::json mmat = nlohmann::json::array();
     Acts::MaterialGrid2D grid = bvMaterial2D->getMapper().getGrid();
-    for (std::size_t bin = 0; bin < grid.size(); bin++) {
-      nlohmann::json jmat(Material(grid.at(bin)));
-      mmat.push_back(jmat);
+    for (const auto& binValue : grid) {
+      mmat.push_back(nlohmann::json(Material(binValue)));
     }
     jMaterial[Acts::jsonKey().datakey] = std::move(mmat);
     // Write the bin utility
@@ -589,9 +584,8 @@ void Acts::to_json(nlohmann::json& j, const volumeMaterialPointer& material) {
     // convert the data
     nlohmann::json mmat = nlohmann::json::array();
     Acts::MaterialGrid3D grid = bvMaterial3D->getMapper().getGrid();
-    for (std::size_t bin = 0; bin < grid.size(); bin++) {
-      nlohmann::json jmat(Material(grid.at(bin)));
-      mmat.push_back(jmat);
+    for (const auto& binValue : grid) {
+      mmat.push_back(nlohmann::json(Material(binValue)));
     }
     jMaterial[Acts::jsonKey().datakey] = std::move(mmat);
     // Write the bin utility

--- a/Plugins/Mille/src/ActsToMille.cpp
+++ b/Plugins/Mille/src/ActsToMille.cpp
@@ -274,19 +274,18 @@ Mille::MilleDecoder::ReadResult unpackMilleRecord(
   std::set<int> seenSurfaceLabels;
   // a measurement with a residual of identical zero is typically a
   // correlation constraint encoded as pseudo-measurement
-  targetState.measurementDim =
-      std::count_if(measurements.begin(), measurements.end(),
-                    [](const Mille::MilleMeasurement& measurement) {
-                      return measurement.measurement != 0;
-                    });
+  targetState.measurementDim = std::ranges::count_if(
+      measurements, [](const Mille::MilleMeasurement& measurement) {
+        return measurement.measurement != 0;
+      });
 
   // discover labels in use
   for (const Mille::MilleMeasurement& measurement : measurements) {
     if (measurement.localLabels.empty()) {
       continue;
     }
-    auto [minLabel, maxLabel] = std::minmax_element(
-        measurement.localLabels.begin(), measurement.localLabels.end());
+    const auto [minLabel, maxLabel] =
+        std::ranges::minmax_element(measurement.localLabels);
     firstLocal = std::min(firstLocal, *minLabel);
     lastLocal = std::max(lastLocal, *maxLabel);
     seenGlobalLabels.insert(measurement.globalLabels.begin(),


### PR DESCRIPTION
refactor: Adopt `std::ranges` where SonarCloud flags the iterator-pair form

## What

Clears all **44** open SonarCloud issues that push toward the C++20 ranges library.

| Rule | Count | Change |
| --- | ---: | --- |
| `cpp:S6197` | 32 | `std::alg(c.begin(), c.end())` → `std::ranges::alg(c)` |
| `cpp:S5566` | 7 | index-only `for` loops → range-for / `std::ranges::any_of` |
| `cpp:S6165` | 3 | erase-remove idiom and manual erase loops → `std::erase_if` |
| `cpp:S6024` | 2 | `r.size()` in generic code → `std::ranges::size(r)` |

28 files, +136 / −149. No behaviour change intended anywhere.

Left out on purpose: `std::accumulate` / `std::iota` keep their iterator pairs — `<numeric>` has no C++20 `std::ranges::` equivalents. `cpp:S6171`, `cpp:S6234` and `cpp:S6188` are C++20 modernization but not ranges, so they stay open.

## Worth a reviewer's eye

- **`GsfUtils.cpp`** — `std::ranges::remove_if` returns a `subrange`, not an iterator. The "did we remove everything?" test became `removed.begin() == cmps.begin()`.
- **`ActsToMille.cpp`** — `std::ranges::minmax_element` returns `minmax_element_result` (`.min`/`.max`), not a `std::pair`. The structured binding still works.
- **`DD4hepLayerBuilder.cpp`** — the old code transformed `[begin, unique_result)`; it now erases the duplicate tail first and transforms the whole vector. Identical output — the vector is sorted on the preceding line.
- Comparator → projection conversions (`stable_sort`, `nth_element`, `max_element` ×2, `sort`) are exact: `{}` is `std::ranges::less`.

## Two changes outside the flagged lines

- **`MultiStepperLoop.hpp`** — required, not opportunistic. `constComponentIterable()` returned an iterable whose function-local iterator held a `const State&`; a reference member deletes copy assignment, so it wasn't `std::movable`, so it wasn't a C++20 iterator and `std::ranges::all_of` rejected it. Now a `const State*`, plus a post-increment (`std::incrementable` requires `i++`). Both structs are function-local and returned via `auto` — nothing outside can name them.
- **`MaterialJsonConverter.cpp`** — once the loop became a range-for, `nlohmann::json jmat(Material(binValue));` turned into a most vexing parse under `-Werror`. Rewritten as `mmat.push_back(nlohmann::json(Material(binValue)));`.

## Verification

- Build clean (C++20, `-Werror`); **376/376** unit tests pass.
- `pre-commit run --all-files`: 20/20 hooks.
- **Public API surface: +0 added, 0 breaking.** The tool reports one entry, `EigenStepper::State::stepData` — a file this PR never touches. A HEAD-vs-HEAD control run reproduces it: Doxygen names that anonymous struct non-deterministically.
- pytest failures on my machine are all pre-existing (missing `pyarrow`/`pyhepmc`, a missing `betheHeitler_*.json` in the install tree, and FPE/log-threshold trips). Confirmed by stashing this change, rebuilding `main`, and re-running the affected files: identical 12-failure set.

SonarCloud won't reflect this until one full debug build after merge — the scan runs on `workflow_run: [Analysis] completed`.