### PR TITLE
fix: Don't reject volumes with a non-convertible extra navigation policy

### DIFF
--- a/Plugins/Detray/src/DetrayPayloadConverter.cpp
+++ b/Plugins/Detray/src/DetrayPayloadConverter.cpp
@@ -865,6 +865,16 @@ DetrayPayloadConverter::convertTrackingGeometry(
       std::optional<DetraySurfaceGrid> detrayGrid = std::nullopt;
 
       navPolicy->visit([&](const INavigationPolicy& policy) {
+        auto grid = m_cfg.convertNavigationPolicy(policy, gctx, surfaceLookupFn,
+                                                  logger());
+        if (!grid.has_value()) {
+          // Policies without an explicit detray conversion (see
+          // NOOP_CONVERTER_IMPL) are not a conflict: a volume may legitimately
+          // combine e.g. a SurfaceArrayNavigationPolicy with a
+          // TryAllNavigationPolicy for passives and portals.
+          return;
+        }
+
         if (detrayGrid.has_value()) {
           ACTS_ERROR("Volume "
                      << volume.volumeName()
@@ -874,8 +884,7 @@ DetrayPayloadConverter::convertTrackingGeometry(
               "Multiple detray-compatible navigation policies"};
         }
 
-        detrayGrid = m_cfg.convertNavigationPolicy(policy, gctx,
-                                                   surfaceLookupFn, logger());
+        detrayGrid = std::move(grid);
       });
 
       if (detrayGrid.has_value()) {


### PR DESCRIPTION
## Summary

`DetrayPayloadConverter::convertTrackingGeometry` walks a volume's navigation policies and errors out when it finds more than one it can convert. The guard was checked *before* the conversion and against the accumulated result:

```cpp
navPolicy->visit([&](const INavigationPolicy& policy) {
  if (detrayGrid.has_value()) { /* throw */ }
  detrayGrid = m_cfg.convertNavigationPolicy(policy, gctx, surfaceLookupFn, logger());
});
```

so it trips on the second policy *visited* rather than the second policy that actually converts.

A volume may legitimately combine a convertible policy with one that has no detray equivalent. The ATLAS ITk gives each layer a `SurfaceArrayNavigationPolicy` for the sensitives plus a `TryAllNavigationPolicy` for passives and portals. `TryAllNavigationPolicy` is a `NOOP_CONVERTER_IMPL` and returns `std::nullopt`, so there is only ever one convertible policy — yet converting the ITk tracking geometry aborted with:

```
ERROR Volume InnerPixel_Brl_0 has more than one detray-convertible navigation policy. This cannot currently be handled.
terminate: Multiple detray-compatible navigation policies
```

The fix converts first, returns early for policies that yield no grid, and only then checks for a genuine conflict. Volumes with two actually-convertible policies still raise the same error.

## Testing

Found while converting the ATLAS ITk Gen3 `Acts::TrackingGeometry` to detray from inside Athena's `ActsTrk::TrackingGeometrySvc` (ITk pixel + strip + HGTD + beam pipe, `detray::itk_metadata`). With this change the conversion completes and `detray::detail::check_consistency` passes on the resulting detector; without it, it throws as above.

The bug is present identically in v47.4.0, v47.5.0 and current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)