### PR TITLE
perf(detray): Remove unnecessary use of trigonometry for Jacobians

### DIFF
--- a/Detray/core/include/detray/propagator/detail/jacobian_concentric_cylindrical.hpp
+++ b/Detray/core/include/detray/propagator/detail/jacobian_concentric_cylindrical.hpp
@@ -72,9 +72,6 @@ struct jacobian<concentric_cylindrical2D<algebra_t>> {
     bound_to_free_jacobian_submatrix_type bound_pos_to_free_pos_derivative =
         matrix::zero<bound_to_free_jacobian_submatrix_type>();
 
-    const scalar_type r{vector::perp(pos)};
-    const scalar_type phi{vector::phi(pos)};
-
     // Assert the integrity of the local matrix wrt to the globally
     // defined track parameterization.
     static_assert(e_bound_loc1 == e_bound_loc0 + 1);
@@ -88,9 +85,9 @@ struct jacobian<concentric_cylindrical2D<algebra_t>> {
     constexpr unsigned int e_submatrix_free_pos2 = 2u;
 
     getter::element(bound_pos_to_free_pos_derivative, e_submatrix_free_pos0,
-                    e_submatrix_bound_loc0) = -r * math::sin(phi);
+                    e_submatrix_bound_loc0) = -pos[1];
     getter::element(bound_pos_to_free_pos_derivative, e_submatrix_free_pos1,
-                    e_submatrix_bound_loc0) = r * math::cos(phi);
+                    e_submatrix_bound_loc0) = pos[0];
     getter::element(bound_pos_to_free_pos_derivative, e_submatrix_free_pos2,
                     e_submatrix_bound_loc1) = 1.f;
 
@@ -115,8 +112,8 @@ struct jacobian<concentric_cylindrical2D<algebra_t>> {
     free_to_bound_jacobian_submatrix_type free_pos_to_bound_pos_derivative =
         matrix::zero<free_to_bound_jacobian_submatrix_type>();
 
-    const scalar_type r_inv{1.f / vector::perp(pos)};
-    const scalar_type phi{vector::phi(pos)};
+    const scalar_type ir2 =
+        scalar_type{1} / (pos[0] * pos[0] + pos[1] * pos[1]);
 
     // Assert the integrity of the local matrix wrt to the globally
     // defined track parameterization.
@@ -131,9 +128,9 @@ struct jacobian<concentric_cylindrical2D<algebra_t>> {
     constexpr unsigned int e_submatrix_free_pos2 = 2u;
 
     getter::element(free_pos_to_bound_pos_derivative, e_submatrix_bound_loc0,
-                    e_submatrix_free_pos0) = -r_inv * math::sin(phi);
+                    e_submatrix_free_pos0) = -pos[1] * ir2;
     getter::element(free_pos_to_bound_pos_derivative, e_submatrix_bound_loc0,
-                    e_submatrix_free_pos1) = r_inv * math::cos(phi);
+                    e_submatrix_free_pos1) = pos[0] * ir2;
     getter::element(free_pos_to_bound_pos_derivative, e_submatrix_bound_loc1,
                     e_submatrix_free_pos2) = 1.f;
 

--- a/Detray/core/include/detray/propagator/detail/jacobian_engine.hpp
+++ b/Detray/core/include/detray/propagator/detail/jacobian_engine.hpp
@@ -154,13 +154,7 @@ struct jacobian_engine {
     free_to_bound_jacobian_submatrix_type dangle_ddir =
         matrix::zero<free_to_bound_jacobian_submatrix_type>();
 
-    const scalar_type theta{vector::theta(dir)};
-    const scalar_type phi{vector::phi(dir)};
-
-    const scalar_type cos_theta{math::cos(theta)};
-    const scalar_type sin_theta{math::sin(theta)};
-    const scalar_type cos_phi{math::cos(phi)};
-    const scalar_type sin_phi{math::sin(phi)};
+    const scalar_type perp{vector::perp(dir)};
 
     // Assert the integrity of the local matrix wrt to the globally
     // defined track parameterization.
@@ -176,16 +170,19 @@ struct jacobian_engine {
 
     // Set d(phi, theta)/d(n_x, n_y, n_z)
     // @note This codes have a serious bug when theta is equal to zero...
+    const scalar_type iperp = scalar_type{1} / perp;
+    const scalar_type iperp2 = iperp * iperp;
     getter::element(dangle_ddir, e_submatrix_bound_phi, e_submatrix_free_dir0) =
-        -sin_phi / sin_theta;
+        -dir[1] * iperp2;
     getter::element(dangle_ddir, e_submatrix_bound_phi, e_submatrix_free_dir1) =
-        cos_phi / sin_theta;
+        dir[0] * iperp2;
+    const scalar_type zoperp = dir[2] * iperp;
     getter::element(dangle_ddir, e_submatrix_bound_theta,
-                    e_submatrix_free_dir0) = cos_phi * cos_theta;
+                    e_submatrix_free_dir0) = dir[0] * zoperp;
     getter::element(dangle_ddir, e_submatrix_bound_theta,
-                    e_submatrix_free_dir1) = sin_phi * cos_theta;
+                    e_submatrix_free_dir1) = dir[1] * zoperp;
     getter::element(dangle_ddir, e_submatrix_bound_theta,
-                    e_submatrix_free_dir2) = -sin_theta;
+                    e_submatrix_free_dir2) = -perp;
 
     return dangle_ddir;
   }


### PR DESCRIPTION
This commit removes some unnecessary uses of trigonometric functions, including the expensive atan2, in the Jacobian helpers of detray.