### PR TITLE
refactor(detray): Transpose mask loop in intersector

### DIFF
--- a/Detray/core/include/detray/navigation/detail/intersection_kernel.hpp
+++ b/Detray/core/include/detray/navigation/detail/intersection_kernel.hpp
@@ -101,33 +101,24 @@ struct intersection_initialize {
       }
     }
 
-    // Resolve the masks that belong to the surface
-    for (const auto &mask : detray::ranges::subrange(mask_group, mask_range)) {
-      intersection_t is{};
+    for (std::size_t i = 0u; i < n_sol; ++i) {
+      // Resolve the masks that belong to the surface
+      for (const auto &mask :
+           detray::ranges::subrange(mask_group, mask_range)) {
+        intersection_t is{};
 
-      // Build the resulting intersecion(s) from the intersection point
-      if constexpr (n_sol > 1) {
-        std::uint8_t n_found{0u};
-
-        for (std::size_t i = 0u; i < n_sol; ++i) {
+        // Build the resulting intersection(s) from the intersection point
+        if constexpr (n_sol > 1) {
           resolve_mask(is, traj, result[i], sf_desc, mask, ctf, cfg,
                        external_mask_tolerance);
-
-          if (is.is_probably_inside()) {
-            insert_sorted(is, is_container);
-            ++n_found;
-          }
-          if (n_found == n_sol) {
-            return;
-          }
+        } else {
+          resolve_mask(is, traj, result, sf_desc, mask, ctf, cfg,
+                       external_mask_tolerance);
         }
-      } else {
-        resolve_mask(is, traj, result, sf_desc, mask, ctf, cfg,
-                     external_mask_tolerance);
 
         if (is.is_probably_inside()) {
           insert_sorted(is, is_container);
-          return;
+          break;
         }
       }
     }


### PR DESCRIPTION
The current code for updating navigator candidates in detray has two loops. The outer loop iterates over the masks of the surface, and the inner loop iterates over the intersections with the surface. The problem with this approach is that it bounds the number of returned candidates by |M| * |I|, where M is the set of masks and I is the intersections. While |I| is limited to 2, |M| is in principle unbounded.

This commit transposes the loops so that the intersection loop becomes the outer loop, and the mask loop becomes the inner loop. This allows us to immediately break the inner loop once a result has been found, bounding the number of results to |I|. Any results discarded this way would be otherwise discarded by the navigator state, which removes sufficiently close candidates.