### PR TITLE
refactor(detray): Specialize local to global for 2D local pos

### DIFF
--- a/Detray/core/include/detray/algebra/concepts.hpp
+++ b/Detray/core/include/detray/algebra/concepts.hpp
@@ -126,6 +126,7 @@ template <typename T>
 concept transform3D = requires(T trf) {
   // Local type definitions
   requires scalar<typename T::scalar_type>;
+  requires vector2D<typename T::vector2>;
   requires vector3D<typename T::vector3>;
   requires point2D<typename T::point2>;
   requires point3D<typename T::point3>;
@@ -133,8 +134,10 @@ concept transform3D = requires(T trf) {
   // Methods
   trf.rotation();
   trf.translation();
+  trf.point_to_global(typename T::vector2());
   trf.point_to_global(typename T::vector3());
   trf.point_to_local(typename T::vector3());
+  trf.vector_to_global(typename T::vector2());
   trf.vector_to_global(typename T::vector3());
   trf.vector_to_local(typename T::vector3());
 };

--- a/Detray/core/include/detray/algebra/generic/impl/generic_transform3.hpp
+++ b/Detray/core/include/detray/algebra/generic/impl/generic_transform3.hpp
@@ -42,9 +42,10 @@ struct transform3 {
   using matrix44 = matrix_t<scalar_t, 4, 4>;
   static_assert(concepts::square_matrix<matrix44>);
 
+  using vector2 = detray::traits::get_vector_t<matrix44, 2, scalar_t>;
   using vector3 = detray::traits::get_vector_t<matrix44, 3, scalar_t>;
+  using point2 = vector2;
   using point3 = vector3;
-  using point2 = detray::traits::get_vector_t<matrix44, 2, scalar_t>;
 
   /// Function (object) used for accessing a matrix element/block
   using element_getter = detray::traits::element_getter_t<matrix44>;
@@ -220,6 +221,31 @@ struct transform3 {
   /// @param m is the rotation matrix
   /// @param v is the vector to be rotated
   DETRAY_HOST_DEVICE
+  static constexpr vector3 rotate(const matrix44 &m, const vector2 &v) {
+    vector3 ret{0.f, 0.f, 0.f};
+
+    element_getter{}(ret, 0) +=
+        element_getter{}(m, 0, 0) * element_getter{}(v, 0);
+    element_getter{}(ret, 1) +=
+        element_getter{}(m, 1, 0) * element_getter{}(v, 0);
+    element_getter{}(ret, 2) +=
+        element_getter{}(m, 2, 0) * element_getter{}(v, 0);
+
+    element_getter{}(ret, 0) +=
+        element_getter{}(m, 0, 1) * element_getter{}(v, 1);
+    element_getter{}(ret, 1) +=
+        element_getter{}(m, 1, 1) * element_getter{}(v, 1);
+    element_getter{}(ret, 2) +=
+        element_getter{}(m, 2, 1) * element_getter{}(v, 1);
+
+    return ret;
+  }
+
+  /// Rotate a vector into / from a frame
+  ///
+  /// @param m is the rotation matrix
+  /// @param v is the vector to be rotated
+  DETRAY_HOST_DEVICE
   static constexpr vector3 rotate(const matrix44 &m, const vector3 &v) {
     vector3 ret{0.f, 0.f, 0.f};
 
@@ -289,6 +315,16 @@ struct transform3 {
   DETRAY_HOST_DEVICE
   constexpr const matrix44 &matrix_inverse() const { return _data_inv; }
 
+  /// This method transform from a point from the local 2D cartesian frame to
+  /// the global 3D cartesian frame
+  DETRAY_HOST_DEVICE constexpr point3 point_to_global(const point2 &v) const {
+    const vector3 rg = rotate(_data, v);
+
+    return {element_getter{}(rg, 0) + element_getter{}(_data, 0, 3),
+            element_getter{}(rg, 1) + element_getter{}(_data, 1, 3),
+            element_getter{}(rg, 2) + element_getter{}(_data, 2, 3)};
+  }
+
   /// This method transform from a point from the local 3D cartesian frame to
   /// the global 3D cartesian frame
   DETRAY_HOST_DEVICE constexpr point3 point_to_global(const point3 &v) const {
@@ -307,6 +343,13 @@ struct transform3 {
     return {element_getter{}(rg, 0) + element_getter{}(_data_inv, 0, 3),
             element_getter{}(rg, 1) + element_getter{}(_data_inv, 1, 3),
             element_getter{}(rg, 2) + element_getter{}(_data_inv, 2, 3)};
+  }
+
+  /// This method transform from a vector from the local 2D cartesian frame to
+  /// the global 3D cartesian frame
+  DETRAY_HOST_DEVICE constexpr vector3 vector_to_global(
+      const vector2 &v) const {
+    return rotate(_data, v);
   }
 
   /// This method transform from a vector from the local 3D cartesian frame to

--- a/Detray/core/include/detray/geometry/coordinates/cartesian2D.hpp
+++ b/Detray/core/include/detray/geometry/coordinates/cartesian2D.hpp
@@ -59,8 +59,7 @@ struct cartesian2D {
   DETRAY_HOST_DEVICE static inline point3_type local_to_global(
       const transform3_type &trf, const mask_t & /*mask*/, const loc_point &p,
       const vector3_type & /*dir*/) {
-    return trf.point_to_global(
-        point3_type{p[0], p[1], static_cast<scalar_type>(0)});
+    return trf.point_to_global(p);
   }
 
   /// @returns the normal vector in global coordinates

--- a/Detray/core/include/detray/geometry/coordinates/cylindrical2D.hpp
+++ b/Detray/core/include/detray/geometry/coordinates/cylindrical2D.hpp
@@ -22,6 +22,7 @@ struct cylindrical2D {
   using scalar_type = dscalar<algebra_t>;
   using point2_type = dpoint2D<algebra_t>;
   using point3_type = dpoint3D<algebra_t>;
+  using vector2_type = dvector2D<algebra_t>;
   using vector3_type = dvector3D<algebra_t>;
   using transform3_type = dtransform3D<algebra_t>;
 
@@ -79,11 +80,9 @@ struct cylindrical2D {
   DETRAY_HOST_DEVICE static inline vector3_type normal(
       const transform3_type &trf, const point2_type &p, const mask_t &mask) {
     const scalar_type phi{p[0] / mask[mask_t::shape::e_r]};
-    const vector3_type local_normal{math::cos(phi), math::sin(phi),
-                                    static_cast<scalar_type>(0)};
 
     // normal vector in global coordinate
-    return trf.vector_to_global(local_normal);
+    return trf.vector_to_global(vector2_type{math::cos(phi), math::sin(phi)});
   }
 
   /// @returns the normal vector in global coordinates given a local position
@@ -91,11 +90,9 @@ struct cylindrical2D {
   DETRAY_HOST_DEVICE static inline vector3_type normal(
       const transform3_type &trf, const point3_type &p) {
     const scalar_type phi{p[0] / p[2]};
-    const vector3_type local_normal{math::cos(phi), math::sin(phi),
-                                    static_cast<scalar_type>(0)};
 
     // normal vector in global coordinate
-    return trf.vector_to_global(local_normal);
+    return trf.vector_to_global(vector2_type{math::cos(phi), math::sin(phi)});
   }
 
 };  // struct cylindrical2D

--- a/Detray/core/include/detray/geometry/coordinates/cylindrical3D.hpp
+++ b/Detray/core/include/detray/geometry/coordinates/cylindrical3D.hpp
@@ -22,6 +22,7 @@ struct cylindrical3D {
   using scalar_type = dscalar<algebra_t>;
   using point2_type = dpoint2D<algebra_t>;
   using point3_type = dpoint3D<algebra_t>;
+  using vector2_type = dvector2D<algebra_t>;
   using vector3_type = dvector3D<algebra_t>;
   using transform3_type = dtransform3D<algebra_t>;
 
@@ -70,10 +71,8 @@ struct cylindrical3D {
   /// @param p
   DETRAY_HOST_DEVICE static inline vector3_type normal(
       const transform3_type &trf, const point3_type &p) {
-    const vector3_type local_normal{math::cos(p[1]), math::sin(p[1]), 0.f};
-
     // normal vector in global coordinate
-    return trf.vector_to_global(local_normal);
+    return trf.vector_to_global(vector2_type{math::cos(p[1]), math::sin(p[1])});
   }
 
 };  // struct cylindrical3D

--- a/Detray/core/include/detray/geometry/coordinates/polar2D.hpp
+++ b/Detray/core/include/detray/geometry/coordinates/polar2D.hpp
@@ -64,14 +64,16 @@ struct polar2D {
   DETRAY_HOST_DEVICE static inline point3_type local_to_global(
       const transform3_type &trf, const mask_t & /*mask*/, const loc_point &p,
       const vector3_type & /*dir*/) {
-    return polar2D<algebra_t>::local_to_global(
-        trf, {p[0], p[1], static_cast<scalar_type>(0)});
+    const scalar_type x = p[0] * math::cos(p[1]);
+    const scalar_type y = p[0] * math::sin(p[1]);
+
+    return trf.point_to_global(loc_point{x, y});
   }
 
   /// @returns the normal vector in global coordinates
   template <typename mask_t>
   DETRAY_HOST_DEVICE static inline vector3_type normal(
-      const transform3_type &trf, const point2_type & /*loc*/ = {},
+      const transform3_type &trf, const loc_point & /*loc*/ = {},
       const mask_t & /*mask*/ = {}) {
     return trf.z();
   }

--- a/Detray/plugins/algebra/eigen/include/algebra/impl/eigen_transform3.hpp
+++ b/Detray/plugins/algebra/eigen/include/algebra/impl/eigen_transform3.hpp
@@ -53,12 +53,11 @@ struct transform3 {
   template <int N>
   using array_type = eigen::array<scalar_type, N>;
 
-  /// 3-element "vector" type
+  /// Vector and point types
+  using vector2 = array_type<2>;
   using vector3 = array_type<3>;
-  /// Point in 3D space
+  using point2 = vector2;
   using point3 = vector3;
-  /// Point in 2D space
-  using point2 = array_type<2>;
 
   /// 4x4 matrix type
   using matrix44 =
@@ -185,6 +184,19 @@ struct transform3 {
   /// @param m is the rotation matrix
   /// @param v is the vector to be rotated
   template <typename derived_type>
+    requires(Eigen::MatrixBase<derived_type>::RowsAtCompileTime == 2 &&
+             Eigen::MatrixBase<derived_type>::ColsAtCompileTime == 1)
+  DETRAY_HOST_DEVICE static constexpr auto rotate(
+      const Eigen::Transform<scalar_type, 3, Eigen::Affine> &m,
+      const Eigen::MatrixBase<derived_type> &v) {
+    return m.matrix().template block<3, 2>(0, 0) * v;
+  }
+
+  /// Rotate a vector into / from a frame
+  ///
+  /// @param m is the rotation matrix
+  /// @param v is the vector to be rotated
+  template <typename derived_type>
     requires(Eigen::MatrixBase<derived_type>::RowsAtCompileTime == 3 &&
              Eigen::MatrixBase<derived_type>::ColsAtCompileTime == 1)
   DETRAY_HOST_DEVICE static constexpr auto rotate(
@@ -233,6 +245,17 @@ struct transform3 {
     return _data_inv.matrix();
   }
 
+  /// This method transform from a point from the local 2D cartesian frame to
+  /// the global 3D cartesian frame
+  template <typename derived_type>
+    requires(Eigen::MatrixBase<derived_type>::RowsAtCompileTime == 2 &&
+             Eigen::MatrixBase<derived_type>::ColsAtCompileTime == 1)
+  DETRAY_HOST_DEVICE constexpr auto point_to_global(
+      const Eigen::MatrixBase<derived_type> &v) const {
+    return (_data.matrix().template block<3, 2>(0, 0) * v +
+            _data.matrix().template block<3, 1>(0, 3));
+  }
+
   /// This method transform from a point from the local 3D cartesian frame to
   /// the global 3D cartesian frame
   template <typename derived_type>
@@ -251,6 +274,16 @@ struct transform3 {
   DETRAY_HOST_DEVICE constexpr auto point_to_local(
       const Eigen::MatrixBase<derived_type> &v) const {
     return (_data_inv * v);
+  }
+
+  /// This method transform from a vector from the local 3D cartesian frame to
+  /// the global 3D cartesian frame
+  template <typename derived_type>
+    requires(Eigen::MatrixBase<derived_type>::RowsAtCompileTime == 2 &&
+             Eigen::MatrixBase<derived_type>::ColsAtCompileTime == 1)
+  DETRAY_HOST_DEVICE constexpr auto vector_to_global(
+      const Eigen::MatrixBase<derived_type> &v) const {
+    return (_data.linear().matrix().template block<3, 2>(0, 0) * v);
   }
 
   /// This method transform from a vector from the local 3D cartesian frame to

--- a/Detray/plugins/algebra/fastor/include/algebra/impl/fastor_transform3.hpp
+++ b/Detray/plugins/algebra/fastor/include/algebra/impl/fastor_transform3.hpp
@@ -45,12 +45,11 @@ struct transform3 {
   template <std::size_t N>
   using array_type = fastor::Vector<scalar_t, N>;
 
-  /// 3-element "vector" type
+  /// Vector and point types
+  using vector2 = array_type<2>;
   using vector3 = array_type<3>;
-  /// Point in 3D space
+  using point2 = vector2;
   using point3 = vector3;
-  /// Point in 2D space
-  using point2 = array_type<2>;
 
   /// 4x4 matrix type
   using matrix44 = fastor::Matrix<scalar_type, 4UL, 4UL>;
@@ -210,6 +209,18 @@ struct transform3 {
   /// This method transform from a point from the local 3D cartesian frame to
   /// the global 3D cartesian frame
   DETRAY_HOST
+  constexpr point3 point_to_global(const point2 &v) const {
+    Fastor::Tensor<scalar_type, 4> vector_4;
+    vector_4(Fastor::fseq<0, 2>()) = v;
+    vector_4[2] = static_cast<scalar_type>(0);
+    vector_4[3] = static_cast<scalar_type>(1);
+    return Fastor::Tensor<scalar_type, 3>(
+        Fastor::matmul(_data, vector_4)(Fastor::fseq<0, 3>()));
+  }
+
+  /// This method transform from a point from the local 3D cartesian frame to
+  /// the global 3D cartesian frame
+  DETRAY_HOST
   constexpr point3 point_to_global(const point3 &v) const {
     Fastor::Tensor<scalar_type, 4> vector_4;
     vector_4(Fastor::fseq<0, 3>()) = v;
@@ -227,6 +238,18 @@ struct transform3 {
     vector_4[3] = static_cast<scalar_type>(1);
     return Fastor::Tensor<scalar_type, 3>(
         Fastor::matmul(_data_inv, vector_4)(Fastor::fseq<0, 3>()));
+  }
+
+  /// This method transform from a vector from the local 2D cartesian frame to
+  /// the global 3D cartesian frame
+  DETRAY_HOST
+  constexpr point3 vector_to_global(const vector2 &v) const {
+    Fastor::Tensor<scalar_type, 4> vector_4;
+    vector_4(Fastor::fseq<0, 2>()) = v;
+    vector_4[2] = static_cast<scalar_type>(0);
+    vector_4[3] = static_cast<scalar_type>(0);
+    return Fastor::Tensor<scalar_type, 3>(
+        Fastor::matmul(_data, vector_4)(Fastor::fseq<0, 3>()));
   }
 
   /// This method transform from a vector from the local 3D cartesian frame to

--- a/Detray/plugins/algebra/smatrix/include/algebra/impl/smatrix_transform3.hpp
+++ b/Detray/plugins/algebra/smatrix/include/algebra/impl/smatrix_transform3.hpp
@@ -37,12 +37,11 @@ struct transform3 {
   template <unsigned int N>
   using array_type = ROOT::Math::SVector<scalar_t, N>;
 
-  /// 3-element "vector" type
+  /// Vector and point types
+  using vector2 = array_type<2>;
   using vector3 = array_type<3>;
-  /// Point in 3D space
+  using point2 = vector2;
   using point3 = vector3;
-  /// Point in 2D space
-  using point2 = array_type<2>;
 
   /// 4x4 matrix type
   using matrix44 = ROOT::Math::SMatrix<scalar_type, 4, 4>;
@@ -218,6 +217,17 @@ struct transform3 {
   /// This method transform from a point from the local 3D cartesian frame to
   /// the global 3D cartesian frame
   DETRAY_HOST
+  constexpr point3 point_to_global(const point2 &v) const {
+    ROOT::Math::SVector<scalar_type, 4> vector_4;
+    vector_4.Place_at(v, 0);
+    vector_4[3] = static_cast<scalar_type>(1);
+    return ROOT::Math::SVector<scalar_type, 4>(_data * vector_4)
+        .template Sub<point3>(0);
+  }
+
+  /// This method transform from a point from the local 3D cartesian frame to
+  /// the global 3D cartesian frame
+  DETRAY_HOST
   constexpr point3 point_to_global(const point3 &v) const {
     ROOT::Math::SVector<scalar_type, 4> vector_4;
     vector_4.Place_at(v, 0);
@@ -234,6 +244,16 @@ struct transform3 {
     vector_4.Place_at(v, 0);
     vector_4[3] = static_cast<scalar_type>(1);
     return ROOT::Math::SVector<scalar_type, 4>(_data_inv * vector_4)
+        .template Sub<point3>(0);
+  }
+
+  /// This method transform from a vector from the local 2D cartesian frame to
+  /// the global 3D cartesian frame
+  DETRAY_HOST
+  constexpr point3 vector_to_global(const vector2 &v) const {
+    ROOT::Math::SVector<scalar_type, 4> vector_4;
+    vector_4.Place_at(v, 0);
+    return ROOT::Math::SVector<scalar_type, 4>(_data * vector_4)
         .template Sub<point3>(0);
   }
 

--- a/Detray/plugins/algebra/vc_aos/include/algebra/impl/vc_aos_transform3.hpp
+++ b/Detray/plugins/algebra/vc_aos/include/algebra/impl/vc_aos_transform3.hpp
@@ -62,12 +62,11 @@ struct transform3 {
   template <std::size_t N>
   using array_type = array_t<scalar_type, N>;
 
-  /// 3-element "vector" type (does not observe translations)
+  /// Vector and point types
+  using vector2 = algebra::storage::vector<2u, scalar_type, array_t>;
   using vector3 = algebra::storage::vector<3u, scalar_type, array_t>;
-  /// Point in 3D space (does observe translations)
+  using point2 = vector2;
   using point3 = vector3;
-  /// Point in 2D space
-  using point2 = algebra::storage::vector<2u, scalar_type, array_t>;
 
   /// 4x4 matrix type (Last row is {0, 0, 0, 1} and can be omitted)
   using matrix44 = algebra::storage::matrix<array_t, scalar_type, 3u, 4u>;
@@ -249,6 +248,16 @@ struct transform3 {
   ///
   /// @param m is the rotation matrix
   /// @param v is the vector to be rotated
+  template <concepts::vector2D vector2_type>
+  DETRAY_HOST_DEVICE constexpr auto rotate(const matrix44 &m,
+                                           const vector2_type &v) const {
+    return m[e_x] * v[0] + m[e_y] * v[1];
+  }
+
+  /// Rotate a vector into / from a frame
+  ///
+  /// @param m is the rotation matrix
+  /// @param v is the vector to be rotated
   template <concepts::vector3D vector3_type>
   DETRAY_HOST_DEVICE constexpr auto rotate(const matrix44 &m,
                                            const vector3_type &v) const {
@@ -291,6 +300,20 @@ struct transform3 {
   DETRAY_HOST_DEVICE
   constexpr const matrix44 &matrix_inverse() const { return _data_inv; }
 
+  /// This method transform from a point from the local 2D cartesian frame
+  ///  to the global 3D cartesian frame
+  ///
+  /// @tparam point_type 3D point
+  ///
+  /// @param v is the point to be transformed
+  ///
+  /// @return a global point
+  template <concepts::point2D point2_type>
+  DETRAY_HOST_DEVICE constexpr auto point_to_global(
+      const point2_type &p) const {
+    return rotate(_data, p) + _data[e_t];
+  }
+
   /// This method transform from a point from the local 3D cartesian frame
   ///  to the global 3D cartesian frame
   ///
@@ -318,8 +341,22 @@ struct transform3 {
     return rotate(_data_inv, p) + _data_inv[e_t];
   }
 
+  /// This method transform from a vector from the local 2D cartesian frame
+  /// to the global 3D cartesian frame
+  ///
+  /// @tparam vector3_type 3D vector
+  ///
+  /// @param v is the vector to be transformed
+  ///
+  /// @return a vector in global coordinates
+  template <concepts::vector2D vector2_type>
+  DETRAY_HOST_DEVICE constexpr auto vector_to_global(
+      const vector2_type &v) const {
+    return rotate(_data, v);
+  }
+
   /// This method transform from a vector from the local 3D cartesian frame
-  ///  to the global 3D cartesian frame
+  /// to the global 3D cartesian frame
   ///
   /// @tparam vector3_type 3D vector
   ///


### PR DESCRIPTION
In cases where the 2D local position is used, do not compute the local transformation of the z-component. For this, specialized `point_to_global` and  `vector_to_global` methods are added to the transform3 types.
