### PR TITLE
feat: HIP Track Fitting, main branch (2026.08.25.)

### DIFF
--- a/Traccc/device/common/include/traccc/fitting/device/impl/kalman_fitting_algorithm.ipp
+++ b/Traccc/device/common/include/traccc/fitting/device/impl/kalman_fitting_algorithm.ipp
@@ -7,6 +7,9 @@
 
 #pragma once
 
+// Project include(s).
+#include "traccc/utils/detector_buffer_bfield_visitor.hpp"
+
 // System include(s).
 #include <cassert>
 

--- a/Traccc/device/hip/CMakeLists.txt
+++ b/Traccc/device/hip/CMakeLists.txt
@@ -21,6 +21,8 @@ find_package(HIPToolkit REQUIRED)
 add_library(
     traccc_hip_device
     OBJECT
+    # Utility code.
+    "src/utils/magnetic_field_types.hpp"
     # Clusterization code.
     "include/traccc/hip/clusterization/clusterization_algorithm.hpp"
     "src/clusterization/clusterization_algorithm.hip"
@@ -30,6 +32,12 @@ add_library(
     "src/clusterization/kernels/reify_cluster_data.hip"
     "include/traccc/hip/clusterization/measurement_sorting_algorithm.hpp"
     "src/clusterization/measurement_sorting_algorithm.hip"
+    # Track fitting code.
+    "include/traccc/hip/fitting/kalman_fitting_algorithm.hpp"
+    "src/fitting/kalman_fitting_algorithm_fit_backward_kernel.hip"
+    "src/fitting/kalman_fitting_algorithm_fit_forward_kernel.hip"
+    "src/fitting/kalman_fitting_algorithm_fit_prelude_kernel.hip"
+    "src/fitting/kalman_fitting_algorithm_prepare_track_fit_order.hip"
 )
 target_include_directories(
     traccc_hip_device
@@ -37,7 +45,7 @@ target_include_directories(
 )
 target_link_libraries(
     traccc_hip_device
-    PUBLIC traccc::core traccc::hip_utils vecmem::core
+    PUBLIC traccc::core traccc::hip_utils vecmem::core covfie::core covfie::hip
     PRIVATE HIP::hiprt traccc::device_common
 )
 set_target_properties(
@@ -58,6 +66,8 @@ elseif("${CMAKE_HIP_PLATFORM}" STREQUAL "nvidia")
 endif()
 
 traccc_add_library( traccc_hip hip TYPE SHARED
+   # Track fitting code.
+   "src/fitting/kalman_fitting_algorithm.cpp"
    # Utility code.
    "include/traccc/hip/utils/algorithm_base.hpp"
    "src/utils/algorithm_base.cpp"

--- a/Traccc/device/hip/include/traccc/hip/fitting/kalman_fitting_algorithm.hpp
+++ b/Traccc/device/hip/include/traccc/hip/fitting/kalman_fitting_algorithm.hpp
@@ -1,0 +1,93 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Library include(s).
+#include "traccc/hip/utils/algorithm_base.hpp"
+#include "traccc/hip/utils/stream_wrapper.hpp"
+
+// Project include(s).
+#include "traccc/fitting/device/kalman_fitting_algorithm.hpp"
+
+namespace traccc::hip {
+
+/// Kalman filter based track fitting algorithm using HIP
+class kalman_fitting_algorithm : public device::kalman_fitting_algorithm,
+                                 public hip::algorithm_base {
+ public:
+  /// Constructor with the algorithm's configuration
+  ///
+  /// @param config The configuration object
+  /// @param mr     The memory resource(s) used by the algorithm
+  /// @param copy   The copy object used by the algorithm
+  /// @param str    The HIP stream used by the algorithm
+  /// @param logger The logger used by the algorithm
+  ///
+  kalman_fitting_algorithm(
+      const config_type& config, const traccc::memory_resource& mr,
+      const vecmem::copy& copy, const stream_wrapper& str,
+      std::unique_ptr<const Logger> logger = getDummyLogger().clone());
+
+ private:
+  /// @name Function(s) implemented from @c device::kalman_fitting_algorithm
+  /// @{
+
+  /// Prepare a buffer with the index order with which to fit the tracks
+  ///
+  /// @param[in] tracks The tracks to be fitted
+  /// @param[out] track_sort_keys Buffer storing temporary sorting keys
+  /// @param[out] track_indices The buffer to write the fitting order into
+  ///
+  void prepare_track_fit_order(
+      const edm::track_collection<default_algebra>::const_view& tracks,
+      vecmem::data::vector_view<device::sort_key>& track_sort_keys,
+      vecmem::data::vector_view<unsigned int>& track_indices) const override;
+
+  /// Kernel to prepare the fitting payloads
+  ///
+  /// @param payload The payload for the kernel(s)
+  ///
+  void fit_prelude_kernel(
+      const device::fit_prelude_payload& payload) const override;
+
+  /// Function preparing the fitting payload
+  ///
+  /// @param det             The detector buffer to prepare the payload for
+  /// @param field           The magnetic field to prepare the payload for
+  /// @param n_surfaces      The number of surfaces for each track to be
+  ///                        fitted
+  /// @param payload         The (non-templated) payload for the kernel(s)
+  ///
+  /// @return The prepared payload for the fitting kernel(s)
+  ///
+  fit_payload prepare_fit_payload(
+      const detector_buffer& det, const magnetic_field& field,
+      const std::vector<unsigned int>& n_surfaces,
+      const device::fit_payload& payload) const override;
+
+  /// Function launching the "forward fitting" kernel(s)
+  ///
+  /// @param config The fitting configuration
+  /// @param payload The payload for the fitting kernel(s)
+  ///
+  void fit_forward_kernel(const fitting_config& config,
+                          const fit_payload& payload) const override;
+
+  /// Function launching the "backward fitting" kernel(s)
+  ///
+  /// @param config The fitting configuration
+  /// @param payload The payload for the fitting kernel(s)
+  ///
+  void fit_backward_kernel(const fitting_config& config,
+                           const fit_payload& payload) const override;
+
+  /// @}
+
+};  // class kalman_fitting_algorithm
+
+}  // namespace traccc::hip

--- a/Traccc/device/hip/src/fitting/kalman_fitting_algorithm.cpp
+++ b/Traccc/device/hip/src/fitting/kalman_fitting_algorithm.cpp
@@ -1,0 +1,35 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "traccc/hip/fitting/kalman_fitting_algorithm.hpp"
+
+#include "../utils/magnetic_field_types.hpp"
+#include "../utils/utils.hpp"
+
+// Project include(s).
+#include "traccc/geometry/detector.hpp"
+
+namespace traccc::hip {
+
+kalman_fitting_algorithm::kalman_fitting_algorithm(
+    const config_type& config, const traccc::memory_resource& mr,
+    const vecmem::copy& copy, const stream_wrapper& str,
+    std::unique_ptr<const Logger> logger)
+    : device::kalman_fitting_algorithm{config, mr, copy, std::move(logger)},
+      hip::algorithm_base{str} {}
+
+auto kalman_fitting_algorithm::prepare_fit_payload(
+    const detector_buffer& det, const magnetic_field& field,
+    const std::vector<unsigned int>& n_surfaces,
+    const device::fit_payload& payload) const -> fit_payload {
+  return prepare_fit_payload_helper<detector_type_list,
+                                    hip::bfield_type_list<scalar>>(
+      det, field, n_surfaces, payload);
+}
+
+}  // namespace traccc::hip

--- a/Traccc/device/hip/src/fitting/kalman_fitting_algorithm_fit_backward_kernel.hip
+++ b/Traccc/device/hip/src/fitting/kalman_fitting_algorithm_fit_backward_kernel.hip
@@ -1,0 +1,68 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "../utils/global_index.hpp"
+#include "../utils/hip_error_handling.hpp"
+#include "../utils/magnetic_field_types.hpp"
+#include "../utils/utils.hpp"
+#include "traccc/hip/fitting/kalman_fitting_algorithm.hpp"
+
+// Project include(s).
+#include "traccc/fitting/details/kalman_fitting_types.hpp"
+#include "traccc/fitting/device/fit_backward.hpp"
+#include "traccc/geometry/detector.hpp"
+#include "traccc/utils/detector_buffer_bfield_visitor.hpp"
+
+// HIP include(s).
+#include <hip/hip_runtime.h>
+
+namespace traccc::hip {
+namespace kernels {
+
+template <typename fitter_t>
+__global__ __launch_bounds__(128) void fit_backward(
+    const fitting_config cfg, const device::fit_payload payload,
+    const device::fit_tpayload<
+        typename fitter_t::detector_type::const_view_type,
+        typename fitter_t::bfield_type, typename fitter_t::surface_type>*
+        tpayload) {
+  device::fit_backward<fitter_t>(details::global_index1(), cfg, payload,
+                                 *tpayload);
+}
+
+}  // namespace kernels
+
+void kalman_fitting_algorithm::fit_backward_kernel(
+    const fitting_config& config, const fit_payload& payload) const {
+  return detector_buffer_magnetic_field_visitor<detector_type_list,
+                                                hip::bfield_type_list<scalar>>(
+      payload.detector, payload.field,
+      [&]<typename detector_traits_t, typename bfield_view_t>(
+          const typename detector_traits_t::view&, const bfield_view_t&) {
+        // Get the number of tracks.
+        const unsigned int n_tracks = payload.payload.tracks.tracks.capacity();
+        assert(n_tracks == copy().get_size(payload.payload.tracks.tracks));
+
+        // Launch parameters for the kernel.
+        const unsigned int nThreads = warp_size() * 4;
+        const unsigned int nBlocks = (n_tracks + nThreads - 1) / nThreads;
+
+        // Fitter type to use.
+        using fitter_t =
+            traccc::details::kalman_fitter_t<typename detector_traits_t::device,
+                                             bfield_view_t>;
+
+        // Run the track fitting
+        hipLaunchKernelGGL(kernels::fit_backward<fitter_t>, nBlocks, nThreads,
+                           0, details::get_stream(stream()), config,
+                           payload.payload, payload.get_tpayload<fitter_t>());
+        TRACCC_HIP_ERROR_CHECK(hipGetLastError());
+      });
+}
+
+}  // namespace traccc::hip

--- a/Traccc/device/hip/src/fitting/kalman_fitting_algorithm_fit_forward_kernel.hip
+++ b/Traccc/device/hip/src/fitting/kalman_fitting_algorithm_fit_forward_kernel.hip
@@ -1,0 +1,68 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "../utils/global_index.hpp"
+#include "../utils/hip_error_handling.hpp"
+#include "../utils/magnetic_field_types.hpp"
+#include "../utils/utils.hpp"
+#include "traccc/hip/fitting/kalman_fitting_algorithm.hpp"
+
+// Project include(s).
+#include "traccc/fitting/details/kalman_fitting_types.hpp"
+#include "traccc/fitting/device/fit_forward.hpp"
+#include "traccc/geometry/detector.hpp"
+#include "traccc/utils/detector_buffer_bfield_visitor.hpp"
+
+// HIP include(s).
+#include <hip/hip_runtime.h>
+
+namespace traccc::hip {
+namespace kernels {
+
+template <typename fitter_t>
+__global__ __launch_bounds__(128) void fit_forward(
+    const fitting_config cfg, const device::fit_payload payload,
+    const device::fit_tpayload<
+        typename fitter_t::detector_type::const_view_type,
+        typename fitter_t::bfield_type, typename fitter_t::surface_type>*
+        tpayload) {
+  device::fit_forward<fitter_t>(details::global_index1(), cfg, payload,
+                                *tpayload);
+}
+
+}  // namespace kernels
+
+void kalman_fitting_algorithm::fit_forward_kernel(
+    const fitting_config& config, const fit_payload& payload) const {
+  return detector_buffer_magnetic_field_visitor<detector_type_list,
+                                                hip::bfield_type_list<scalar>>(
+      payload.detector, payload.field,
+      [&]<typename detector_traits_t, typename bfield_view_t>(
+          const typename detector_traits_t::view&, const bfield_view_t&) {
+        // Get the number of tracks.
+        const unsigned int n_tracks = payload.payload.tracks.tracks.capacity();
+        assert(n_tracks == copy().get_size(payload.payload.tracks.tracks));
+
+        // Launch parameters for the kernel.
+        const unsigned int nThreads = warp_size() * 4;
+        const unsigned int nBlocks = (n_tracks + nThreads - 1) / nThreads;
+
+        // Fitter type to use.
+        using fitter_t =
+            traccc::details::kalman_fitter_t<typename detector_traits_t::device,
+                                             bfield_view_t>;
+
+        // Run the track fitting
+        hipLaunchKernelGGL(kernels::fit_forward<fitter_t>, nBlocks, nThreads, 0,
+                           details::get_stream(stream()), config,
+                           payload.payload, payload.get_tpayload<fitter_t>());
+        TRACCC_HIP_ERROR_CHECK(hipGetLastError());
+      });
+}
+
+}  // namespace traccc::hip

--- a/Traccc/device/hip/src/fitting/kalman_fitting_algorithm_fit_prelude_kernel.hip
+++ b/Traccc/device/hip/src/fitting/kalman_fitting_algorithm_fit_prelude_kernel.hip
@@ -1,0 +1,51 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "../utils/global_index.hpp"
+#include "../utils/hip_error_handling.hpp"
+#include "../utils/utils.hpp"
+#include "traccc/hip/fitting/kalman_fitting_algorithm.hpp"
+
+// Project include(s).
+#include "traccc/fitting/device/fit_prelude.hpp"
+
+// HIP include(s).
+#include <hip/hip_runtime.h>
+
+// System include(s).
+#include <cassert>
+
+namespace traccc::hip {
+namespace kernels {
+
+__global__ void fit_prelude(const device::fit_prelude_payload payload) {
+  device::fit_prelude(details::global_index1(), payload);
+}
+
+}  // namespace kernels
+
+void kalman_fitting_algorithm::fit_prelude_kernel(
+    const device::fit_prelude_payload& payload) const {
+  // Get the number of tracks.
+  const unsigned int n_tracks = payload.input_tracks.tracks.capacity();
+  assert(n_tracks == copy().get_size(payload.input_tracks.tracks));
+  assert(n_tracks == payload.track_indices.capacity());
+  assert(payload.track_indices.size_ptr() == nullptr);
+  assert(n_tracks == copy().get_size(payload.output_tracks.tracks));
+
+  // Launch parameters for the kernel.
+  const unsigned int nThreads = warp_size() * 4;
+  const unsigned int nBlocks = (n_tracks + nThreads - 1) / nThreads;
+
+  // Run the fitting, using the sorted parameter IDs.
+  hipLaunchKernelGGL(kernels::fit_prelude, nBlocks, nThreads, 0,
+                     details::get_stream(stream()), payload);
+  TRACCC_HIP_ERROR_CHECK(hipGetLastError());
+}
+
+}  // namespace traccc::hip

--- a/Traccc/device/hip/src/fitting/kalman_fitting_algorithm_prepare_track_fit_order.hip
+++ b/Traccc/device/hip/src/fitting/kalman_fitting_algorithm_prepare_track_fit_order.hip
@@ -1,0 +1,83 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "../utils/global_index.hpp"
+#include "../utils/hip_error_handling.hpp"
+#include "../utils/utils.hpp"
+#include "traccc/hip/fitting/kalman_fitting_algorithm.hpp"
+
+// Project include(s).
+#include "traccc/fitting/device/fill_fitting_sort_keys.hpp"
+
+// (Roc)Thrust include(s).
+#include <thrust/execution_policy.h>
+#include <thrust/sort.h>
+
+// HIP include(s).
+#include <hip/hip_runtime.h>
+
+// System include(s).
+#include <cassert>
+#include <memory_resource>
+
+namespace traccc::hip {
+namespace kernels {
+
+__global__ void fill_fitting_sort_keys(
+    edm::track_collection<default_algebra>::const_view track_candidates_view,
+    vecmem::data::vector_view<device::sort_key> keys_view,
+    vecmem::data::vector_view<unsigned int> ids_view) {
+  device::fill_fitting_sort_keys(details::global_index1(),
+                                 track_candidates_view, keys_view, ids_view);
+}
+
+}  // namespace kernels
+
+void kalman_fitting_algorithm::prepare_track_fit_order(
+    const edm::track_collection<default_algebra>::const_view& tracks,
+    vecmem::data::vector_view<device::sort_key>& track_sort_keys,
+    vecmem::data::vector_view<unsigned int>& track_indices) const {
+  // Get the number of tracks.
+  const unsigned int n_tracks = tracks.capacity();
+  assert(n_tracks == copy().get_size(tracks));
+  assert(n_tracks == track_indices.capacity());
+  assert(track_indices.size_ptr() == nullptr);
+
+  // Launch parameters for the kernel.
+  const unsigned int nThreads = warp_size() * 4;
+  const unsigned int nBlocks = (n_tracks + nThreads - 1) / nThreads;
+
+  // Get a convenience variable for the stream that we'll be using.
+  hipStream_t str = details::get_stream(stream());
+
+  // Fill the keys and indices buffers.
+  hipLaunchKernelGGL(kernels::fill_fitting_sort_keys, nBlocks, nThreads, 0, str,
+                     tracks, track_sort_keys, track_indices);
+
+// Set up the Thrust execution policy. Unfortunately this has to be done in
+// a backend specify way. :-(
+#if defined(__HIP_PLATFORM_AMD__)
+  auto policy =
+      thrust::hip::par_nosync(std::pmr::polymorphic_allocator(&(mr().main)))
+          .on(str);
+#elif defined(__HIP_PLATFORM_NVIDIA__)
+  auto policy =
+      thrust::cuda::par_nosync(std::pmr::polymorphic_allocator(&(mr().main)))
+          .on(str);
+#else
+#error "Unrecognised HIP platform."
+#endif
+
+  // Sort the key to get the sorted parameter ids
+  vecmem::device_vector<device::sort_key> keys_device(track_sort_keys);
+  vecmem::device_vector<unsigned int> track_indices_device(track_indices);
+  thrust::sort_by_key(policy, keys_device.begin(), keys_device.end(),
+                      track_indices_device.begin());
+}
+
+}  // namespace traccc::hip

--- a/Traccc/device/hip/src/utils/magnetic_field_types.hpp
+++ b/Traccc/device/hip/src/utils/magnetic_field_types.hpp
@@ -1,0 +1,42 @@
+/** TRACCC library, part of the ACTS project (R&D line)
+ *
+ * (c) 2026 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Covfie include(s).
+#include <covfie/core/backend/primitive/constant.hpp>
+#include <covfie/core/backend/transformer/affine.hpp>
+#include <covfie/core/backend/transformer/clamp.hpp>
+#include <covfie/core/backend/transformer/linear.hpp>
+#include <covfie/core/backend/transformer/strided.hpp>
+#include <covfie/core/concepts.hpp>
+#include <covfie/core/field.hpp>
+#include <covfie/core/vector.hpp>
+#include <covfie/hip/backend/primitive/hip_device_array.hpp>
+
+#include "traccc/bfield/magnetic_field_types.hpp"
+
+namespace traccc::hip {
+
+/// Inhomogeneous B-field backend type using HIP global memory
+template <typename scalar_t>
+using inhom_global_bfield_backend_t =
+    covfie::backend::affine<covfie::backend::linear<covfie::backend::clamp<
+        covfie::backend::strided<covfie::vector::vector_d<std::size_t, 3>,
+                                 covfie::backend::hip_device_array<
+                                     covfie::vector::vector_d<scalar_t, 3>>>>>>;
+// Test that the type is a valid backend for a field
+static_assert(
+    covfie::concepts::field_backend<inhom_global_bfield_backend_t<float>>,
+    "hip::inhom_global_bfield_backend_t is not a valid field backend type");
+
+/// @brief the standard list of HIP bfield types to support
+template <typename scalar_t>
+using bfield_type_list = std::tuple<const_bfield_backend_t<scalar_t>,
+                                    inhom_global_bfield_backend_t<scalar_t>>;
+
+}  // namespace traccc::hip


### PR DESCRIPTION
As the next step in adding HIP versions of "everything", this adds `traccc::hip::kalman_fitting_algorithm`.

I wanted to try something new for the code design. Currently we build the CUDA code in a fairly elaborate way. Building specializations of templated kernels used in fitting, as separate object files. That's pretty much as efficient as possible for parallelizing the build. But it also requires the maintenance of a good number of files for each kernel that is handled in such a way.

With Alpaka and SYCL we are on the other extreme. Just building all specializations of all kernels as part of a single object file.

What I did here was to separate the kernels each into their own source files. But still build all template specializations as a single compilation unit.

This cuts down drastically on the number of files that we need to maintain. But is admittedly not as efficient as what we have for CUDA. Still, I wanted to ask how we'd want to organize this code in the long run. Should we migrate all backends to the setup that CUDA has? Or would it make more sense to harmonize the implementations something like this? (Note that while for SYCL a setup similar to CUDA could be done, but for Alpaka I'm not even absolutely sure that it can...)