### PR TITLE
ci: Fix workflow trigger leaks

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -2,11 +2,14 @@ name: Builds
 
 on:
   push:
-    # The merge queue also pushes to its temp ref, which separately triggers
-    # merge_group below; without this the two runs share a concurrency group
-    # and cancel-in-progress evicts the PR from the queue (#5884 follow-up).
+    # The release branches (keep in sync with release.yml) carry a tree the
+    # merge queue has already built. The queue's own temp ref triggers
+    # merge_group below; a push run there shares its concurrency group and
+    # evicts the PR from the queue.
     branches-ignore:
-      - "gh-readonly-queue/**"
+      - 'releases'
+      - 'release/**'
+      - 'gh-readonly-queue/**'
   pull_request:
     branches:
       - main

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -2,11 +2,14 @@ name: Checks
 
 on:
   push:
-    # The merge queue also pushes to its temp ref, which separately triggers
-    # merge_group below; without this the two runs share a concurrency group
-    # and cancel-in-progress evicts the PR from the queue (#5884 follow-up).
+    # The release branches (keep in sync with release.yml) carry a tree the
+    # merge queue has already built. The queue's own temp ref triggers
+    # merge_group below; a push run there shares its concurrency group and
+    # evicts the PR from the queue.
     branches-ignore:
-      - "gh-readonly-queue/**"
+      - 'releases'
+      - 'release/**'
+      - 'gh-readonly-queue/**'
   pull_request:
     branches:
       - main

--- a/.github/workflows/detray.yml
+++ b/.github/workflows/detray.yml
@@ -2,11 +2,14 @@ name: Detray
 
 on:
   push:
-    # The merge queue also pushes to its temp ref, which separately triggers
-    # merge_group below; without this the two runs share a concurrency group
-    # and cancel-in-progress evicts the PR from the queue (#5884 follow-up).
+    # The release branches (keep in sync with release.yml) carry a tree the
+    # merge queue has already built. The queue's own temp ref triggers
+    # merge_group below; a push run there shares its concurrency group and
+    # evicts the PR from the queue.
     branches-ignore:
-      - "gh-readonly-queue/**"
+      - 'releases'
+      - 'release/**'
+      - 'gh-readonly-queue/**'
     paths:
       - "Detray/**"
       - ".github/workflows/detray.yml"

--- a/.github/workflows/devcontainer-ci.yml
+++ b/.github/workflows/devcontainer-ci.yml
@@ -2,11 +2,21 @@ name: Devcontainer CI
 
 on:
   push:
+    # The release branches (keep in sync with release.yml) and the merge
+    # queue's temp ref carry a tree that has already been built.
+    branches-ignore:
+      - 'releases'
+      - 'release/**'
+      - 'gh-readonly-queue/**'
   pull_request:
     branches:
       - main
       - 'release/**'
       - 'develop/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,6 +10,10 @@ on:
       - 'releases'
       - 'release/**'
       - 'gh-readonly-queue/**'
+    # Tag pushes drive the versioned deploy in "Repository Dispatch" below,
+    # and a branch filter alone would suppress them.
+    tags:
+      - 'v*'
   pull_request:
     branches:
       - main

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,11 +2,14 @@ name: Docs
 
 on:
   push:
-    # The merge queue also pushes to its temp ref, which separately triggers
-    # merge_group below; without this the two runs share a concurrency group
-    # and cancel-in-progress evicts the PR from the queue (#5884 follow-up).
+    # The release branches (keep in sync with release.yml) carry a tree the
+    # merge queue has already built. The queue's own temp ref triggers
+    # merge_group below; a push run there shares its concurrency group and
+    # evicts the PR from the queue.
     branches-ignore:
-      - "gh-readonly-queue/**"
+      - 'releases'
+      - 'release/**'
+      - 'gh-readonly-queue/**'
   pull_request:
     branches:
       - main

--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -15,15 +15,14 @@ permissions:
 
 jobs:
   check_milestone:
-    if: ${{ github.event.issue.pull_request || github.event.pull_request }}
+    # Open PRs only: this gates merging, and cutting a release re-milestones a
+    # release worth of merged PRs, two events each.
+    if: github.event.pull_request.state == 'open'
 
     runs-on: ubuntu-slim
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
+      # No checkout: the script below is inline.
       - name: "Check for milestone on PR"
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:

--- a/.github/workflows/traccc.yml
+++ b/.github/workflows/traccc.yml
@@ -8,6 +8,12 @@ name: Traccc
 
 on:
   push:
+    # The release branches (keep in sync with release.yml) and the merge
+    # queue's temp ref carry a tree that has already been built.
+    branches-ignore:
+      - 'releases'
+      - 'release/**'
+      - 'gh-readonly-queue/**'
     paths:
       - "Traccc/**"
       - "Detray/**"

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -16,3 +16,8 @@ rules:
   adhoc-packages:
     ignore:
       - devcontainer-ci.yml
+  # The lychee cache is only written by `external-linkcheck`, which never runs
+  # on the tag pushes that publish docs.
+  cache-poisoning:
+    ignore:
+      - docs.yml


### PR DESCRIPTION
Three trigger defects, found while looking at what a release starts.

`Builds`, `Checks`, `Docs`, `Detray`, `Traccc` and `Devcontainer CI` triggered
on a push to any branch, so a push to `releases` rebuilt a tree the merge queue
had already built. `Traccc` and `Devcontainer CI` also missed #5884 and ran on
every merge-queue entry. Ignore `releases`, `release/**` and
`gh-readonly-queue/**` in all six, and give `Devcontainer CI` a concurrency
group. Those three are the only refs outside `main` that upstream ever sees a
push on, so this is equivalent to `branches: [main]` here while leaving CI on a
fork's own branches alone.

`docs.yml` dispatches a versioned deploy on `ref_type == 'tag'`, but a branch
filter with no `tags` filter suppresses tag pushes, so that arm had never run
and `versions.json` on gh-pages lists none. Add `tags: ['v*']`.

Cutting a release re-milestones a release worth of merged PRs, each move
emitting `demilestoned` + `milestoned`, so `Check PR milestone` ran ~96 times on
PRs that were already merged. Restrict it to open PRs and drop its unused
checkout.

Required checks are unaffected: they come from `merge_group` runs.
