### PR TITLE
fix: Reset AMVF vertex to the fit prior in every iteration

### DIFF
--- a/Core/include/Acts/Vertexing/AMVFInfo.hpp
+++ b/Core/include/Acts/Vertexing/AMVFInfo.hpp
@@ -29,7 +29,8 @@ struct VertexInfo {
         oldPosition(pos),
         seedPosition(pos) {}
 
-  /// Vertex constraint for fitting procedure
+  /// Prior the fit restarts from in every iteration. If unset, the fitter
+  /// initializes it with the vertex state at the start of the fit.
   Acts::Vertex constraint;
 
   /// Point where all associated tracks are linearized

--- a/Core/src/Vertexing/AdaptiveMultiVertexFitter.cpp
+++ b/Core/src/Vertexing/AdaptiveMultiVertexFitter.cpp
@@ -79,16 +79,20 @@ Result<void> AdaptiveMultiVertexFitter::fit(
         }
       }
 
-      // Check if we use the constraint during the vertex fit
-      if (state.vtxInfoMap[vtx].constraint.fullCovariance() !=
-          SquareMatrix4::Zero()) {
-        const Vertex& constraint = state.vtxInfoMap[vtx].constraint;
-        vtx->setFullPosition(constraint.fullPosition());
-        vtx->setFitQuality(constraint.fitQuality());
-        vtx->setFullCovariance(constraint.fullCovariance());
-      } else if (vtx->fullCovariance() == SquareMatrix4::Zero()) {
-        return VertexingError::NoCovariance;
+      // setWeightsAndUpdate re-adds every track, so each iteration is a full
+      // refit and the vertex has to be reset to its prior first.
+      Vertex& prior = vtxInfo.constraint;
+      if (prior.fullCovariance() == SquareMatrix4::Zero()) {
+        if (vtx->fullCovariance() == SquareMatrix4::Zero()) {
+          return VertexingError::NoCovariance;
+        }
+        prior.setFullPosition(vtx->fullPosition());
+        prior.setFitQuality(vtx->fitQuality());
+        prior.setFullCovariance(vtx->fullCovariance());
       }
+      vtx->setFullPosition(prior.fullPosition());
+      vtx->setFitQuality(prior.fitQuality());
+      vtx->setFullCovariance(prior.fullCovariance());
 
       // Set vertexCompatibility for all TrackAtVertex objects
       // at the current vertex

--- a/Tests/UnitTests/Core/Vertexing/AdaptiveMultiVertexFitterTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/AdaptiveMultiVertexFitterTests.cpp
@@ -446,8 +446,50 @@ BOOST_AUTO_TEST_CASE(time_fitting) {
     BOOST_CHECK_GT(vtxCov(i, i), 0.);
   }
 
-  // Check that the covariance matrix is approximately symmetric
-  CHECK_CLOSE_ABS(vtxCov - vtxCov.transpose(), SquareMatrix4::Zero(), 1e-5);
+  // Check that the covariance matrix is approximately symmetric. Its entries
+  // span several orders of magnitude, hence the relative tolerance.
+  CHECK_CLOSE_ABS(vtxCov - vtxCov.transpose(), SquareMatrix4::Zero(),
+                  1e-3 * vtxCov.cwiseAbs().maxCoeff());
+
+  // Every track must contribute exactly once: ndf is the sum of the track
+  // weights, 2 degrees of freedom each.
+  double sumTrackWeights = 0.;
+  for (const auto& trk : trks) {
+    sumTrackWeights +=
+        state.tracksAtVerticesMap.at(std::make_pair(InputTrack{&trk}, &vtx))
+            .trackWeight;
+  }
+  CHECK_CLOSE_ABS(vtx.fitQuality().second, 2 * sumTrackWeights, 1e-9);
+
+  // An unconstrained fit must equal a fit constrained to the initial vertex
+  // state
+  Vertex constrainedVtx(vtxSeedPos);
+  constrainedVtx.setFullCovariance(initialCovariance);
+
+  Vertex constraint(vtxSeedPos);
+  constraint.setFullCovariance(initialCovariance);
+
+  AdaptiveMultiVertexFitter::State constrainedState(*bField, magFieldContext);
+  VertexInfo& constrainedVtxInfo = constrainedState.vtxInfoMap[&constrainedVtx];
+  constrainedVtxInfo.constraint = constraint;
+
+  for (const auto& trk : trks) {
+    constrainedVtxInfo.trackLinks.push_back(InputTrack{&trk});
+    constrainedState.tracksAtVerticesMap.insert(
+        std::make_pair(std::make_pair(InputTrack{&trk}, &constrainedVtx),
+                       TrackAtVertex(1., trk, InputTrack{&trk})));
+  }
+
+  constrainedState.addVertexToMultiMap(constrainedVtx);
+
+  std::vector<Vertex*> constrainedVtxFitPtr = {&constrainedVtx};
+  auto constrainedRes = fitter.addVtxToFit(
+      constrainedState, constrainedVtxFitPtr, vertexingOptions);
+
+  BOOST_CHECK(constrainedRes.ok());
+
+  CHECK_CLOSE_ABS(constrainedVtx.fullPosition(), vtx.fullPosition(), 1e-9);
+  CHECK_CLOSE_ABS(constrainedVtx.fullCovariance(), vtx.fullCovariance(), 1e-9);
 }
 
 /// @brief Unit test for AdaptiveMultiVertexFitter


### PR DESCRIPTION
Every iteration of the adaptive multi-vertex fit is a full refit:
`setWeightsAndUpdate` re-adds every track to the vertex, so the vertex has to
be reset to the prior of the fit beforehand. That only happened if a constraint
was set. Without one the vertex kept the state of the previous iteration and
every iteration accumulated the information of all tracks once more. After N
iterations the vertex information matrix was inflated by roughly N, i.e. the
covariance was too small by that factor, and chi2/ndf counted every track N
times.

If no constraint is given, the state the vertex has when the fit starts is now
used as the prior. `AdaptiveMultiVertexFinder` always sets a constraint - the
beam spot, or the seed position with `initialVariances` - so its results are
unchanged.
