### PR TITLE
feat(json): Read and write tracking geometry as CBOR and zstd

### DIFF
--- a/Examples/Scripts/Python/geometry_validation.py
+++ b/Examples/Scripts/Python/geometry_validation.py
@@ -99,9 +99,7 @@ def main():
 
         if args.input != "":
             print(">>> Reading tracking geometry from", args.input)
-            trackingGeometry = converter.fromJson(
-                gContext, Path(args.input).read_text()
-            )
+            trackingGeometry = converter.fromFile(gContext, Path(args.input))
             print(">>> Read tracking geometry from", args.input)
 
         if args.output_json:

--- a/Examples/Scripts/Python/material_merge_rz_view.py
+++ b/Examples/Scripts/Python/material_merge_rz_view.py
@@ -97,7 +97,7 @@ def load_tracking_geometry(
     from acts.json import TrackingGeometryJsonConverter
 
     converter = TrackingGeometryJsonConverter()
-    return converter.fromJson(gctx, json_path.absolute())
+    return converter.fromFile(gctx, json_path.absolute())
 
 
 def collect_rz(tracking_geometry: acts.TrackingGeometry, gctx: acts.GeometryContext):

--- a/Plugins/Json/CMakeLists.txt
+++ b/Plugins/Json/CMakeLists.txt
@@ -23,6 +23,7 @@ acts_add_library(
     src/SeedingConfigJsonConverter.cpp
     src/TrackingGeometryJsonConverter.cpp
     src/BetheHeitlerApproxJsonConverter.cpp
+    src/detail/JsonIo.cpp
     ACTS_INCLUDE_FOLDER include/ActsPlugins
 )
 
@@ -42,5 +43,19 @@ target_compile_definitions(
     ActsPluginJson
     PRIVATE JSON_DISABLE_ENUM_SERIALIZATION=1
 )
+
+# zstd is optional: without it, reading a compressed file and requesting
+# compressed output both fail with an explanatory error. All zstd use is
+# confined to the .cpp, so the definition stays private and the headers
+# compile identically either way.
+message(CHECK_START "Json plugin: checking for zstd")
+find_package(ZSTD QUIET)
+if(ZSTD_FOUND)
+    message(CHECK_PASS "found")
+    target_link_libraries(ActsPluginJson PRIVATE ZSTD::ZSTD)
+    target_compile_definitions(ActsPluginJson PRIVATE ACTS_JSON_ZSTD_SUPPORT=1)
+else()
+    message(CHECK_FAIL "not found")
+endif()
 
 acts_compile_headers(PluginJson GLOB include/**/*.hpp)

--- a/Plugins/Json/include/ActsPlugins/Json/TrackingGeometryJsonConverter.hpp
+++ b/Plugins/Json/include/ActsPlugins/Json/TrackingGeometryJsonConverter.hpp
@@ -244,6 +244,22 @@ class TrackingGeometryJsonConverter {
       const GeometryContext& gctx, const std::filesystem::path& jsonPath,
       const Options& options = Options::defaultOptions()) const;
 
+  /// Reconstruct a tracking geometry from an in-memory JSON payload.
+  ///
+  /// @param gctx geometry context
+  /// @param encoded Reference to the encoded JSON object
+  /// @param options options for the conversion
+  ///
+  /// @return pointer to deserialized geometry
+  ///
+  /// @deprecated Renamed to @ref fromJson, which now takes the payload.
+  [[deprecated("renamed to fromJson(), which now takes an in-memory payload")]]
+  std::shared_ptr<TrackingGeometry> fromJsonPayload(
+      const GeometryContext& gctx, const nlohmann::json& encoded,
+      const Options& options = Options::defaultOptions()) const {
+    return fromJson(gctx, encoded, options);
+  }
+
   /// Convert a tracking volume hierarchy to JSON.
   ///
   /// @param gctx geometry context

--- a/Plugins/Json/include/ActsPlugins/Json/TrackingGeometryJsonConverter.hpp
+++ b/Plugins/Json/include/ActsPlugins/Json/TrackingGeometryJsonConverter.hpp
@@ -67,6 +67,11 @@ class TrackingGeometryJsonConverter {
 
     /// Whether to write surface material information during serialization
     bool writeMaterial{true};
+
+    /// zstd compression level used when writing to a compressed file.
+    /// Ignored for uncompressed output. Higher levels trade write time for
+    /// size; decompression speed is unaffected.
+    int compressionLevel{9};
   };
 
   /// Generic lookup from object pointer identity to serialized object ID.
@@ -179,27 +184,64 @@ class TrackingGeometryJsonConverter {
       const GeometryContext& gctx, const TrackingGeometry& geometry,
       const Options& options = Options::defaultOptions()) const;
 
-  /// Reconstruct a tracking geometry from a JSON file on
-  /// stored on disk
-  ///
-  /// @param gctx geometry context
-  /// @param jsonPath The path to the JSON file on disk
-  /// @param options options for the conversion
-  ///
-  /// @return pointer to deserialized geometry
-  std::shared_ptr<TrackingGeometry> fromJson(
-      const GeometryContext& gctx, const std::filesystem::path& jsonPath,
-      const Options& options = Options::defaultOptions()) const;
-
-  /// Reconstruct a tracking geometry from a deserialized JSON file
+  /// Reconstruct a tracking geometry from an in-memory JSON payload.
   ///
   /// @param gctx geometry context
   /// @param encoded Reference to the encoded JSON object
   /// @param options options for the conversion
   ///
   /// @return pointer to deserialized geometry
-  std::shared_ptr<TrackingGeometry> fromJsonPayload(
+  std::shared_ptr<TrackingGeometry> fromJson(
       const GeometryContext& gctx, const nlohmann::json& encoded,
+      const Options& options = Options::defaultOptions()) const;
+
+  /// Write a tracking geometry to a file.
+  ///
+  /// The file name selects the format, so a file never misrepresents its own
+  /// contents: `.json` and `.cbor` are stored verbatim, `.json.zst` and
+  /// `.cbor.zst` are zstd compressed. A `.json.zst` file stays readable with
+  /// the usual shell tooling, e.g. `zless` or `zstdcat | jq`.
+  ///
+  /// @param gctx geometry context
+  /// @param geometry tracking geometry to write
+  /// @param path destination file, whose extension selects the format
+  /// @param options options for the conversion
+  ///
+  /// @throw std::invalid_argument if the format cannot be deduced from @p path
+  void toFile(const GeometryContext& gctx, const TrackingGeometry& geometry,
+              const std::filesystem::path& path,
+              const Options& options = Options::defaultOptions()) const;
+
+  /// Reconstruct a tracking geometry from a file.
+  ///
+  /// Encoding and compression are detected from the file contents rather than
+  /// its name, so any format written by @ref toFile is accepted without the
+  /// caller having to declare which one it is.
+  ///
+  /// @param gctx geometry context
+  /// @param path the file to read
+  /// @param options options for the conversion
+  ///
+  /// @return pointer to deserialized geometry
+  std::shared_ptr<TrackingGeometry> fromFile(
+      const GeometryContext& gctx, const std::filesystem::path& path,
+      const Options& options = Options::defaultOptions()) const;
+
+  /// Reconstruct a tracking geometry from a JSON file stored on disk.
+  ///
+  /// @param gctx geometry context
+  /// @param jsonPath The path to the JSON file on disk
+  /// @param options options for the conversion
+  ///
+  /// @return pointer to deserialized geometry
+  ///
+  /// @deprecated Use @ref fromFile instead. `fromJson` now takes an in-memory
+  ///             payload, matching every other converter in this plugin.
+  [[deprecated(
+      "use fromFile() to read from a path; fromJson() now takes an "
+      "in-memory nlohmann::json")]]
+  std::shared_ptr<TrackingGeometry> fromJson(
+      const GeometryContext& gctx, const std::filesystem::path& jsonPath,
       const Options& options = Options::defaultOptions()) const;
 
   /// Convert a tracking volume hierarchy to JSON.

--- a/Plugins/Json/include/ActsPlugins/Json/detail/JsonIo.hpp
+++ b/Plugins/Json/include/ActsPlugins/Json/detail/JsonIo.hpp
@@ -1,0 +1,108 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <cstddef>
+#include <filesystem>
+#include <span>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+namespace Acts::detail {
+
+/// How a JSON document is encoded on disk.
+enum class JsonEncoding {
+  /// Human readable JSON text
+  Text,
+  /// Binary CBOR, as produced by `nlohmann::json::to_cbor`
+  Cbor,
+};
+
+/// Compression applied on top of the encoded payload.
+enum class JsonCompression {
+  /// The encoded payload is stored verbatim
+  None,
+  /// The encoded payload is wrapped in a single zstd frame
+  Zstd,
+};
+
+/// The on-disk format of a JSON document: how it is encoded, and whether it
+/// is compressed. The two are independent, so all four combinations are
+/// valid.
+struct JsonFileFormat {
+  /// Payload encoding
+  JsonEncoding encoding{JsonEncoding::Text};
+  /// Payload compression
+  JsonCompression compression{JsonCompression::None};
+};
+
+/// Whether this build can read and write zstd compressed payloads.
+///
+/// zstd is an optional dependency: when it is not found at configure time,
+/// writing compressed output and reading a compressed file both throw.
+///
+/// @return true if zstd support was compiled in
+bool zstdSupported();
+
+/// Deduce the on-disk format from a file name.
+///
+/// The file name is the only specification of the output format, which keeps
+/// it honest about its own contents:
+///   - `.json`     text, uncompressed
+///   - `.cbor`     CBOR, uncompressed
+///   - `.json.zst` text, zstd compressed
+///   - `.cbor.zst` CBOR, zstd compressed
+///
+/// @param path the file name to inspect
+/// @throw std::invalid_argument if the extension is not one of the above
+/// @return the deduced format
+JsonFileFormat jsonFormatFromPath(const std::filesystem::path& path);
+
+/// Encode a JSON payload into its on-disk representation.
+///
+/// @param payload the JSON document to encode
+/// @param format the target encoding and compression
+/// @param indentation indentation for text output, ignored for CBOR
+/// @param compressionLevel zstd level, ignored when not compressing
+/// @return the encoded bytes
+std::vector<std::byte> encodeJson(const nlohmann::json& payload,
+                                  const JsonFileFormat& format,
+                                  unsigned indentation, int compressionLevel);
+
+/// Decode a JSON payload, detecting encoding and compression from content.
+///
+/// Compression is detected from the zstd frame magic, and the encoding from
+/// the leading byte of the (decompressed) payload, so the caller does not
+/// need to know or declare the format. The file name is used only to make
+/// error messages point at the offending file.
+///
+/// @param data the encoded bytes
+/// @param origin file the data came from, used for diagnostics only
+/// @return the decoded JSON document
+nlohmann::json decodeJson(std::span<const std::byte> data,
+                          const std::filesystem::path& origin = {});
+
+/// Write a JSON payload to a file, in the format its name implies.
+///
+/// @param path destination, whose extension selects the format
+/// @param payload the JSON document to write
+/// @param indentation indentation for text output, ignored for CBOR
+/// @param compressionLevel zstd level, ignored when not compressing
+void writeJsonFile(const std::filesystem::path& path,
+                   const nlohmann::json& payload, unsigned indentation,
+                   int compressionLevel);
+
+/// Read a JSON payload from a file, whatever format it is in.
+///
+/// @param path the file to read
+/// @return the decoded JSON document
+nlohmann::json readJsonFile(const std::filesystem::path& path);
+
+}  // namespace Acts::detail

--- a/Plugins/Json/src/TrackingGeometryJsonConverter.cpp
+++ b/Plugins/Json/src/TrackingGeometryJsonConverter.cpp
@@ -43,9 +43,9 @@
 #include "ActsPlugins/Json/GridJsonConverter.hpp"
 #include "ActsPlugins/Json/SurfaceJsonConverter.hpp"
 #include "ActsPlugins/Json/UtilitiesJsonConverter.hpp"
+#include "ActsPlugins/Json/detail/JsonIo.hpp"
 
 #include <filesystem>
-#include <fstream>
 #include <stdexcept>
 #include <unordered_set>
 
@@ -1205,28 +1205,33 @@ Acts::TrackingGeometryJsonConverter::trackingVolumeFromJson(
   return std::shared_ptr<TrackingVolume>(std::move(root));
 }
 
+void Acts::TrackingGeometryJsonConverter::toFile(
+    const GeometryContext& gctx, const TrackingGeometry& geometry,
+    const std::filesystem::path& path, const Options& options) const {
+  ACTS_DEBUG("Writing TrackingGeometry to '" << path.string() << "'");
+  detail::writeJsonFile(path, toJson(gctx, geometry, options),
+                        options.indentation, options.compressionLevel);
+}
+
+std::shared_ptr<Acts::TrackingGeometry>
+Acts::TrackingGeometryJsonConverter::fromFile(const GeometryContext& gctx,
+                                              const std::filesystem::path& path,
+                                              const Options& options) const {
+  ACTS_DEBUG("Reading TrackingGeometry from '" << path.string() << "'");
+  return fromJson(gctx, detail::readJsonFile(path), options);
+}
+
 std::shared_ptr<Acts::TrackingGeometry>
 Acts::TrackingGeometryJsonConverter::fromJson(const GeometryContext& gctx,
                                               const std::filesystem::path& path,
                                               const Options& options) const {
-  if (!std::filesystem::exists(path)) {
-    throw std::invalid_argument(std::format(
-        "TrackingGeometryJsonConverter() - JSON file {:} does not exist",
-        path.native()));
-  }
-  std::ifstream istr{path};
-  if (!istr.good()) {
-    throw std::invalid_argument(std::format(
-        "TrackingGeometryJsonConverter() - Cannot open '{:}'", path.native()));
-  }
-  nlohmann::json encoded{};
-  istr >> encoded;
-  return fromJsonPayload(gctx, encoded, options);
+  return fromFile(gctx, path, options);
 }
+
 std::shared_ptr<Acts::TrackingGeometry>
-Acts::TrackingGeometryJsonConverter::fromJsonPayload(
-    const GeometryContext& gctx, const nlohmann::json& encoded,
-    const Options& options) const {
+Acts::TrackingGeometryJsonConverter::fromJson(const GeometryContext& gctx,
+                                              const nlohmann::json& encoded,
+                                              const Options& options) const {
   ACTS_DEBUG("Reconstructing TrackingGeometry from JSON");
   auto world = trackingVolumeFromJson(gctx, encoded, options);
 

--- a/Plugins/Json/src/detail/JsonIo.cpp
+++ b/Plugins/Json/src/detail/JsonIo.cpp
@@ -1,0 +1,248 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "ActsPlugins/Json/detail/JsonIo.hpp"
+
+#include <algorithm>
+#include <array>
+#include <format>
+#include <fstream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+
+#ifdef ACTS_JSON_ZSTD_SUPPORT
+#include <zstd.h>
+#endif
+
+namespace {
+
+using Acts::detail::JsonCompression;
+using Acts::detail::JsonEncoding;
+using Acts::detail::JsonFileFormat;
+
+/// zstd frame magic number 0xFD2FB528, little endian as it appears on disk.
+constexpr std::array<std::byte, 4> kZstdMagic{std::byte{0x28}, std::byte{0xB5},
+                                              std::byte{0x2F}, std::byte{0xFD}};
+
+bool hasZstdMagic(std::span<const std::byte> data) {
+  return data.size() >= kZstdMagic.size() &&
+         std::equal(kZstdMagic.begin(), kZstdMagic.end(), data.begin());
+}
+
+/// Copy any contiguous byte-like range into a byte buffer.
+template <typename container_t>
+std::vector<std::byte> toBytes(const container_t& container) {
+  auto bytes = std::as_bytes(std::span{container});
+  return {bytes.begin(), bytes.end()};
+}
+
+std::string_view asStringView(std::span<const std::byte> data) {
+  return {reinterpret_cast<const char*>(data.data()), data.size()};
+}
+
+std::vector<std::byte> compressZstd(std::span<const std::byte> data,
+                                    int level) {
+#ifdef ACTS_JSON_ZSTD_SUPPORT
+  std::vector<std::byte> out(ZSTD_compressBound(data.size()));
+  std::size_t written =
+      ZSTD_compress(out.data(), out.size(), data.data(), data.size(), level);
+  if (ZSTD_isError(written) != 0u) {
+    throw std::runtime_error(
+        std::format("zstd compression failed: {}", ZSTD_getErrorName(written)));
+  }
+  out.resize(written);
+  return out;
+#else
+  static_cast<void>(data);
+  static_cast<void>(level);
+  throw std::runtime_error(
+      "zstd compressed output was requested, but ACTS was built without zstd "
+      "support. Reconfigure with zstd available to write compressed files.");
+#endif
+}
+
+std::vector<std::byte> decompressZstd(std::span<const std::byte> data,
+                                      const std::filesystem::path& origin) {
+#ifdef ACTS_JSON_ZSTD_SUPPORT
+  unsigned long long size = ZSTD_getFrameContentSize(data.data(), data.size());
+  if (size == ZSTD_CONTENTSIZE_ERROR) {
+    throw std::runtime_error(std::format(
+        "'{}' starts with a zstd magic number but is not a valid zstd frame",
+        origin.string()));
+  }
+  if (size == ZSTD_CONTENTSIZE_UNKNOWN) {
+    throw std::runtime_error(std::format(
+        "'{}' is a zstd stream without a declared content size, which is not "
+        "supported here; recompress it as a single frame",
+        origin.string()));
+  }
+  std::vector<std::byte> out(size);
+  std::size_t written =
+      ZSTD_decompress(out.data(), out.size(), data.data(), data.size());
+  if (ZSTD_isError(written) != 0u) {
+    throw std::runtime_error(
+        std::format("'{}' could not be decompressed, the zstd frame is likely "
+                    "truncated or corrupt: {}",
+                    origin.string(), ZSTD_getErrorName(written)));
+  }
+  out.resize(written);
+  return out;
+#else
+  static_cast<void>(data);
+  throw std::runtime_error(std::format(
+      "'{}' is zstd compressed, but ACTS was built without zstd support. "
+      "Reconfigure with zstd available to read this file.",
+      origin.string()));
+#endif
+}
+
+}  // namespace
+
+bool Acts::detail::zstdSupported() {
+#ifdef ACTS_JSON_ZSTD_SUPPORT
+  return true;
+#else
+  return false;
+#endif
+}
+
+Acts::detail::JsonFileFormat Acts::detail::jsonFormatFromPath(
+    const std::filesystem::path& path) {
+  std::string name = path.filename().string();
+  JsonFileFormat format{};
+
+  if (name.ends_with(".zst")) {
+    format.compression = JsonCompression::Zstd;
+    name.resize(name.size() - std::string_view{".zst"}.size());
+  }
+
+  if (name.ends_with(".json")) {
+    format.encoding = JsonEncoding::Text;
+  } else if (name.ends_with(".cbor")) {
+    format.encoding = JsonEncoding::Cbor;
+  } else {
+    throw std::invalid_argument(std::format(
+        "Cannot deduce the output format of '{}': expected one of '.json', "
+        "'.cbor', '.json.zst' or '.cbor.zst'",
+        path.string()));
+  }
+
+  return format;
+}
+
+std::vector<std::byte> Acts::detail::encodeJson(const nlohmann::json& payload,
+                                                const JsonFileFormat& format,
+                                                unsigned indentation,
+                                                int compressionLevel) {
+  std::vector<std::byte> encoded =
+      format.encoding == JsonEncoding::Cbor
+          ? toBytes(nlohmann::json::to_cbor(payload))
+          : toBytes(payload.dump(static_cast<int>(indentation)));
+
+  if (format.compression == JsonCompression::Zstd) {
+    return compressZstd(encoded, compressionLevel);
+  }
+  return encoded;
+}
+
+nlohmann::json Acts::detail::decodeJson(std::span<const std::byte> data,
+                                        const std::filesystem::path& origin) {
+  std::vector<std::byte> decompressed;
+  bool wasCompressed = hasZstdMagic(data);
+  if (wasCompressed) {
+    decompressed = decompressZstd(data, origin);
+    data = decompressed;
+  }
+
+  auto isSpace = [](std::byte b) {
+    char c = static_cast<char>(b);
+    return c == ' ' || c == '\t' || c == '\n' || c == '\r';
+  };
+  auto it = std::ranges::find_if_not(data, isSpace);
+  if (it == data.end()) {
+    throw std::runtime_error(
+        std::format("'{}' contains no payload to decode", origin.string()));
+  }
+
+  // JSON text always starts with '{' or '['. Our CBOR payloads are always a
+  // map or an array at the top level, i.e. major type 5 or 4, which cannot
+  // collide with either of those two ASCII bytes.
+  auto lead = static_cast<unsigned char>(*it);
+  bool isText = lead == '{' || lead == '[';
+  bool isCbor = (lead & 0xE0) == 0xA0 || (lead & 0xE0) == 0x80;
+
+  // A decompressed payload that does not parse points at the compressed file,
+  // so say which stage the content came from.
+  std::string_view stage = wasCompressed ? " (after decompression)" : "";
+
+  if (!isText && !isCbor) {
+    throw std::runtime_error(std::format(
+        "'{}'{} is neither JSON text nor CBOR, leading byte is 0x{:02X}",
+        origin.string(), stage, lead));
+  }
+
+  try {
+    if (isText) {
+      return nlohmann::json::parse(asStringView(data));
+    }
+    return nlohmann::json::from_cbor(data);
+  } catch (const nlohmann::json::exception& e) {
+    throw std::runtime_error(std::format(
+        "Failed to decode {} payload from '{}'{}: {}", isText ? "JSON" : "CBOR",
+        origin.string(), stage, e.what()));
+  }
+}
+
+void Acts::detail::writeJsonFile(const std::filesystem::path& path,
+                                 const nlohmann::json& payload,
+                                 unsigned indentation, int compressionLevel) {
+  std::vector<std::byte> encoded = encodeJson(payload, jsonFormatFromPath(path),
+                                              indentation, compressionLevel);
+
+  std::ofstream ofs{path, std::ios::binary};
+  if (!ofs.good()) {
+    throw std::runtime_error(
+        std::format("Cannot open '{}' for writing", path.string()));
+  }
+  ofs.write(reinterpret_cast<const char*>(encoded.data()),
+            static_cast<std::streamsize>(encoded.size()));
+  if (!ofs.good()) {
+    throw std::runtime_error(
+        std::format("Failed to write '{}'", path.string()));
+  }
+}
+
+nlohmann::json Acts::detail::readJsonFile(const std::filesystem::path& path) {
+  if (!std::filesystem::exists(path)) {
+    throw std::invalid_argument(
+        std::format("File '{}' does not exist", path.string()));
+  }
+
+  std::ifstream ifs{path, std::ios::binary};
+  if (!ifs.good()) {
+    throw std::invalid_argument(std::format("Cannot open '{}'", path.string()));
+  }
+
+  ifs.seekg(0, std::ios::end);
+  auto size = ifs.tellg();
+  if (size < 0) {
+    throw std::runtime_error(
+        std::format("Cannot determine the size of '{}'", path.string()));
+  }
+  ifs.seekg(0, std::ios::beg);
+
+  std::vector<std::byte> data(static_cast<std::size_t>(size));
+  ifs.read(reinterpret_cast<char*>(data.data()),
+           static_cast<std::streamsize>(data.size()));
+  if (ifs.bad()) {
+    throw std::runtime_error(std::format("Failed to read '{}'", path.string()));
+  }
+
+  return decodeJson(data, path);
+}

--- a/Python/Examples/tests/test_geometry.py
+++ b/Python/Examples/tests/test_geometry.py
@@ -213,7 +213,7 @@ def test_odd_gen3_json_roundtrip(tmp_path, odd_detector_gen3):
     assert json_path.stat().st_size > 0
 
     converter = TrackingGeometryJsonConverter()
-    rebuilt_geometry = converter.fromJson(gctx, json_path.absolute())
+    rebuilt_geometry = converter.fromFile(gctx, json_path.absolute())
 
     rebuilt = CountingVisitor()
     rebuilt_geometry.apply(rebuilt)

--- a/Python/Plugins/src/Json.cpp
+++ b/Python/Plugins/src/Json.cpp
@@ -94,7 +94,10 @@ PYBIND11_MODULE(ActsPluginsPythonBindingsJson, json) {
         .def_readwrite("indentation",
                        &TrackingGeometryJsonConverter::Options::indentation)
         .def_readwrite("writeMaterial",
-                       &TrackingGeometryJsonConverter::Options::writeMaterial);
+                       &TrackingGeometryJsonConverter::Options::writeMaterial)
+        .def_readwrite(
+            "compressionLevel",
+            &TrackingGeometryJsonConverter::Options::compressionLevel);
 
     cls.def(py::init([](TrackingGeometryJsonConverter::Config config,
                         Acts::Logging::Level level) {
@@ -125,8 +128,12 @@ PYBIND11_MODULE(ActsPluginsPythonBindingsJson, json) {
             py::arg("gctx"), py::arg("geometry"),
             py::arg("options") =
                 TrackingGeometryJsonConverter::Options::defaultOptions())
-        .def("fromJson", &TrackingGeometryJsonConverter::fromJson,
-             py::arg("gctx"), py::arg("jsonPath"),
+        .def("toFile", &TrackingGeometryJsonConverter::toFile, py::arg("gctx"),
+             py::arg("geometry"), py::arg("path"),
+             py::arg("options") =
+                 TrackingGeometryJsonConverter::Options::defaultOptions())
+        .def("fromFile", &TrackingGeometryJsonConverter::fromFile,
+             py::arg("gctx"), py::arg("path"),
              py::arg("options") =
                  TrackingGeometryJsonConverter::Options::defaultOptions());
   }

--- a/Tests/UnitTests/Plugins/Json/TrackingGeometryJsonConverterTests.cpp
+++ b/Tests/UnitTests/Plugins/Json/TrackingGeometryJsonConverterTests.cpp
@@ -38,13 +38,17 @@
 #include "Acts/Utilities/AxisDefinitions.hpp"
 #include "Acts/Utilities/Logger.hpp"
 #include "ActsPlugins/Json/TrackingGeometryJsonConverter.hpp"
+#include "ActsPlugins/Json/detail/JsonIo.hpp"
 #include "ActsTests/CommonHelpers/CylindricalTrackingGeometry.hpp"
 #include "ActsTests/CommonHelpers/TemporaryDirectory.hpp"
 
 #include <cstddef>
+#include <filesystem>
 #include <fstream>
 #include <functional>
 #include <memory>
+#include <stdexcept>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -368,7 +372,7 @@ BOOST_AUTO_TEST_CASE(TrackingGeometryJsonConverterRoundTrip) {
   }
   BOOST_CHECK(sharedPortalPreserved);
 
-  auto decodedGeometry = converter.fromJson(gctx, jsonPath);
+  auto decodedGeometry = converter.fromFile(gctx, jsonPath);
   BOOST_REQUIRE(decodedGeometry != nullptr);
   BOOST_REQUIRE(decodedGeometry->highestTrackingVolume() != nullptr);
   BOOST_CHECK_EQUAL(decodedGeometry->highestTrackingVolume()->volumeName(),
@@ -414,7 +418,7 @@ BOOST_AUTO_TEST_CASE(TrackingGeometryJsonConverterNavigation) {
     out << encoded.dump(2);
   }
 
-  auto decodedGeometry = converter.fromJson(gctx, jsonPath);
+  auto decodedGeometry = converter.fromFile(gctx, jsonPath);
 
   const auto* htvSource = sourceGeometry->highestTrackingVolume();
   const auto* htvDecoded = decodedGeometry->highestTrackingVolume();
@@ -572,6 +576,101 @@ BOOST_AUTO_TEST_CASE(MultiLayerNavigationPolicyRoundTrip) {
                     restored.indexedGrid().casts[1]);
 
   BOOST_CHECK(policy.config().binExpansion == restored.config().binExpansion);
+}
+
+// Every format toFile() can write must survive a round trip through
+// fromFile(), which detects the format from the content rather than the name.
+BOOST_AUTO_TEST_CASE(TrackingGeometryFileFormatRoundTrip) {
+  using namespace Acts;
+
+  GeometryContext gctx = GeometryContext::dangerouslyDefaultConstruct();
+  CylindricalTrackingGeometry cylindricalGeometryBuilder(gctx, true);
+  auto sourceGeometry = cylindricalGeometryBuilder();
+
+  TrackingGeometryJsonConverter converter;
+  TemporaryDirectory tmpDir{};
+
+  std::vector<std::string> names{"geometry.json", "geometry.cbor"};
+  if (detail::zstdSupported()) {
+    names.emplace_back("geometry.json.zst");
+    names.emplace_back("geometry.cbor.zst");
+  }
+
+  for (const auto& name : names) {
+    BOOST_TEST_CONTEXT("format " << name) {
+      auto path = tmpDir.path() / name;
+      converter.toFile(gctx, *sourceGeometry, path);
+      BOOST_REQUIRE(std::filesystem::exists(path));
+
+      auto decoded = converter.fromFile(gctx, path);
+      BOOST_REQUIRE(decoded != nullptr);
+      BOOST_REQUIRE(decoded->highestTrackingVolume() != nullptr);
+      BOOST_CHECK(*sourceGeometry->highestTrackingVolume() ==
+                  *decoded->highestTrackingVolume());
+    }
+  }
+}
+
+// The compact and compressed encodings should actually be smaller, otherwise
+// the format plumbing is silently writing plain text.
+BOOST_AUTO_TEST_CASE(TrackingGeometryFileFormatSizes) {
+  using namespace Acts;
+
+  GeometryContext gctx = GeometryContext::dangerouslyDefaultConstruct();
+  CylindricalTrackingGeometry cylindricalGeometryBuilder(gctx, true);
+  auto sourceGeometry = cylindricalGeometryBuilder();
+
+  TrackingGeometryJsonConverter converter;
+  TemporaryDirectory tmpDir{};
+
+  auto writeAndSize = [&](const std::string& name) {
+    auto path = tmpDir.path() / name;
+    converter.toFile(gctx, *sourceGeometry, path);
+    return std::filesystem::file_size(path);
+  };
+
+  auto jsonSize = writeAndSize("geometry.json");
+  BOOST_CHECK_LT(writeAndSize("geometry.cbor"), jsonSize);
+
+  if (detail::zstdSupported()) {
+    BOOST_CHECK_LT(writeAndSize("geometry.json.zst"), jsonSize);
+  }
+}
+
+// The format is taken from the file name alone, so a name that does not name
+// a format has to be rejected rather than guessed at.
+BOOST_AUTO_TEST_CASE(TrackingGeometryFileFormatUnknownExtension) {
+  using namespace Acts;
+
+  GeometryContext gctx = GeometryContext::dangerouslyDefaultConstruct();
+  CylindricalTrackingGeometry cylindricalGeometryBuilder(gctx, true);
+  auto sourceGeometry = cylindricalGeometryBuilder();
+
+  TrackingGeometryJsonConverter converter;
+  TemporaryDirectory tmpDir{};
+
+  BOOST_CHECK_THROW(
+      converter.toFile(gctx, *sourceGeometry, tmpDir.path() / "geometry.dat"),
+      std::invalid_argument);
+}
+
+// A file that is neither JSON nor CBOR must be reported as such, rather than
+// surfacing as a confusing parse error.
+BOOST_AUTO_TEST_CASE(TrackingGeometryFileFormatUndecodable) {
+  using namespace Acts;
+
+  GeometryContext gctx = GeometryContext::dangerouslyDefaultConstruct();
+  TrackingGeometryJsonConverter converter;
+  TemporaryDirectory tmpDir{};
+
+  auto path = tmpDir.path() / "garbage.json";
+  {
+    std::ofstream out(path, std::ios::binary);
+    BOOST_REQUIRE(out.good());
+    out << "not a geometry";
+  }
+
+  BOOST_CHECK_THROW(converter.fromFile(gctx, path), std::runtime_error);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Lets the tracking geometry be written and read as CBOR and/or zstd, in addition to plain JSON.