### PR TITLE
build: Fix TRACCC_TEST_DATA_DIR Setting, main branch (2026.08.24.)

### DIFF
--- a/Traccc/io/CMakeLists.txt
+++ b/Traccc/io/CMakeLists.txt
@@ -88,5 +88,5 @@ target_link_libraries(
 )
 target_compile_definitions(
     traccc_io
-    PRIVATE TRACCC_TEST_DATA_DIR="${CMAKE_SOURCE_DIR}/data"
+    PRIVATE TRACCC_TEST_DATA_DIR="${CMAKE_CURRENT_SOURCE_DIR}/../data"
 )


### PR DESCRIPTION
Made the TRACCC_TEST_DATA_DIR setting more robust. So that it would be correct also when building traccc as part of Acts.

The relative path being hardcoded like this is not the absolute best. But it didn't seem worth it to go the whole hog, and use CMake's path handling to generate a correct platform specific path. (Windows is not a supported platform for this project at the moment anyway.)