### PR TITLE
perf(detray): Discard inverse from transformation types

### DIFF
--- a/Detray/core/include/detray/algebra/generic/impl/generic_transform3.hpp
+++ b/Detray/core/include/detray/algebra/generic/impl/generic_transform3.hpp
@@ -63,7 +63,6 @@ struct transform3 {
   /// @name Data objects
   /// @{
   matrix44 _data{generic::math::identity<matrix44>()};
-  matrix44 _data_inv{generic::math::identity<matrix44>()};
 
   /// @}
 
@@ -78,7 +77,7 @@ struct transform3 {
   /// @param z the z axis of the new frame, normal vector for planes
   DETRAY_HOST_DEVICE
   transform3(const vector3 &t, const vector3 &x, const vector3 &y,
-             const vector3 &z, bool get_inverse = true) {
+             const vector3 &z) {
     element_getter{}(_data, 0, 0) = element_getter{}(x, 0);
     element_getter{}(_data, 1, 0) = element_getter{}(x, 1);
     element_getter{}(_data, 2, 0) = element_getter{}(x, 2);
@@ -95,10 +94,6 @@ struct transform3 {
     element_getter{}(_data, 1, 3) = element_getter{}(t, 1);
     element_getter{}(_data, 2, 3) = element_getter{}(t, 2);
     element_getter{}(_data, 3, 3) = 1.f;
-
-    if (get_inverse) {
-      _data_inv = matrix_inversion{}(_data);
-    }
   }
 
   /// Constructor with arguments: t, z, x
@@ -109,9 +104,8 @@ struct transform3 {
   ///
   /// @note y will be constructed by cross product
   DETRAY_HOST_DEVICE
-  transform3(const vector3 &t, const vector3 &z, const vector3 &x,
-             bool get_inverse = true)
-      : transform3(t, x, cross(z, x), z, get_inverse) {}
+  transform3(const vector3 &t, const vector3 &z, const vector3 &x)
+      : transform3(t, x, cross(z, x), z) {}
 
   /// Constructor with arguments: translation
   ///
@@ -134,46 +128,13 @@ struct transform3 {
     element_getter{}(_data, 1, 3) = element_getter{}(t, 1);
     element_getter{}(_data, 2, 3) = element_getter{}(t, 2);
     element_getter{}(_data, 3, 3) = 1.f;
-
-    _data_inv = matrix_inversion{}(_data);
   }
 
   /// Constructor with arguments: matrix
   ///
   /// @param m is the full 4x4 matrix
   DETRAY_HOST_DEVICE
-  explicit transform3(const matrix44 &m) : _data{m} {
-    _data_inv = matrix_inversion{}(_data);
-  }
-
-  /// Constructor with arguments: matrix and its inverse
-  ///
-  /// @param m is the full 4x4 matrix
-  /// @param m_inv is the inverse to m
-  DETRAY_HOST_DEVICE
-  transform3(const matrix44 &m, const matrix44 &m_inv)
-      : _data{m}, _data_inv{m_inv} {
-    // The assertion will not hold for (casts to) int
-    if constexpr (std::floating_point<scalar_type>) {
-      // The concrete type of matrix mult is not available at this point
-      auto prod = generic::math::zero<matrix44>();
-
-      constexpr element_getter elem{};
-
-      for (index_t i = 0; i < 4; ++i) {
-        for (index_t j = 0; j < 4; ++j) {
-          for (index_t k = 0; k < 4; ++k) {
-            elem(prod, k, j) += elem(m, k, i) * elem(m_inv, i, j);
-          }
-        }
-      }
-
-      [[maybe_unused]] constexpr auto epsilon{
-          std::numeric_limits<scalar_type>::epsilon()};
-      assert(algebra::approx_equal(prod, generic::math::identity<matrix44>(),
-                                   16.f * epsilon, 1e-6f));
-    }
-  }
+  explicit transform3(const matrix44 &m) : _data{m} {}
 
   /// Constructor with arguments: matrix as array of scalar
   ///
@@ -196,8 +157,6 @@ struct transform3 {
     element_getter{}(_data, 1, 3) = ma[7];
     element_getter{}(_data, 2, 3) = ma[11];
     element_getter{}(_data, 3, 3) = 1.f;
-
-    _data_inv = matrix_inversion{}(_data);
   }
 
   /// Equality operator
@@ -273,6 +232,38 @@ struct transform3 {
     return ret;
   }
 
+  /// Rotate a vector into / from a frame, but use the inverse of m
+  ///
+  /// @param m is the inverse of the rotation matrix
+  /// @param v is the vector to be rotated
+  DETRAY_HOST_DEVICE
+  static constexpr vector3 rotate_inv(const matrix44 &m, const vector3 &v) {
+    vector3 ret{0.f, 0.f, 0.f};
+
+    element_getter{}(ret, 0) +=
+        element_getter{}(m, 0, 0) * element_getter{}(v, 0);
+    element_getter{}(ret, 1) +=
+        element_getter{}(m, 0, 1) * element_getter{}(v, 0);
+    element_getter{}(ret, 2) +=
+        element_getter{}(m, 0, 2) * element_getter{}(v, 0);
+
+    element_getter{}(ret, 0) +=
+        element_getter{}(m, 1, 0) * element_getter{}(v, 1);
+    element_getter{}(ret, 1) +=
+        element_getter{}(m, 1, 1) * element_getter{}(v, 1);
+    element_getter{}(ret, 2) +=
+        element_getter{}(m, 1, 2) * element_getter{}(v, 1);
+
+    element_getter{}(ret, 0) +=
+        element_getter{}(m, 2, 0) * element_getter{}(v, 2);
+    element_getter{}(ret, 1) +=
+        element_getter{}(m, 2, 1) * element_getter{}(v, 2);
+    element_getter{}(ret, 2) +=
+        element_getter{}(m, 2, 2) * element_getter{}(v, 2);
+
+    return ret;
+  }
+
   /// This method retrieves the rotation of a transform
   DETRAY_HOST_DEVICE
   auto constexpr rotation() const {
@@ -313,7 +304,39 @@ struct transform3 {
 
   /// This method retrieves the 4x4 matrix of an inverse transform
   DETRAY_HOST_DEVICE
-  constexpr const matrix44 &matrix_inverse() const { return _data_inv; }
+  constexpr const matrix44 matrix_inverse() const {
+    matrix44 ret;
+
+    element_getter{}(ret, 0, 0) = element_getter{}(_data, 0, 0);
+    element_getter{}(ret, 0, 1) = element_getter{}(_data, 1, 0);
+    element_getter{}(ret, 0, 2) = element_getter{}(_data, 2, 0);
+    element_getter{}(ret, 1, 0) = element_getter{}(_data, 0, 1);
+    element_getter{}(ret, 1, 1) = element_getter{}(_data, 1, 1);
+    element_getter{}(ret, 1, 2) = element_getter{}(_data, 2, 1);
+    element_getter{}(ret, 2, 0) = element_getter{}(_data, 0, 2);
+    element_getter{}(ret, 2, 1) = element_getter{}(_data, 1, 2);
+    element_getter{}(ret, 2, 2) = element_getter{}(_data, 2, 2);
+
+    element_getter{}(ret, 0, 3) =
+        -(element_getter{}(_data, 0, 0) * element_getter{}(_data, 0, 3) +
+          element_getter{}(_data, 1, 0) * element_getter{}(_data, 1, 3) +
+          element_getter{}(_data, 2, 0) * element_getter{}(_data, 2, 3));
+    element_getter{}(ret, 1, 3) =
+        -(element_getter{}(_data, 0, 1) * element_getter{}(_data, 0, 3) +
+          element_getter{}(_data, 1, 1) * element_getter{}(_data, 1, 3) +
+          element_getter{}(_data, 2, 1) * element_getter{}(_data, 2, 3));
+    element_getter{}(ret, 2, 3) =
+        -(element_getter{}(_data, 0, 2) * element_getter{}(_data, 0, 3) +
+          element_getter{}(_data, 1, 2) * element_getter{}(_data, 1, 3) +
+          element_getter{}(_data, 2, 2) * element_getter{}(_data, 2, 3));
+
+    element_getter{}(ret, 3, 0) = 0;
+    element_getter{}(ret, 3, 1) = 0;
+    element_getter{}(ret, 3, 2) = 0;
+    element_getter{}(ret, 3, 3) = 1;
+
+    return ret;
+  }
 
   /// This method transform from a point from the local 2D cartesian frame to
   /// the global 3D cartesian frame
@@ -338,11 +361,10 @@ struct transform3 {
   /// This method transform from a vector from the global 3D cartesian frame
   /// into the local 3D cartesian frame
   DETRAY_HOST_DEVICE constexpr point3 point_to_local(const point3 &v) const {
-    const vector3 rg = rotate(_data_inv, v);
-
-    return {element_getter{}(rg, 0) + element_getter{}(_data_inv, 0, 3),
-            element_getter{}(rg, 1) + element_getter{}(_data_inv, 1, 3),
-            element_getter{}(rg, 2) + element_getter{}(_data_inv, 2, 3)};
+    const vector3 d{element_getter{}(v, 0) - element_getter{}(_data, 0, 3),
+                    element_getter{}(v, 1) - element_getter{}(_data, 1, 3),
+                    element_getter{}(v, 2) - element_getter{}(_data, 2, 3)};
+    return rotate_inv(_data, d);
   }
 
   /// This method transform from a vector from the local 2D cartesian frame to
@@ -362,7 +384,7 @@ struct transform3 {
   /// This method transform from a vector from the global 3D cartesian frame
   /// into the local 3D cartesian frame
   DETRAY_HOST_DEVICE constexpr vector3 vector_to_local(const vector3 &v) const {
-    return rotate(_data_inv, v);
+    return rotate_inv(_data, v);
   }
 
 };  // struct transform3

--- a/Detray/core/include/detray/algebra/utils/casts.hpp
+++ b/Detray/core/include/detray/algebra/utils/casts.hpp
@@ -99,8 +99,7 @@ template <concepts::scalar scalar_t, concepts::transform3D transform_t>
 DETRAY_HOST_DEVICE constexpr auto cast_to(const transform_t& trf) {
   using new_trf3_t = typename transform_t::template other_type<scalar_t>;
 
-  return new_trf3_t{::detray::algebra::cast_to<scalar_t>(trf.matrix()),
-                    ::detray::algebra::cast_to<scalar_t>(trf.matrix_inverse())};
+  return new_trf3_t{::detray::algebra::cast_to<scalar_t>(trf.matrix())};
 }
 
 }  // namespace detray::algebra

--- a/Detray/plugins/algebra/eigen/include/algebra/impl/eigen_transform3.hpp
+++ b/Detray/plugins/algebra/eigen/include/algebra/impl/eigen_transform3.hpp
@@ -73,7 +73,6 @@ struct transform3 {
   /// @{
 
   Eigen::Transform<scalar_type, 3, Eigen::Affine> _data;
-  Eigen::Transform<scalar_type, 3, Eigen::Affine> _data_inv;
 
   /// @}
 
@@ -85,7 +84,7 @@ struct transform3 {
   /// @param z the z axis of the new frame, normal vector for planes
   DETRAY_HOST_DEVICE
   transform3(const vector3 &t, const vector3 &x, const vector3 &y,
-             const vector3 &z, bool get_inverse = true) {
+             const vector3 &z) {
     _data.setIdentity();
 
     auto &matrix = _data.matrix();
@@ -93,12 +92,6 @@ struct transform3 {
     matrix.template block<3, 1>(0, 1) = y;
     matrix.template block<3, 1>(0, 2) = z;
     matrix.template block<3, 1>(0, 3) = t;
-
-    if (get_inverse) {
-      _data_inv = _data.inverse();
-    } else {
-      _data_inv.setIdentity();
-    }
   }
 
   /// Constructor with arguments: t, z, x
@@ -107,9 +100,8 @@ struct transform3 {
   /// @param z the z axis of the new frame, normal vector for planes
   /// @param x the x axis of the new frame
   DETRAY_HOST_DEVICE
-  transform3(const vector3 &t, const vector3 &z, const vector3 &x,
-             bool get_inverse = true)
-      : transform3(t, x, z.cross(x), z, get_inverse) {}
+  transform3(const vector3 &t, const vector3 &z, const vector3 &x)
+      : transform3(t, x, z.cross(x), z) {}
 
   /// Constructor with arguments: translation
   ///
@@ -120,36 +112,13 @@ struct transform3 {
 
     auto &matrix = _data.matrix();
     matrix.template block<3, 1>(0, 3) = t;
-
-    _data_inv = _data.inverse();
   }
 
   /// Constructor with arguments: matrix
   ///
   /// @param m is the full 4x4 matrix
   DETRAY_HOST_DEVICE
-  explicit transform3(const matrix44 &m) {
-    _data.matrix() = m;
-
-    _data_inv = _data.inverse();
-  }
-
-  /// Constructor with arguments: matrix and its inverse
-  ///
-  /// @param m is the full 4x4 matrix
-  /// @param m_inv is the inverse to m
-  DETRAY_HOST_DEVICE
-  transform3(const matrix44 &m, const matrix44 &m_inv)
-      : _data{m}, _data_inv{m_inv} {
-    // The assertion will not hold for (casts to) int
-    if constexpr (std::floating_point<scalar_type>) {
-      [[maybe_unused]] constexpr auto epsilon{
-          std::numeric_limits<scalar_type>::epsilon()};
-      assert(algebra::approx_equal(matrix44(m * m_inv),
-                                   matrix44(matrix44::Identity()),
-                                   16.f * epsilon, 1e-6f));
-    }
-  }
+  explicit transform3(const matrix44 &m) { _data.matrix() = m; }
 
   /// Constructor with arguments: matrix as std::array of scalar
   ///
@@ -158,16 +127,11 @@ struct transform3 {
   explicit transform3(const array_type<16> &ma) {
     _data.matrix() << ma[0], ma[1], ma[2], ma[3], ma[4], ma[5], ma[6], ma[7],
         ma[8], ma[9], ma[10], ma[11], ma[12], ma[13], ma[14], ma[15];
-
-    _data_inv = _data.inverse();
   }
 
   /// Default constructor: set contents to identity matrices
   DETRAY_HOST_DEVICE
-  transform3() {
-    _data.setIdentity();
-    _data_inv.setIdentity();
-  }
+  transform3() { _data.setIdentity(); }
 
   /// Default constructors
   transform3(const transform3 &rhs) = default;
@@ -240,9 +204,18 @@ struct transform3 {
   constexpr const matrix44 &matrix() const { return _data.matrix(); }
 
   /// This method retrieves the 4x4 matrix of an inverse transform
+  ///
+  /// @note the rotation is assumed to be orthonormal, so that the inverse is
+  /// the transpose of the rotation and @c -R^T*t as the translation.
   DETRAY_HOST_DEVICE
-  constexpr const matrix44 &matrix_inverse() const {
-    return _data_inv.matrix();
+  constexpr matrix44 matrix_inverse() const {
+    matrix44 ret{matrix44::Identity()};
+
+    ret.template block<3, 3>(0, 0) = _data.linear().transpose();
+    ret.template block<3, 1>(0, 3) =
+        -(_data.linear().transpose() * _data.translation());
+
+    return ret;
   }
 
   /// This method transform from a point from the local 2D cartesian frame to
@@ -271,9 +244,9 @@ struct transform3 {
   template <typename derived_type>
     requires(Eigen::MatrixBase<derived_type>::RowsAtCompileTime == 3 &&
              Eigen::MatrixBase<derived_type>::ColsAtCompileTime == 1)
-  DETRAY_HOST_DEVICE constexpr auto point_to_local(
+  DETRAY_HOST_DEVICE constexpr point3 point_to_local(
       const Eigen::MatrixBase<derived_type> &v) const {
-    return (_data_inv * v);
+    return _data.linear().transpose() * (v - _data.translation());
   }
 
   /// This method transform from a vector from the local 3D cartesian frame to
@@ -301,9 +274,9 @@ struct transform3 {
   template <typename derived_type>
     requires(Eigen::MatrixBase<derived_type>::RowsAtCompileTime == 3 &&
              Eigen::MatrixBase<derived_type>::ColsAtCompileTime == 1)
-  DETRAY_HOST_DEVICE constexpr auto vector_to_local(
+  DETRAY_HOST_DEVICE constexpr vector3 vector_to_local(
       const Eigen::MatrixBase<derived_type> &v) const {
-    return (_data_inv.linear() * v);
+    return _data.linear().transpose() * v;
   }
 };  // struct transform3
 

--- a/Detray/plugins/algebra/fastor/include/algebra/impl/fastor_transform3.hpp
+++ b/Detray/plugins/algebra/fastor/include/algebra/impl/fastor_transform3.hpp
@@ -64,16 +64,12 @@ struct transform3 {
   /// @{
 
   matrix44 _data;
-  matrix44 _data_inv;
 
   /// @}
 
   /// Default constructor: identity
   DETRAY_HOST_DEVICE
-  constexpr transform3() {
-    _data.eye();
-    _data_inv.eye();
-  }
+  constexpr transform3() { _data.eye(); }
 
   /// Constructor with arguments: t, x, y, z
   ///
@@ -83,7 +79,7 @@ struct transform3 {
   /// @param z the z axis of the new frame, normal vector for planes
   DETRAY_HOST_DEVICE
   transform3(const vector3 &t, const vector3 &x, const vector3 &y,
-             const vector3 &z, bool get_inverse = true) {
+             const vector3 &z) {
     // The matrix needs to be initialized to the identity matrix first. We
     // only modify the top 4x3 portion of the matrix, so it doesn't matter
     // what values it initially had. However, the bottom row is required to
@@ -95,10 +91,6 @@ struct transform3 {
     _data(Fastor::fseq<0, 3>(), 1) = y;
     _data(Fastor::fseq<0, 3>(), 2) = z;
     _data(Fastor::fseq<0, 3>(), 3) = t;
-
-    if (get_inverse) {
-      _data_inv = Fastor::inverse(_data);
-    }
   }
 
   /// Constructor with arguments: t, z, x
@@ -107,9 +99,8 @@ struct transform3 {
   /// @param z the z axis of the new frame, normal vector for planes
   /// @param x the x axis of the new frame
   DETRAY_HOST
-  transform3(const vector3 &t, const vector3 &z, const vector3 &x,
-             bool get_inverse = true)
-      : transform3(t, x, Fastor::cross(z, x), z, get_inverse) {}
+  transform3(const vector3 &t, const vector3 &z, const vector3 &x)
+      : transform3(t, x, Fastor::cross(z, x), z) {}
 
   /// Constructor with arguments: translation
   ///
@@ -123,45 +114,20 @@ struct transform3 {
     _data.eye2();
 
     _data(Fastor::fseq<0, 3>(), 3) = t;
-
-    _data_inv = Fastor::inverse(_data);
   }
 
   /// Constructor with arguments: matrix
   ///
   /// @param m is the full 4x4 matrix
   DETRAY_HOST
-  explicit transform3(const matrix44 &m) : _data{m} {
-    _data_inv = Fastor::inverse(_data);
-  }
-
-  /// Constructor with arguments: matrix and its inverse
-  ///
-  /// @param m is the full 4x4 matrix
-  /// @param m_inv is the inverse to m
-  DETRAY_HOST
-  transform3(const matrix44 &m, const matrix44 &m_inv)
-      : _data{m}, _data_inv{m_inv} {
-    // The assertion will not hold for (casts to) int
-    if constexpr (std::floating_point<scalar_type>) {
-      [[maybe_unused]] constexpr auto epsilon{
-          std::numeric_limits<scalar_type>::epsilon()};
-
-      [[maybe_unused]] matrix44 identity_matrix;
-      identity_matrix.eye2();
-      assert(algebra::approx_equal(m * m_inv, identity_matrix, 16.f * epsilon,
-                                   1e-6f));
-    }
-  }
+  explicit transform3(const matrix44 &m) : _data{m} {}
 
   /// Constructor with arguments: matrix as Fastor::Tensor<scalar_t, 16> of
   /// scalars
   ///
   /// @param ma is the full 4x4 matrix as a 16-element array
   DETRAY_HOST
-  explicit transform3(const array_type<16> &ma) : _data{ma} {
-    _data_inv = Fastor::inverse(_data);
-  }
+  explicit transform3(const array_type<16> &ma) : _data{ma} {}
 
   /// Default constructors
   transform3(const transform3 &rhs) = default;
@@ -203,8 +169,22 @@ struct transform3 {
   constexpr matrix44 matrix() const { return _data; }
 
   /// This method retrieves the 4x4 matrix of an inverse transform
+  ///
+  /// @note the rotation is assumed to be orthonormal, so that the inverse is
+  /// the transpose of the rotation and @c -R^T*t as the translation.
   DETRAY_HOST
-  constexpr matrix44 matrix_inverse() const { return _data_inv; }
+  constexpr matrix44 matrix_inverse() const {
+    matrix44 ret;
+    ret.eye2();
+
+    const Fastor::Tensor<scalar_type, 3, 3> rot_inv{
+        Fastor::transpose(rotation())};
+
+    ret(Fastor::fseq<0, 3>(), Fastor::fseq<0, 3>()) = rot_inv;
+    ret(Fastor::fseq<0, 3>(), 3) = -Fastor::matmul(rot_inv, translation());
+
+    return ret;
+  }
 
   /// This method transform from a point from the local 3D cartesian frame to
   /// the global 3D cartesian frame
@@ -233,11 +213,9 @@ struct transform3 {
   /// into the local 3D cartesian frame
   DETRAY_HOST
   constexpr point3 point_to_local(const point3 &v) const {
-    Fastor::Tensor<scalar_type, 4> vector_4;
-    vector_4(Fastor::fseq<0, 3>()) = v;
-    vector_4[3] = static_cast<scalar_type>(1);
-    return Fastor::Tensor<scalar_type, 3>(
-        Fastor::matmul(_data_inv, vector_4)(Fastor::fseq<0, 3>()));
+    const vector3 d{v - translation()};
+
+    return point3{Fastor::matmul(Fastor::transpose(rotation()), d)};
   }
 
   /// This method transform from a vector from the local 2D cartesian frame to
@@ -267,11 +245,7 @@ struct transform3 {
   /// into the local 3D cartesian frame
   DETRAY_HOST
   constexpr point3 vector_to_local(const vector3 &v) const {
-    Fastor::Tensor<scalar_type, 4> vector_4;
-    vector_4(Fastor::fseq<0, 3>()) = v;
-    vector_4[3] = static_cast<scalar_type>(0);
-    return Fastor::Tensor<scalar_type, 3>(
-        Fastor::matmul(_data_inv, vector_4)(Fastor::fseq<0, 3>()));
+    return point3{Fastor::matmul(Fastor::transpose(rotation()), v)};
   }
 };  // struct transform3
 

--- a/Detray/plugins/algebra/smatrix/include/algebra/impl/smatrix_transform3.hpp
+++ b/Detray/plugins/algebra/smatrix/include/algebra/impl/smatrix_transform3.hpp
@@ -56,7 +56,6 @@ struct transform3 {
   /// @{
 
   matrix44 _data = ROOT::Math::SMatrixIdentity();
-  matrix44 _data_inv = ROOT::Math::SMatrixIdentity();
 
   /// @}
 
@@ -68,7 +67,7 @@ struct transform3 {
   ///  @param z the z axis of the new frame, normal vector for planes
   DETRAY_HOST_DEVICE
   transform3(const vector3 &t, const vector3 &x, const vector3 &y,
-             const vector3 &z, bool get_inverse = true) {
+             const vector3 &z) {
     _data(0, 0) = x[0];
     _data(1, 0) = x[1];
     _data(2, 0) = x[2];
@@ -81,12 +80,6 @@ struct transform3 {
     _data(0, 3) = t[0];
     _data(1, 3) = t[1];
     _data(2, 3) = t[2];
-
-    if (get_inverse) {
-      int ifail = 0;
-      _data_inv = _data.Inverse(ifail);
-      SMATRIX_CHECK(ifail);
-    }
   }
 
   /// Constructor with arguments: t, z, x
@@ -95,9 +88,8 @@ struct transform3 {
   /// @param z the z axis of the new frame, normal vector for planes
   /// @param x the x axis of the new frame
   DETRAY_HOST
-  transform3(const vector3 &t, const vector3 &z, const vector3 &x,
-             bool get_inverse = true)
-      : transform3(t, x, ROOT::Math::Cross(z, x), z, get_inverse) {}
+  transform3(const vector3 &t, const vector3 &z, const vector3 &x)
+      : transform3(t, x, ROOT::Math::Cross(z, x), z) {}
 
   /// Constructor with arguments: translation
   ///
@@ -107,40 +99,13 @@ struct transform3 {
     _data(0, 3) = t[0];
     _data(1, 3) = t[1];
     _data(2, 3) = t[2];
-
-    int ifail = 0;
-    _data_inv = _data.Inverse(ifail);
-    SMATRIX_CHECK(ifail);
   }
 
   /// Constructor with arguments: matrix
   ///
   /// @param m is the full 4x4 matrix
   DETRAY_HOST
-  explicit transform3(const matrix44 &m) {
-    _data = m;
-
-    int ifail = 0;
-    _data_inv = _data.Inverse(ifail);
-    SMATRIX_CHECK(ifail);
-  }
-
-  /// Constructor with arguments: matrix and its inverse
-  ///
-  /// @param m is the full 4x4 matrix
-  /// @param m_inv is the inverse to m
-  DETRAY_HOST
-  transform3(const matrix44 &m, const matrix44 &m_inv)
-      : _data{m}, _data_inv{m_inv} {
-    // The assertion will not hold for (casts to) int
-    if constexpr (std::floating_point<scalar_type>) {
-      [[maybe_unused]] constexpr auto epsilon{
-          std::numeric_limits<scalar_type>::epsilon()};
-      assert(algebra::approx_equal(matrix44(m * m_inv),
-                                   matrix44(ROOT::Math::SMatrixIdentity()),
-                                   16.f * epsilon, 1e-6f));
-    }
-  }
+  explicit transform3(const matrix44 &m) { _data = m; }
 
   /// Constructor with arguments: matrix as ROOT::Math::SVector<scalar_t, 16>
   /// of scalars
@@ -164,11 +129,6 @@ struct transform3 {
     _data(1, 3) = ma[7];
     _data(2, 3) = ma[11];
     _data(3, 3) = ma[15];
-
-    int ifail = 0;
-    _data_inv = _data.Inverse(ifail);
-    // Ignore failures here, since the unit test does manage to trigger an
-    // error from ROOT in this place...
   }
 
   /// Default constructors
@@ -211,8 +171,24 @@ struct transform3 {
   constexpr matrix44 matrix() const { return _data; }
 
   /// This method retrieves the 4x4 matrix of an inverse transform
+  ///
+  /// @note the rotation is assumed to be orthonormal, so that the inverse is
+  /// the transpose of the rotation and @c -R^T*t as the translation.
   DETRAY_HOST
-  constexpr matrix44 matrix_inverse() const { return _data_inv; }
+  constexpr matrix44 matrix_inverse() const {
+    matrix44 ret = ROOT::Math::SMatrixIdentity();
+
+    const vector3 t{translation()};
+
+    for (unsigned int i = 0u; i < 3u; ++i) {
+      for (unsigned int j = 0u; j < 3u; ++j) {
+        ret(i, j) = _data(j, i);
+      }
+      ret(i, 3) = -ROOT::Math::Dot(_data.template SubCol<vector3>(i, 0), t);
+    }
+
+    return ret;
+  }
 
   /// This method transform from a point from the local 3D cartesian frame to
   /// the global 3D cartesian frame
@@ -240,11 +216,10 @@ struct transform3 {
   /// into the local 3D cartesian frame
   DETRAY_HOST
   constexpr point3 point_to_local(const point3 &v) const {
-    ROOT::Math::SVector<scalar_type, 4> vector_4;
-    vector_4.Place_at(v, 0);
-    vector_4[3] = static_cast<scalar_type>(1);
-    return ROOT::Math::SVector<scalar_type, 4>(_data_inv * vector_4)
-        .template Sub<point3>(0);
+    const vector3 d{v - translation()};
+
+    return point3{ROOT::Math::Dot(x(), d), ROOT::Math::Dot(y(), d),
+                  ROOT::Math::Dot(z(), d)};
   }
 
   /// This method transform from a vector from the local 2D cartesian frame to
@@ -271,10 +246,8 @@ struct transform3 {
   /// into the local 3D cartesian frame
   DETRAY_HOST
   constexpr point3 vector_to_local(const vector3 &v) const {
-    ROOT::Math::SVector<scalar_type, 4> vector_4;
-    vector_4.Place_at(v, 0);
-    return ROOT::Math::SVector<scalar_type, 4>(_data_inv * vector_4)
-        .template Sub<point3>(0);
+    return point3{ROOT::Math::Dot(x(), v), ROOT::Math::Dot(y(), v),
+                  ROOT::Math::Dot(z(), v)};
   }
 };  // struct transform3
 

--- a/Detray/plugins/algebra/vc_aos/include/algebra/impl/vc_aos_transform3.hpp
+++ b/Detray/plugins/algebra/vc_aos/include/algebra/impl/vc_aos_transform3.hpp
@@ -85,14 +85,11 @@ struct transform3 {
   /// @{
 
   matrix44 _data;
-  matrix44 _data_inv;
 
   /// @}
   /// Default constructor: identity
   DETRAY_HOST_DEVICE
-  constexpr transform3()
-      : _data{algebra::storage::identity<matrix44>()},
-        _data_inv{algebra::storage::identity<matrix44>()} {}
+  constexpr transform3() : _data{algebra::storage::identity<matrix44>()} {}
 
   /// Constructor with arguments: t, x, y, z
   ///
@@ -103,7 +100,7 @@ struct transform3 {
   DETRAY_HOST_DEVICE
   transform3(const vector3 &t, const vector3 &x, const vector3 &y,
              const vector3 &z)
-      : _data{x, y, z, t}, _data_inv{invert(_data)} {}
+      : _data{x, y, z, t} {}
 
   /// Constructor with arguments: t, z, x
   ///
@@ -126,29 +123,13 @@ struct transform3 {
   DETRAY_HOST_DEVICE
   explicit transform3(const vector3 &t)
       : _data{column_t{1.f, 0.f, 0.f}, column_t{0.f, 1.f, 0.f},
-              column_t{0.f, 0.f, 1.f}, t},
-        _data_inv{invert(_data)} {}
+              column_t{0.f, 0.f, 1.f}, t} {}
 
   /// Constructor with arguments: matrix
   ///
   /// @param m is the full 4x4 matrix with simd-vector elements
   DETRAY_HOST_DEVICE
-  explicit transform3(const matrix44 &m) : _data{m}, _data_inv{invert(_data)} {}
-
-  /// Constructor with arguments: matrix and its inverse
-  ///
-  /// @param m is the full 4x4 matrix
-  /// @param m_inv is the inverse to m
-  DETRAY_HOST_DEVICE
-  transform3(const matrix44 &m, const matrix44 &m_inv)
-      : _data{m}, _data_inv{m_inv} {
-    // The assertion will not hold for (casts to) int
-    if constexpr (std::floating_point<scalar_type>) {
-      [[maybe_unused]] constexpr auto epsilon{
-          std::numeric_limits<float>::epsilon()};
-      assert(algebra::approx_equal(invert(m), m_inv, 16.f * epsilon, 1e-6f));
-    }
-  }
+  explicit transform3(const matrix44 &m) : _data{m} {}
 
   /// Constructor with arguments: matrix as std::array of scalar
   ///
@@ -161,8 +142,6 @@ struct transform3 {
     _data[e_y] = column_t{ma[1], ma[5], ma[9]};
     _data[e_z] = column_t{ma[2], ma[6], ma[10]};
     _data[e_t] = column_t{ma[3], ma[7], ma[11]};
-
-    _data_inv = invert(_data);
   }
 
   /// Defaults
@@ -264,6 +243,18 @@ struct transform3 {
     return m[e_x] * v[0] + m[e_y] * v[1] + m[e_z] * v[2];
   }
 
+  /// Rotate a vector into / from a frame, using the transpose of the rotation
+  ///
+  /// @param m is the matrix whose rotation part is transposed
+  /// @param v is the vector to be rotated
+  template <concepts::vector3D vector3_type>
+  DETRAY_HOST_DEVICE constexpr column_t rotate_inv(
+      const matrix44 &m, const vector3_type &v) const {
+    return column_t{m[e_x][0] * v[0] + m[e_x][1] * v[1] + m[e_x][2] * v[2],
+                    m[e_y][0] * v[0] + m[e_y][1] * v[1] + m[e_y][2] * v[2],
+                    m[e_z][0] * v[0] + m[e_z][1] * v[1] + m[e_z][2] * v[2]};
+  }
+
   /// This method retrieves the rotation of a transform
   DETRAY_HOST_DEVICE
   constexpr auto rotation() const {
@@ -297,8 +288,20 @@ struct transform3 {
   constexpr const matrix44 &matrix() const { return _data; }
 
   /// This method retrieves the 4x4 matrix of an inverse transform
+  ///
+  /// @note the rotation is assumed to be orthonormal, so that the inverse is
+  /// the transpose of the rotation and @c -R^T*t as the translation.
   DETRAY_HOST_DEVICE
-  constexpr const matrix44 &matrix_inverse() const { return _data_inv; }
+  constexpr matrix44 matrix_inverse() const {
+    matrix44 i;
+
+    i[e_x] = column_t{_data[e_x][0], _data[e_y][0], _data[e_z][0]};
+    i[e_y] = column_t{_data[e_x][1], _data[e_y][1], _data[e_z][1]};
+    i[e_z] = column_t{_data[e_x][2], _data[e_y][2], _data[e_z][2]};
+    i[e_t] = scalar_type(-1.f) * rotate_inv(_data, _data[e_t]);
+
+    return i;
+  }
 
   /// This method transform from a point from the local 2D cartesian frame
   ///  to the global 3D cartesian frame
@@ -338,7 +341,9 @@ struct transform3 {
   /// @return a local point
   template <concepts::point3D point3_type>
   DETRAY_HOST_DEVICE constexpr auto point_to_local(const point3_type &p) const {
-    return rotate(_data_inv, p) + _data_inv[e_t];
+    return rotate_inv(_data,
+                      column_t{p[0] - _data[e_t][0], p[1] - _data[e_t][1],
+                               p[2] - _data[e_t][2]});
   }
 
   /// This method transform from a vector from the local 2D cartesian frame
@@ -380,7 +385,7 @@ struct transform3 {
   template <concepts::vector3D vector3_type>
   DETRAY_HOST_DEVICE constexpr auto vector_to_local(
       const vector3_type &v) const {
-    return rotate(_data_inv, v);
+    return rotate_inv(_data, v);
   }
 };  // struct transform3
 

--- a/Detray/tests/integration_tests/cpu/detectors/wire_chamber_navigation.cpp
+++ b/Detray/tests/integration_tests/cpu/detectors/wire_chamber_navigation.cpp
@@ -90,7 +90,7 @@ int main(int argc, char **argv) {
   cfg_hel_scan.name("wire_chamber_helix_scan");
   // Let the Newton algorithm dynamically choose tol. based on approx. error
   cfg_hel_scan.mask_tolerance(detray::detail::invalid_value<scalar>());
-  cfg_hel_scan.track_generator().n_tracks(10000u);
+  cfg_hel_scan.track_generator().n_tracks(1000u);
   cfg_hel_scan.track_generator().randomize_charge(true);
   cfg_hel_scan.track_generator().eta_range(-1.f, 1.f);
   // TODO: Fails for smaller momenta


### PR DESCRIPTION
The transformations we keep in our detray detector carry an explicitly reified inverse matrix, but these transformations are rigid, which means that the inverse can be trivially computed. If the transformation matrix is [[R, t], [0, 1]] in homogeneous format, the inverse is [[R^T, -R^T*t], [0, 1]] which we can compute trivially by swapping the matrix elements. Thus, we need not store the inverse matrix at all.