### PR TITLE
fix: Dense energy loss is skipped without covariance transport and does not reverse

### DIFF
--- a/Core/include/Acts/Propagator/detail/SympyStepperDenseStep.hpp
+++ b/Core/include/Acts/Propagator/detail/SympyStepperDenseStep.hpp
@@ -9,7 +9,6 @@
 #pragma once
 
 #include "Acts/Definitions/Algebra.hpp"
-#include "Acts/Definitions/Direction.hpp"
 #include "Acts/Propagator/SympyStepper.hpp"
 #include "Acts/Utilities/Result.hpp"
 
@@ -31,7 +30,6 @@ namespace detail {
 /// @param [in,out] state the stepper state, read for the start parameters and
 ///        written with the end parameters on success
 /// @param [in] material the volume material
-/// @param [in] timeDirection direction of time propagation
 /// @param [in] h the step size to attempt
 /// @param [in] errTol the tolerated error estimate
 /// @param [out] errorEstimate the error estimate of the attempted step
@@ -42,10 +40,9 @@ namespace detail {
 /// @return whether the step was accepted, or an error
 Result<bool> sympyDenseStep(const SympyStepper& stepper,
                             SympyStepper::State& state,
-                            const IVolumeMaterial& material,
-                            Direction timeDirection, double h, double errTol,
-                            double& errorEstimate, Vector3& lastField,
-                            std::span<double> jac);
+                            const IVolumeMaterial& material, double h,
+                            double errTol, double& errorEstimate,
+                            Vector3& lastField, std::span<double> jac);
 
 }  // namespace detail
 }  // namespace Acts

--- a/Core/src/Propagator/SympyStepper.cpp
+++ b/Core/src/Propagator/SympyStepper.cpp
@@ -145,7 +145,6 @@ Result<double> SympyStepper::step(State& state, Direction propDir,
   double h = state.stepSize.value() * propDir;
 
   const double initialH = h;
-  const Direction timeDirection = Direction::fromScalarZeroAsPositive(h);
 
   const Vector3 pos = position(state);
   const Vector3 dir = direction(state);
@@ -222,9 +221,9 @@ Result<double> SympyStepper::step(State& state, Direction propDir,
           errorEstimate, 4 * stepTolerance, endPos, state.pars[eFreeTime],
           endDir, std::span<double, 3>(lastField.data(), 3), derivative, jac);
     } else {
-      res = detail::sympyDenseStep(*this, state, *material, timeDirection, h,
-                                   4 * stepTolerance, errorEstimate, lastField,
-                                   jac);
+      res =
+          detail::sympyDenseStep(*this, state, *material, h, 4 * stepTolerance,
+                                 errorEstimate, lastField, jac);
     }
     if (!res.ok()) {
       return res.error();

--- a/Core/src/Propagator/detail/SympyStepperDenseStep.cpp
+++ b/Core/src/Propagator/detail/SympyStepperDenseStep.cpp
@@ -22,10 +22,9 @@ namespace Acts::detail {
 
 Result<bool> sympyDenseStep(const SympyStepper& stepper,
                             SympyStepper::State& state,
-                            const IVolumeMaterial& material,
-                            Direction timeDirection, double h, double errTol,
-                            double& errorEstimate, Vector3& lastField,
-                            std::span<double> jac) {
+                            const IVolumeMaterial& material, double h,
+                            double errTol, double& errorEstimate,
+                            Vector3& lastField, std::span<double> jac) {
   const Vector3 pos = stepper.position(state);
   const Vector3 dir = stepper.direction(state);
   const double t = stepper.time(state);
@@ -49,14 +48,14 @@ Result<bool> sympyDenseStep(const SympyStepper& stepper,
 
     const MaterialSlab slab(material.material({p[0], p[1], p[2]}),
                             1.0f * UnitConstants::mm);
+    // Unsigned: the step's own sign gives the energy back on a backward step,
+    // matching `PointwiseMaterialInteraction`.
     if (state.options.dense.meanEnergyLoss) {
-      return timeDirection * computeEnergyLossMean(slab, absPdg,
-                                                   static_cast<float>(m),
-                                                   static_cast<float>(l), absQ);
+      return computeEnergyLossMean(slab, absPdg, static_cast<float>(m),
+                                   static_cast<float>(l), absQ);
     }
-    return timeDirection * computeEnergyLossMode(slab, absPdg,
-                                                 static_cast<float>(m),
-                                                 static_cast<float>(l), absQ);
+    return computeEnergyLossMode(slab, absPdg, static_cast<float>(m),
+                                 static_cast<float>(l), absQ);
   };
 
   return rk4_dense(

--- a/Core/src/Propagator/generate_sympy_stepper.py
+++ b/Core/src/Propagator/generate_sympy_stepper.py
@@ -739,7 +739,9 @@ def print_rk4_dense(name_exprs, run_cse=True):
             return (
                 "if (err > errTol) {\n  return Acts::Result<bool>::success(false);\n}"
             )
-        if str(var) == "new_dir":
+        if str(var) == "new_qop":
+            # new_qop carries the energy loss, so it belongs to the step and
+            # has to be written before the jacobian-only part is skipped
             return "if (M.empty()) {\n  return Acts::Result<bool>::success(true);\n}"
         if str(var) == "new_M":
             return "\n".join(

--- a/Tests/UnitTests/Core/Propagator/SympyStepperTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/SympyStepperTests.cpp
@@ -555,6 +555,36 @@ BOOST_AUTO_TEST_CASE(sympy_stepper_dense_energy_loss_without_covariance) {
   CHECK_CLOSE_REL(run(false), run(true), 1e-12);
 }
 
+/// Backward propagation gives the energy back, following the convention of
+/// `PointwiseMaterialInteraction`.
+BOOST_AUTO_TEST_CASE(sympy_stepper_dense_energy_loss_reverses) {
+  auto bField = std::make_shared<ConstantBField>(Vector3(0, 0, 2_T));
+  SympyStepper stepper(bField);
+  const HomogeneousVolumeMaterial silicon(makeSilicon());
+
+  const double qop0 = 1. / 1_GeV;
+  SympyStepper::Options options(tgContext, mfContext);
+  options.maxStepSize = 20_mm;
+  options.initialStepSize = 20_mm;
+  options.doDense = true;
+
+  auto state = stepper.makeState(options);
+  stepper.initialize(
+      state, BoundTrackParameters::createCurvilinear(
+                 Vector4::Zero(), 0.4, 0.7, qop0, Covariance::Identity(),
+                 ParticleHypothesis::pion()));
+  for (int i = 0; i < 10; ++i) {
+    BOOST_REQUIRE(stepper.step(state, Direction::Forward(), &silicon).ok());
+  }
+  BOOST_CHECK_GT(stepper.qOverP(state), qop0);
+  for (int i = 0; i < 10; ++i) {
+    BOOST_REQUIRE(stepper.step(state, Direction::Backward(), &silicon).ok());
+  }
+  CHECK_SMALL(state.pathAccumulated, 1e-9);
+  // the residual is RK truncation error; the sign bug would be percents
+  CHECK_CLOSE_REL(stepper.qOverP(state), qop0, 1e-7);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }  // namespace ActsTests

--- a/Tests/UnitTests/Core/Propagator/SympyStepperTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/SympyStepperTests.cpp
@@ -20,6 +20,8 @@
 #include "Acts/MagneticField/ConstantBField.hpp"
 #include "Acts/MagneticField/MagneticFieldContext.hpp"
 #include "Acts/MagneticField/MagneticFieldProvider.hpp"
+#include "Acts/Material/HomogeneousVolumeMaterial.hpp"
+#include "Acts/Material/Material.hpp"
 #include "Acts/Propagator/ConstrainedStep.hpp"
 #include "Acts/Propagator/EigenStepper.hpp"
 #include "Acts/Propagator/SympyStepper.hpp"
@@ -29,6 +31,7 @@
 #include "Acts/Utilities/Logger.hpp"
 #include "Acts/Utilities/Result.hpp"
 #include "ActsTests/CommonHelpers/FloatComparisons.hpp"
+#include "ActsTests/CommonHelpers/PredefinedMaterials.hpp"
 
 #include <array>
 #include <cmath>
@@ -518,6 +521,38 @@ BOOST_AUTO_TEST_CASE(sympy_stepper_covariance_matches_eigen) {
     // the wrong jacobian order deviates by ~1e-2.
     CHECK_CLOSE_COVARIANCE(sympyCov, eigenCov, 1e-9);
   }
+}
+
+/// A dense step applies the energy loss with and without covariance transport.
+BOOST_AUTO_TEST_CASE(sympy_stepper_dense_energy_loss_without_covariance) {
+  auto bField = std::make_shared<ConstantBField>(Vector3(0, 0, 2_T));
+  SympyStepper stepper(bField);
+  const HomogeneousVolumeMaterial silicon(makeSilicon());
+
+  const double qop0 = 1. / 1_GeV;
+  auto run = [&](bool withCovariance) {
+    SympyStepper::Options options(tgContext, mfContext);
+    options.maxStepSize = 20_mm;
+    options.initialStepSize = 20_mm;
+    options.doDense = true;
+
+    std::optional<Covariance> cov;
+    if (withCovariance) {
+      cov = Covariance::Identity();
+    }
+    auto state = stepper.makeState(options);
+    stepper.initialize(state, BoundTrackParameters::createCurvilinear(
+                                  Vector4::Zero(), 0.4, 0.7, qop0, cov,
+                                  ParticleHypothesis::pion()));
+    for (int i = 0; i < 10; ++i) {
+      BOOST_REQUIRE(stepper.step(state, Direction::Forward(), &silicon).ok());
+    }
+    return stepper.qOverP(state);
+  };
+
+  // 200 mm of silicon is a few percent of a 1 GeV pion's momentum
+  BOOST_CHECK_GT(run(false), qop0);
+  CHECK_CLOSE_REL(run(false), run(true), 1e-12);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Two bugs in the sympy dense stepper's energy loss. They cancel on
`PropagationSympyDenseConstant/ForwardBackward`, so fixing either alone breaks
it: `g` also feeds the RK stages, so it moves the trajectory even when
`new_qop` is never written.

**The energy loss is skipped without covariance transport.** The dense kernel
returns early when there is no jacobian to transport, above the q/p update. A
step through material with `covTransport == false` integrates the trajectory
but never applies the energy loss: 200 mm of silicon at 1 GeV leaves q/p
unchanged, where the same step with covariance loses 9% of the momentum.
`new_qop` carries the energy loss and belongs to the step, so the early return
now hangs off it instead of off `new_dir`.

**The energy loss does not reverse with the propagation direction.** `getG`
scaled it by the sign of the step, cancelling the step's own `h` sign, so a
backward step lost energy again instead of giving it back. ACTS' convention is
the opposite, per `PointwiseMaterialInteraction`: "in forward(backward)
propagation, energy decreases(increases)"; `EigenStepperDenseExtension` follows
it.

One unit test per bug.
