### PR TITLE
fix(traccc): Fully qualify detail namespaces

### DIFF
--- a/Traccc/core/include/traccc/finding/details/combinatorial_kalman_filter.hpp
+++ b/Traccc/core/include/traccc/finding/details/combinatorial_kalman_filter.hpp
@@ -223,7 +223,7 @@ combinatorial_kalman_filter(
           std::tuple<candidate_link, bound_track_parameters<algebra_type>>>
           best_links;
 
-      const bool is_line = detail::is_line(sf);
+      const bool is_line = traccc::detail::is_line(sf);
 
       // Iterate over the measurements
       TRACCC_VERBOSE_HOST("No. measurements: " << (up - lo));
@@ -502,8 +502,8 @@ combinatorial_kalman_filter(
       // Create propagator state
       typename traccc::details::ckf_propagator_t<detector_t, bfield_t>::state
           propagation(param, field, det);
-      propagation.set_particle(
-          detail::correct_particle_hypothesis(config.ptc_hypothesis, param));
+      propagation.set_particle(traccc::detail::correct_particle_hypothesis(
+          config.ptc_hypothesis, param));
 
       propagation.stepping()
           .template set_constraint<detray::step::constraint::e_accuracy>(

--- a/Traccc/core/src/clusterization/measurement_creation_algorithm.cpp
+++ b/Traccc/core/src/clusterization/measurement_creation_algorithm.cpp
@@ -47,8 +47,8 @@ measurement_creation_algorithm::operator()(
     assert(cluster.cell_indices().empty() == false);
 
     // Fill measurement from cluster
-    details::fill_measurement(measurement, cluster, i, cells, det_descr,
-                              det_cond);
+    traccc::details::fill_measurement(measurement, cluster, i, cells, det_descr,
+                                      det_cond);
   }
 
   return result;

--- a/Traccc/core/src/clusterization/sparse_ccl_algorithm.cpp
+++ b/Traccc/core/src/clusterization/sparse_ccl_algorithm.cpp
@@ -40,7 +40,7 @@ sparse_ccl_algorithm::output_type sparse_ccl_algorithm::operator()(
   vecmem::device_vector<unsigned int> cluster_indices_device{
       vecmem::get_data(cluster_indices)};
   const unsigned int num_clusters =
-      details::sparse_ccl(cells, cluster_indices_device);
+      traccc::details::sparse_ccl(cells, cluster_indices_device);
 
   // Create the result container.
   output_type clusters{m_mr.get()};

--- a/Traccc/device/common/include/traccc/finding/device/impl/find_tracks.ipp
+++ b/Traccc/device/common/include/traccc/finding/device/impl/find_tracks.ipp
@@ -198,7 +198,7 @@ TRACCC_HOST_DEVICE inline void find_tracks(
 
       if (n_tracks_per_seed.at(seed_idx) < cfg.max_num_branches_per_seed) {
         const detray::tracking_surface sf{det, in_par.surface_link()};
-        const bool is_line = detail::is_line(sf);
+        const bool is_line = traccc::detail::is_line(sf);
 
         const edm::measurement meas = measurements.at(meas_idx);
 

--- a/Traccc/device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp
+++ b/Traccc/device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp
@@ -73,7 +73,7 @@ TRACCC_HOST_DEVICE inline void propagate_to_next_surface(
   // Create propagator state
   typename propagator_t::state propagation(in_par, field_data, *det_data_ptr);
   propagation.set_particle(
-      detail::correct_particle_hypothesis(cfg.ptc_hypothesis, in_par));
+      traccc::detail::correct_particle_hypothesis(cfg.ptc_hypothesis, in_par));
   propagation.stepping()
       .template set_constraint<detray::step::constraint::e_accuracy>(
           cfg.propagation.stepping.step_constraint);

--- a/Traccc/device/common/include/traccc/seeding/device/count_grid_capacities.hpp
+++ b/Traccc/device/common/include/traccc/seeding/device/count_grid_capacities.hpp
@@ -40,8 +40,8 @@ namespace traccc::device {
 TRACCC_HOST_DEVICE
 inline void count_grid_capacities(
     global_index_t globalIndex, const seedfinder_config& config,
-    const details::spacepoint_grid_types::host::axis_p0_type& phi_axis,
-    const details::spacepoint_grid_types::host::axis_p1_type& z_axis,
+    const traccc::details::spacepoint_grid_types::host::axis_p0_type& phi_axis,
+    const traccc::details::spacepoint_grid_types::host::axis_p1_type& z_axis,
     const edm::spacepoint_collection::const_view& spacepoints,
     vecmem::data::vector_view<unsigned int> grid_capacities);
 

--- a/Traccc/device/common/include/traccc/seeding/device/impl/count_doublets.ipp
+++ b/Traccc/device/common/include/traccc/seeding/device/impl/count_doublets.ipp
@@ -95,14 +95,15 @@ inline void count_doublets(
         // Check if this spacepoint is a compatible "bottom" spacepoint
         // to the thread's "middle" spacepoint.
         if (doublet_finding_helper::isCompatible<
-                details::spacepoint_type::bottom>(middle_sp, other_sp,
-                                                  config)) {
+                traccc::details::spacepoint_type::bottom>(middle_sp, other_sp,
+                                                          config)) {
           ++n_mb_cand;
         }
         // Check if this spacepoint is a compatible "top" spacepoint to
         // the thread's "middle" spacepoint.
-        if (doublet_finding_helper::isCompatible<details::spacepoint_type::top>(
-                middle_sp, other_sp, config)) {
+        if (doublet_finding_helper::isCompatible<
+                traccc::details::spacepoint_type::top>(middle_sp, other_sp,
+                                                       config)) {
           ++n_mt_cand;
         }
       }

--- a/Traccc/device/common/include/traccc/seeding/device/impl/count_grid_capacities.ipp
+++ b/Traccc/device/common/include/traccc/seeding/device/impl/count_grid_capacities.ipp
@@ -18,8 +18,8 @@ namespace traccc::device {
 TRACCC_HOST_DEVICE
 inline void count_grid_capacities(
     const global_index_t globalIndex, const seedfinder_config& config,
-    const details::spacepoint_grid_types::host::axis_p0_type& phi_axis,
-    const details::spacepoint_grid_types::host::axis_p1_type& z_axis,
+    const traccc::details::spacepoint_grid_types::host::axis_p0_type& phi_axis,
+    const traccc::details::spacepoint_grid_types::host::axis_p1_type& z_axis,
     const edm::spacepoint_collection::const_view& spacepoints_view,
     vecmem::data::vector_view<unsigned int> grid_capacities_view) {
   // Check if anything needs to be done.

--- a/Traccc/device/common/include/traccc/seeding/device/impl/count_triplets.ipp
+++ b/Traccc/device/common/include/traccc/seeding/device/impl/count_triplets.ipp
@@ -63,7 +63,7 @@ inline void count_triplets(
 
   // Apply the conformal transformation to middle-bot doublet
   traccc::lin_circle lb = doublet_finding_helper::transform_coordinates<
-      details::spacepoint_type::bottom>(spM, spB);
+      traccc::details::spacepoint_type::bottom>(spM, spB);
 
   // Calculate some physical quantities required for triplet compatibility
   // check
@@ -92,7 +92,7 @@ inline void count_triplets(
 
     // Apply the conformal transformation to middle-top doublet
     traccc::lin_circle lt = doublet_finding_helper::transform_coordinates<
-        details::spacepoint_type::top>(spM, spT);
+        traccc::details::spacepoint_type::top>(spM, spT);
 
     // Check if mid-bot and mid-top doublets can form a triplet
     if (triplet_finding_helper::isCompatible(spM, lb, lt, config, iSinTheta2,

--- a/Traccc/device/common/include/traccc/seeding/device/impl/find_doublets.ipp
+++ b/Traccc/device/common/include/traccc/seeding/device/impl/find_doublets.ipp
@@ -103,8 +103,8 @@ inline void find_doublets(
         // Check if this spacepoint is a compatible "bottom" spacepoint
         // to the thread's "middle" spacepoint.
         if (doublet_finding_helper::isCompatible<
-                details::spacepoint_type::bottom>(middle_sp, other_sp,
-                                                  config)) {
+                traccc::details::spacepoint_type::bottom>(middle_sp, other_sp,
+                                                          config)) {
           // Add it as a candidate to the middle-bottom container.
           const unsigned int pos = mid_bot_start_idx + mid_bot_idx++;
           assert(pos < mb_doublets.size());
@@ -112,8 +112,9 @@ inline void find_doublets(
         }
         // Check if this spacepoint is a compatible "top" spacepoint to
         // the thread's "middle" spacepoint.
-        if (doublet_finding_helper::isCompatible<details::spacepoint_type::top>(
-                middle_sp, other_sp, config)) {
+        if (doublet_finding_helper::isCompatible<
+                traccc::details::spacepoint_type::top>(middle_sp, other_sp,
+                                                       config)) {
           // Add it as a candidate to the middle-top container.
           const unsigned int pos = mid_top_start_idx + mid_top_idx++;
           assert(pos < mt_doublets.size());

--- a/Traccc/device/common/include/traccc/seeding/device/impl/find_triplets.ipp
+++ b/Traccc/device/common/include/traccc/seeding/device/impl/find_triplets.ipp
@@ -66,7 +66,7 @@ inline void find_triplets(
 
   // Apply the conformal transformation to middle-bot doublet
   const traccc::lin_circle lb = doublet_finding_helper::transform_coordinates<
-      details::spacepoint_type::bottom>(spM, spB);
+      traccc::details::spacepoint_type::bottom>(spM, spB);
 
   // Calculate some physical quantities required for triplet compatibility
   // check
@@ -99,7 +99,7 @@ inline void find_triplets(
 
     // Apply the conformal transformation to middle-top doublet
     const traccc::lin_circle lt = doublet_finding_helper::transform_coordinates<
-        details::spacepoint_type::top>(spM, spT);
+        traccc::details::spacepoint_type::top>(spM, spT);
 
     // Check if mid-bot and mid-top doublets can form a triplet
     if (triplet_finding_helper::isCompatible(spM, lb, lt, config, iSinTheta2,

--- a/Traccc/device/common/include/traccc/seeding/device/impl/form_spacepoints.ipp
+++ b/Traccc/device/common/include/traccc/seeding/device/impl/form_spacepoints.ipp
@@ -38,7 +38,7 @@ TRACCC_HOST_DEVICE inline void form_spacepoints(
   const edm::measurement meas = measurements.at(globalIndex);
 
   // Fill the spacepoint using the common function.
-  if (details::is_valid_measurement(meas)) {
+  if (traccc::details::is_valid_measurement(meas)) {
     const edm::spacepoint_collection::device::size_type i =
         spacepoints.push_back_default();
     edm::spacepoint sp = spacepoints.at(i);

--- a/Traccc/device/common/include/traccc/seeding/device/impl/populate_grid.ipp
+++ b/Traccc/device/common/include/traccc/seeding/device/impl/populate_grid.ipp
@@ -16,7 +16,7 @@ TRACCC_HOST_DEVICE
 inline void populate_grid(
     const global_index_t globalIndex, const seedfinder_config& config,
     const edm::spacepoint_collection::const_view& spacepoints_view,
-    details::spacepoint_grid_types::view grid_view,
+    traccc::details::spacepoint_grid_types::view grid_view,
     vecmem::data::vector_view<prefix_sum_element_t> grid_prefix_sum_view) {
   // Check if anything needs to be done.
   const edm::spacepoint_collection::const_device spacepoints(spacepoints_view);
@@ -29,10 +29,10 @@ inline void populate_grid(
   /// Check out if the spacepoint can be used for seeding.
   if (is_valid_sp(config, sp)) {
     // Set up the spacepoint grid object(s).
-    details::spacepoint_grid_types::device grid(grid_view);
-    const details::spacepoint_grid_types::device::axis_p0_type& phi_axis =
-        grid.axis_p0();
-    const details::spacepoint_grid_types::device::axis_p1_type& z_axis =
+    traccc::details::spacepoint_grid_types::device grid(grid_view);
+    const traccc::details::spacepoint_grid_types::device::axis_p0_type&
+        phi_axis = grid.axis_p0();
+    const traccc::details::spacepoint_grid_types::device::axis_p1_type& z_axis =
         grid.axis_p1();
 
     // Find the grid bin that the spacepoint belongs to.

--- a/Traccc/device/common/include/traccc/seeding/device/populate_grid.hpp
+++ b/Traccc/device/common/include/traccc/seeding/device/populate_grid.hpp
@@ -31,7 +31,7 @@ TRACCC_HOST_DEVICE
 inline void populate_grid(
     global_index_t globalIndex, const seedfinder_config& config,
     const edm::spacepoint_collection::const_view& spacepoints,
-    details::spacepoint_grid_types::view grid,
+    traccc::details::spacepoint_grid_types::view grid,
     vecmem::data::vector_view<prefix_sum_element_t> grid_prefix_sum);
 
 }  // namespace traccc::device

--- a/Traccc/device/common/src/seeding/triplet_seeding_algorithm.cpp
+++ b/Traccc/device/common/src/seeding/triplet_seeding_algorithm.cpp
@@ -33,8 +33,8 @@ struct triplet_seeding_algorithm::data {
   /// @}
 
   /// Axes for the internal spacepoint grid
-  std::pair<details::spacepoint_grid_types::host::axis_p0_type,
-            details::spacepoint_grid_types::host::axis_p1_type>
+  std::pair<traccc::details::spacepoint_grid_types::host::axis_p0_type,
+            traccc::details::spacepoint_grid_types::host::axis_p1_type>
       m_axes;
 
 };  // struct triplet_seeding_algorithm::data
@@ -95,7 +95,7 @@ auto triplet_seeding_algorithm::operator()(
 
   // Create the spacepoint grid buffer and a prefix sum buffer that describes
   // it. (The latter is needed for the next few steps.)
-  details::spacepoint_grid_types::buffer grid_buffer(
+  traccc::details::spacepoint_grid_types::buffer grid_buffer(
       m_data->m_axes.first, m_data->m_axes.second,
       std::vector<unsigned int>(grid_capacities_host.begin(),
                                 grid_capacities_host.end()),


### PR DESCRIPTION
This commit fixes an issue where, in contexts where both `traccc::detail` and `traccc::device::detail` are defined, unqualified namespace usage of `detail::` leads to errors.