### PR TITLE
feat(detray): Add known-substructure matrix library

### DIFF
--- a/Detray/CMakeLists.txt
+++ b/Detray/CMakeLists.txt
@@ -139,6 +139,11 @@ option(DETRAY_BUILD_TEST_UTILS "Build the test utility library of Detray" OFF)
 option(DETRAY_BUILD_VALIDATION_TOOLS "Build the validation tools of Detray" OFF)
 option(DETRAY_BUILD_BENCHMARKS "Build the benchmark tests" OFF)
 option(DETRAY_BUILD_TUTORIALS "Build the tutorial executables of Detray" OFF)
+option(
+    DETRAY_BUILD_KNOWN_SUBSTRUCTURE_MATRIX_TEST
+    "Build the (very slow to compile) known-substructure matrix unit test"
+    OFF
+)
 
 #
 # Resolve build options and option inter-dependencies

--- a/Detray/core/CMakeLists.txt
+++ b/Detray/core/CMakeLists.txt
@@ -14,6 +14,7 @@ file(
     GLOB _detray_core_public_headers
     RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}"
     "include/detray/algebra/common/*.hpp"
+    "include/detray/algebra/common/ksm/*.hpp"
     "include/detray/algebra/generic/*.hpp"
     "include/detray/algebra/utils/*.hpp"
     "include/detray/builders/*.hpp"
@@ -39,6 +40,7 @@ file(
     GLOB _detray_core_private_headers
     "include/detray/*/detail/*.hpp"
     "include/detray/*/*/detail/*.hpp"
+    "include/detray/*/*/*/detail/*.hpp"
 )
 detray_add_library( detray_core core
    ${_detray_core_public_headers} ${_detray_core_private_headers}

--- a/Detray/core/include/detray/algebra/common/known_substructure_matrix.hpp
+++ b/Detray/core/include/detray/algebra/common/known_substructure_matrix.hpp
@@ -1,0 +1,18 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+// This is a single-include utility header to import all of detray's logic
+// for matrices with known substructures.
+#include "detray/algebra/common/ksm/make_substructure.hpp"
+#include "detray/algebra/common/ksm/matrix.hpp"
+#include "detray/algebra/common/ksm/print.hpp"
+#include "detray/algebra/common/ksm/substructure.hpp"
+#include "detray/algebra/common/ksm/traits.hpp"
+#include "detray/algebra/common/ksm/value.hpp"

--- a/Detray/core/include/detray/algebra/common/ksm/concepts.hpp
+++ b/Detray/core/include/detray/algebra/common/ksm/concepts.hpp
@@ -1,0 +1,323 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+// Project include(s)
+#include "detray/algebra/common/ksm/detail/symbolic_definitions.hpp"
+#include "detray/algebra/common/ksm/fwd.hpp"
+#include "detray/algebra/common/ksm/value.hpp"
+
+// System include(s)
+#include <concepts>
+#include <cstddef>
+#include <utility>
+
+// This file defines many of the concepts KSM supplies, and some helper
+// traits.
+namespace detray::ksm {
+namespace detail {
+template <typename T>
+struct is_integral_value_helper {
+  static constexpr bool value = false;
+};
+
+template <int I>
+struct is_integral_value_helper<integral_value<I>> {
+  static constexpr bool value = true;
+};
+
+template <typename T>
+struct is_symbolic_helper {
+  static constexpr bool value = false;
+};
+
+template <SymbolicOp op, typename A, typename B>
+struct is_symbolic_helper<symbolic<op, A, B>> {
+  static constexpr bool value = true;
+};
+
+template <typename T>
+struct is_index_variable_helper {
+  static constexpr bool value = false;
+};
+
+template <std::size_t I>
+struct is_index_variable_helper<index_variable<I>> {
+  static constexpr bool value = true;
+};
+}  // namespace detail
+
+namespace concepts {
+/// @brief True iff the value is a constant integral value.
+template <typename T>
+concept is_integral_value = detail::is_integral_value_helper<T>::value;
+
+/// @brief True iff the value is a symbolic operation.
+template <typename T>
+concept is_symbolic = detail::is_symbolic_helper<T>::value;
+
+/// @brief True iff the value is an indexed (i.e. non-anonymous) variable.
+template <typename T>
+concept is_index_variable = detail::is_index_variable_helper<T>::value;
+
+/// @brief True iff the value is an anonymous or non-anonymous variable.
+template <typename T>
+concept is_variable = is_index_variable<T> || std::same_as<T, variable>;
+
+/// @brief True iff the type is any valid KSM value, i.e. a symbolic
+/// operation, an anonymous variable, a non-anonymous variable, or an integral
+/// constant.
+template <typename T>
+concept is_value = is_symbolic<T> || is_integral_value<T> || is_variable<T>;
+
+/// @brief True iff the type is a canonical KSM value, i.e. an integral
+/// constant or a non-anonymous variable.
+template <typename T>
+concept is_canonical_value = is_integral_value<T> || is_index_variable<T>;
+}  // namespace concepts
+
+namespace detail {
+template <typename T>
+inline constexpr bool is_row_v = false;
+template <typename... Vs>
+inline constexpr bool is_row_v<row<Vs...>> = (concepts::is_value<Vs> && ...);
+
+template <typename T>
+inline constexpr bool is_canonical_row_v = false;
+template <typename... Vs>
+inline constexpr bool is_canonical_row_v<row<Vs...>> =
+    (concepts::is_canonical_value<Vs> && ...);
+
+template <typename T>
+inline constexpr bool is_canonical_substructure_v = false;
+template <typename... Rs>
+inline constexpr bool is_canonical_substructure_v<substructure<Rs...>> =
+    (is_canonical_row_v<Rs> && ...);
+
+template <typename substructure_t,
+          bool Square = (substructure_t::rows == substructure_t::columns)>
+struct is_symmetric_helper {
+  static constexpr bool value = false;
+};
+
+template <typename substructure_t>
+struct is_symmetric_helper<substructure_t, true> {
+  template <std::size_t... Ks>
+  static constexpr bool all_mirrored(std::index_sequence<Ks...>) {
+    constexpr std::size_t C = substructure_t::columns;
+    return (std::same_as<
+                typename substructure_t::template value_at<Ks / C, Ks % C>,
+                typename substructure_t::template value_at<Ks % C, Ks / C>> &&
+            ...);
+  }
+  static constexpr bool value =
+      all_mirrored(std::make_index_sequence<substructure_t::rows *
+                                            substructure_t::columns>{});
+};
+
+template <typename substructure_t,
+          bool Square = (substructure_t::rows == substructure_t::columns)>
+struct is_diagonal_helper {
+  static constexpr bool value = false;
+};
+
+template <typename substructure_t>
+struct is_diagonal_helper<substructure_t, true> {
+  template <std::size_t... Ks>
+  static constexpr bool all_off_diagonal_zero(std::index_sequence<Ks...>) {
+    constexpr std::size_t C = substructure_t::columns;
+    return ((Ks / C == Ks % C ||
+             std::same_as<
+                 typename substructure_t::template value_at<Ks / C, Ks % C>,
+                 zero>) &&
+            ...);
+  }
+  static constexpr bool value = all_off_diagonal_zero(
+      std::make_index_sequence<substructure_t::rows *
+                               substructure_t::columns>{});
+};
+
+template <typename substructure_t,
+          bool Square = (substructure_t::rows == substructure_t::columns)>
+struct is_upper_triangular_helper {
+  static constexpr bool value = false;
+};
+
+template <typename substructure_t>
+struct is_upper_triangular_helper<substructure_t, true> {
+  template <std::size_t... Ks>
+  static constexpr bool all_lower_zero(std::index_sequence<Ks...>) {
+    constexpr std::size_t C = substructure_t::columns;
+    return ((Ks / C <= Ks % C ||
+             std::same_as<
+                 typename substructure_t::template value_at<Ks / C, Ks % C>,
+                 zero>) &&
+            ...);
+  }
+  static constexpr bool value =
+      all_lower_zero(std::make_index_sequence<substructure_t::rows *
+                                              substructure_t::columns>{});
+};
+
+template <typename substructure_t,
+          bool Square = (substructure_t::rows == substructure_t::columns)>
+struct is_unit_upper_triangular_helper {
+  static constexpr bool value = false;
+};
+
+/// @brief True iff cell (I, J) already holds what the identity needs there.
+///
+/// A stored cell can simply be assigned, so only a constant one can fail.
+///
+/// @{
+template <typename substructure_t, std::size_t I, std::size_t J,
+          bool Stored = concepts::is_index_variable<
+              typename substructure_t::template value_at<I, J>>>
+struct identity_constant_ok {
+  static constexpr bool value =
+      substructure_t::template value_at<I, J>::value == ((I == J) ? 1 : 0);
+};
+
+template <typename substructure_t, std::size_t I, std::size_t J>
+struct identity_constant_ok<substructure_t, I, J, true> {
+  static constexpr bool value = true;
+};
+/// @}
+
+/// @brief True iff flat cells A and B do not disagree about the identity.
+///
+/// Two cells naming the same variable share one scalar, so they cannot hold
+/// different values. That rules out a substructure pairing a diagonal cell
+/// with an off-diagonal one, since the identity wants one in the first and
+/// zero in the second.
+template <typename substructure_t, std::size_t A, std::size_t B>
+struct identity_sharing_ok {
+ private:
+  static constexpr std::size_t C = substructure_t::columns;
+  using a_value = typename substructure_t::template value_at<A / C, A % C>;
+  using b_value = typename substructure_t::template value_at<B / C, B % C>;
+
+ public:
+  static constexpr bool value = !(concepts::is_index_variable<a_value> &&
+                                  std::same_as<a_value, b_value>) ||
+                                ((A / C == A % C) == (B / C == B % C));
+};
+
+template <typename substructure_t>
+struct can_represent_identity_helper {
+  static constexpr std::size_t cells =
+      substructure_t::rows * substructure_t::columns;
+
+  template <std::size_t... Ks>
+  static constexpr bool all_constants_ok(std::index_sequence<Ks...>) {
+    constexpr std::size_t C = substructure_t::columns;
+    return (identity_constant_ok<substructure_t, Ks / C, Ks % C>::value && ...);
+  }
+
+  template <std::size_t A, std::size_t... Bs>
+  static constexpr bool one_against_all(std::index_sequence<Bs...>) {
+    return (identity_sharing_ok<substructure_t, A, Bs>::value && ...);
+  }
+
+  template <std::size_t... As>
+  static constexpr bool all_sharing_ok(std::index_sequence<As...>) {
+    return (one_against_all<As>(std::make_index_sequence<cells>{}) && ...);
+  }
+
+  static constexpr bool value =
+      all_constants_ok(std::make_index_sequence<cells>{}) &&
+      all_sharing_ok(std::make_index_sequence<cells>{});
+};
+
+template <typename substructure_t>
+struct is_unit_upper_triangular_helper<substructure_t, true> {
+  template <std::size_t... Ks>
+  static constexpr bool all_unit_diagonal(std::index_sequence<Ks...>) {
+    constexpr std::size_t C = substructure_t::columns;
+    return ((Ks / C != Ks % C ||
+             std::same_as<
+                 typename substructure_t::template value_at<Ks / C, Ks % C>,
+                 one>) &&
+            ...);
+  }
+  static constexpr bool value =
+      is_upper_triangular_helper<substructure_t>::value &&
+      all_unit_diagonal(std::make_index_sequence<substructure_t::rows *
+                                                 substructure_t::columns>{});
+};
+}  // namespace detail
+
+namespace concepts {
+/// @brief True iff the type is a KSM row.
+template <typename T>
+concept is_row = detail::is_row_v<T>;
+
+/// @brief True iff the type is a KSM row with only canonical values.
+template <typename T>
+concept is_canonical_row = detail::is_canonical_row_v<T>;
+
+/// @brief True iff the type is a KSM substructure with only canonical values.
+template <typename T>
+concept is_canonical = detail::is_canonical_substructure_v<T>;
+
+/// @brief True iff the type is a symmetric KSM substructure.
+template <typename substructure_t>
+concept is_symmetric = is_canonical<substructure_t> &&
+                       detail::is_symmetric_helper<substructure_t>::value;
+
+/// @brief True iff every cell off the diagonal is a structural zero. A
+/// diagonal substructure is also a symmetric one.
+template <typename substructure_t>
+concept is_diagonal = is_canonical<substructure_t> &&
+                      detail::is_diagonal_helper<substructure_t>::value;
+
+/// @brief True iff the type is an upper triangular substructure, i.e. all
+/// elements in the lower triangle are zero.
+template <typename substructure_t>
+concept is_upper_triangular =
+    is_canonical<substructure_t> &&
+    detail::is_upper_triangular_helper<substructure_t>::value;
+
+/// @brief True iff the type is an upper triangular substructure, i.e. all
+/// elements in the lower triangle are zero, and the diagonal is all ones.
+template <typename substructure_t>
+concept is_unit_upper_triangular =
+    is_canonical<substructure_t> &&
+    detail::is_unit_upper_triangular_helper<substructure_t>::value;
+
+/// @brief True iff the substructure can hold the identity matrix.
+///
+/// Two things can stop it. A constant cell is fixed, so it has to already be
+/// what the identity needs there; and cells sharing a variable share one
+/// scalar, so they cannot disagree about it. A substructure naming the same
+/// variable on and off the diagonal fails the second.
+///
+/// This does not require a square substructure: a rectangular one gets ones
+/// along the leading diagonal and zeros elsewhere.
+template <typename substructure_t>
+concept can_represent_identity =
+    is_canonical<substructure_t> &&
+    detail::can_represent_identity_helper<substructure_t>::value;
+
+/// @brief True iff multiplying a substructure by itself gives that same
+/// substructure back.
+///
+/// A closed substructure is one a chain of products can stay inside: the type
+/// of A*A is the type of A, so it is also the type of A*A*A. This is an
+/// important class of substructures as it enables e.g. using the substructure
+/// for propagating a Jacobian.
+template <typename substructure_t>
+concept is_closed_under_multiplication =
+    is_canonical<substructure_t> &&
+    (substructure_t::rows == substructure_t::columns) &&
+    std::same_as<
+        typename substructure_t::template multiplication_type<substructure_t>,
+        substructure_t>;
+}  // namespace concepts
+}  // namespace detray::ksm

--- a/Detray/core/include/detray/algebra/common/ksm/detail/canonicalization.hpp
+++ b/Detray/core/include/detray/algebra/common/ksm/detail/canonicalization.hpp
@@ -1,0 +1,172 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+// Project include(s)
+#include "detray/algebra/common/ksm/concepts.hpp"
+#include "detray/algebra/common/ksm/detail/symbolic.hpp"
+#include "detray/algebra/common/ksm/make_substructure.hpp"
+#include "detray/algebra/common/ksm/value.hpp"
+
+// System include(s)
+#include <array>
+#include <concepts>
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+
+// This file defines the process of canonicalization, which is a process in
+// which we turn a matrix substructure into a canonical format. This allows us
+// to easily reason about structural properties of matrices even after complex
+// series of operations.
+namespace detray::ksm::detail {
+/// @brief Internal helper function for `first_equal_flat_index_v`.
+///
+/// Iterates over a list of flat indices Ks and uses a constexpr loop to find
+/// the first row-major flat index in substructure_t that matches value_t.
+template <typename substructure_t, typename value_t, std::size_t... Ks>
+constexpr std::size_t first_equal_flat_index_helper(
+    std::index_sequence<Ks...>) {
+  constexpr std::size_t C = substructure_t::columns;
+  constexpr std::array<bool, sizeof...(Ks)> eq = {
+      std::same_as<typename substructure_t::template value_at<Ks / C, Ks % C>,
+                   value_t>...};
+  for (std::size_t k = 0; k < sizeof...(Ks); ++k) {
+    if (eq[k]) {
+      return k;
+    }
+  }
+  return sizeof...(Ks);
+}
+
+/// @brief Canonicalization helper that finds the flat index of the first
+/// matrix element that is equal to the one given.
+///
+/// @tparam substructure_t The substructure to search in (haystack).
+/// @tparam value_t The value to look for (needle).
+///
+/// Given a matrix substructure of:
+///
+/// [[A, B, C],
+///  [D, B, A],
+///  [D, E, A]]
+///
+/// A search for B would return number 1, as the first occurrence in a row-major
+/// order is (0, 1) or flat index 1. Searching for D returns 3, as the first
+/// index is (1, 0) or 3.
+///
+/// This wraps first_equal_flat_index_helper by automatically providing the
+/// index sequence.
+template <typename substructure_t, typename value_t>
+inline constexpr std::size_t first_equal_flat_index_v =
+    first_equal_flat_index_helper<substructure_t, value_t>(
+        std::make_index_sequence<substructure_t::rows *
+                                 substructure_t::columns>{});
+
+/// @brief Helper function for canonicalization, which determines the canonical
+/// value of a matrix at a given coordinate.
+///
+/// @tparam T The substructure to be canonicalized.
+/// @tparam I The row index to compute the canonical element for.
+/// @tparam J The column index to compute the canonical element for.
+///
+/// See @c canonicalize_substructure for more details on how canonicalization
+/// works.
+template <typename T, std::size_t I, std::size_t J>
+struct canonicalize_substructure_helper {
+ private:
+  using curr_value = T::template value_at<I, J>;
+  using resolved_value = typename resolve_value<curr_value>::type;
+
+ public:
+  // Encoded here is the core canonicalization logic. For any given (I, J)
+  // coordinate, we do the following:
+  //
+  // 1. Check if the value at (I, J) is an anonymous variable. If yes, return
+  //    a non-anonymous value with flat index (I, J).
+  // 2. Otherwise, check if the value is a constant integral value. If yes,
+  //    this value is already canonical and we return it as-is.
+  // 3. Otherwise, find the flat index of the first matrix element equal to
+  //    the element at (I, J) (which might well be (I, J)) and return a
+  //    non-anonymous variable with that index.
+  using type = std::conditional_t<
+      std::same_as<curr_value, variable>, index_variable<T::columns * I + J>,
+      std::conditional_t<
+          concepts::is_integral_value<resolved_value>, resolved_value,
+          index_variable<first_equal_flat_index_v<T, curr_value>>>>;
+};
+
+/// @brief A type-level function canonicalize a matrix substructure.
+///
+/// A matrix substructure is canonical if:
+///
+/// 1. The substructure contains only non-anonymous variables or constant
+///    values; and
+/// 2. The application of a chosen canonicalization function is idempotent on
+///    it.
+///
+/// Where a canonicalization function is a function that:
+///
+/// 1. Produces a canonical representation when passed any substructure.
+/// 2. Maps structurally identical matrix values to the same value.
+/// 3. Does not map structurally dissimilar values to the same value.
+///
+/// Note that there are very many possible canonicalization functions which
+/// meet the aforementioned properties, this is just one. This is also why the
+/// aforementioned definition of canonicality is circular.
+///
+/// The canonicalization function here works by mapping constant values to
+/// constant values (which a canonicalization function is definitionally
+/// allowed to do), and it maps any other value to a non-anonymous variable at
+/// the index where the _first_ identical value is found. Note that for this
+/// metric, an anonymous value is _never_ identical to any other value.
+///
+/// Take, as an example, the following matrix (where 0..9 are constants, _ is
+/// an anonymous variable, and A..Z are non-anonymous variables). This matrix
+/// substructure is non-canonical.
+///
+/// [[   A+1,     A,     0],
+///  [   A+B,     C,     _],
+///  [     1,     B,   A+B]]
+///
+/// In the canonical representation, we will refer to non-anonymous variables
+/// using a tuple IJ=X, with the I, J coordinates and the corresponding flat
+/// coordinate.
+///
+/// The canonical substructure for the matrix above is:
+///
+/// [[ 0,0=0, 0,1=1,     0],
+///  [ 1,0=3, 1,1=4, 1,2=5],
+///  [     1, 2,1=7, 1,0=3]]
+///
+/// Translating the non-anonymous indices back to letter forms as [0,1,2,...] =
+/// [A,B,C,...] gives:
+///
+/// [[     A,     B,     0],
+///  [     D,     E,     F],
+///  [     1,     H,     D]]
+///
+/// Note that this procedure has preserved constants, and has mapped both cells
+/// with value A+B to a new non-anonymous variable D.
+///
+/// Confirming that the properties of canonicalization hold is left as an
+/// exercise to the reader. ;)
+template <typename T>
+struct canonicalize_substructure {
+  // We curry the canonicalize_substructure_helper function with the matrix
+  // substructure so that we can call generate_substructure_rows on it.
+  template <std::size_t I, std::size_t J>
+  using accessor = canonicalize_substructure_helper<T, I, J>;
+
+  // To compute the canonical substructure, simply map over a matrix of the
+  // same shape and call into the canonicalize substructure helper.
+  using type = typename generate_substructure_rows<
+      accessor, T::columns, std::make_index_sequence<T::rows>>::type;
+};
+}  // namespace detray::ksm::detail

--- a/Detray/core/include/detray/algebra/common/ksm/detail/index_table.hpp
+++ b/Detray/core/include/detray/algebra/common/ksm/detail/index_table.hpp
@@ -1,0 +1,125 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+// Project include(s)
+#include "detray/algebra/common/ksm/concepts.hpp"
+#include "detray/algebra/common/ksm/value.hpp"
+
+// System include(s)
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <type_traits>
+#include <utility>
+
+// This file assigns storage to the cells of a canonical substructure. Cells
+// that name the same index variable share one stored scalar, and a constant
+// cell is not stored at all, so the map from a coordinate to a slot in the
+// value array is what this file computes.
+namespace detray::ksm::detail {
+/// @brief Helper functions that get the index of an index variable, or a
+/// sentinel value of -1 if another value type is passed.
+///
+/// @tparam T The type for which we want the index.
+///
+/// @{
+template <typename T>
+struct index_variable_getter {
+  using type = std::integral_constant<long, -1>;
+};
+
+template <std::size_t I>
+struct index_variable_getter<index_variable<I>> {
+  using type = std::integral_constant<long, I>;
+};
+/// @}
+
+/// @brief The result of @c make_index_table: the storage slot of every cell,
+/// plus the number of distinct slots.
+template <std::size_t N>
+struct index_table_t {
+  std::array<std::size_t, N> table;
+  std::size_t num_variables;
+};
+
+/// @brief Compute the storage slot of every cell of a canonical substructure.
+///
+/// Cells are visited in row-major flat order. The first cell to name a given
+/// index variable claims the next free slot; a later cell naming the same
+/// variable reuses that slot, which is how symmetry and other repeated
+/// structure end up sharing one scalar. A cell that is not an index variable
+/// is a constant and has no storage, so it is given a sentinel slot.
+///
+/// A matrix of the following shape (where A..H are non-anonymous variables):
+///
+/// [[     A,     B,     0],
+///  [     D,     E,     F],
+///  [     1,     H,     D]]
+///
+/// Will end up storing a 6-element array in memory, which will look like this:
+///
+/// [A, B, D, E, F, H]
+template <typename substructure_t, std::size_t... Ks>
+  requires(concepts::is_canonical<substructure_t>)
+constexpr auto make_index_table(std::index_sequence<Ks...>) {
+  constexpr std::size_t C = substructure_t::columns;
+  constexpr std::array<bool, sizeof...(Ks)> is_indexvar = {
+      (concepts::is_index_variable<
+          typename substructure_t::template value_at<Ks / C, Ks % C>>)...};
+  constexpr std::array<long, sizeof...(Ks)> indexvar_indices = {
+      (index_variable_getter<typename substructure_t::template value_at<
+           Ks / C, Ks % C>>::type::value)...};
+
+  std::array<std::size_t, sizeof...(Ks)> table{};
+  std::size_t acc = 0;
+  for (std::size_t k = 0; k < sizeof...(Ks); ++k) {
+    if (is_indexvar[k]) {
+      bool seen_prev = false;
+      std::size_t prev_idx = 0;
+      for (std::size_t j = 0; j < k; ++j) {
+        if (is_indexvar[j] && indexvar_indices[k] == indexvar_indices[j]) {
+          seen_prev = true;
+          prev_idx = j;
+          break;
+        }
+      }
+
+      if (!seen_prev) {
+        table[k] = acc;
+        ++acc;
+      } else {
+        table[k] = table[prev_idx];
+      }
+    } else {
+      table[k] = std::numeric_limits<std::size_t>::max();
+    }
+  }
+  return index_table_t<sizeof...(Ks)>{table, acc};
+}
+
+/// @brief The index table of a canonical substructure, and the two projections
+/// of it that the substructure itself exposes.
+///
+/// @{
+template <typename substructure_t>
+  requires(concepts::is_canonical<substructure_t>)
+inline constexpr auto index_table_info = make_index_table<substructure_t>(
+    std::make_index_sequence<substructure_t::rows * substructure_t::columns>{});
+
+template <typename substructure_t>
+  requires(concepts::is_canonical<substructure_t>)
+inline constexpr auto index_table = index_table_info<substructure_t>.table;
+
+template <typename substructure_t>
+  requires(concepts::is_canonical<substructure_t>)
+inline constexpr auto get_num_variables =
+    index_table_info<substructure_t>.num_variables;
+/// @}
+}  // namespace detray::ksm::detail

--- a/Detray/core/include/detray/algebra/common/ksm/detail/math_helpers.hpp
+++ b/Detray/core/include/detray/algebra/common/ksm/detail/math_helpers.hpp
@@ -1,0 +1,78 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+// Project include(s)
+#include "detray/algebra/common/ksm/concepts.hpp"
+#include "detray/algebra/common/ksm/detail/symbolic.hpp"
+#include "detray/algebra/common/ksm/value.hpp"
+
+// System include(s)
+#include <concepts>
+
+// This file contains a few helper functions, in particular related to
+// matrix determinants.
+namespace detray::ksm::detail {
+/// @brief Helper functions for getting a matrix determinant as a symbolic
+/// value.
+///
+/// The only important thing this function can return is whether the
+/// determinant is structurally 0, structurally non-zero, or variable.
+///
+/// @{
+template <typename T>
+struct get_determinant_helper {};
+
+// Definitionally, the determinant of a 1x1 matrix is the only value in that
+// matrix.
+template <typename T>
+  requires(T::rows == 1 && T::columns == 1)
+struct get_determinant_helper<T> {
+  using type = T::template value_at<0, 0>;
+};
+
+// As we know, the determinant of [[a, b], [c, d]] is ad-bc. We compute that
+// symbolically here and resolve it to a value.
+template <typename T>
+  requires(T::rows == 2 && T::columns == 2)
+struct get_determinant_helper<T> {
+ private:
+  using t1 = value_multiplication<typename T::template value_at<0, 0>,
+                                  typename T::template value_at<1, 1>>;
+  using t2 = value_multiplication<typename T::template value_at<1, 0>,
+                                  typename T::template value_at<0, 1>>;
+
+  // Recall the syntax of resolve_value: the first bool asks whether all
+  // values are from the same matrix; the second asks if we should collapse
+  // the result to a variable. We don't want to do that yet, just in case
+  // ad and bc are structurally identical. If they are, collapsing to
+  // variables would yield V1-V2 which is not structurally zero.
+  using r1 = resolve_value<t1, true, false>::type;
+  using r2 = resolve_value<t2, true, false>::type;
+
+ public:
+  // Then model the symbolic subtraction. This we _do_ want to resolve to a
+  // variable.
+  using type = resolve_value<value_subtraction<r1, r2>, true, true>::type;
+};
+/// @}
+}  // namespace detray::ksm::detail
+
+namespace detray::ksm::concepts {
+/// @brief True iff the matrix is possibly invertible, i.e. if the determinant
+/// is not structurally zero.
+///
+/// @warning This doesn't guarantee that a matrix is invertible at runtime, as
+/// the runtime values might still make inversion impossible.
+template <typename T>
+concept is_invertible =
+    is_canonical<T> && T::rows == T::columns &&
+    (T::rows == 1 || T::rows == 2) &&
+    !std::same_as<typename detail::get_determinant_helper<T>::type, zero>;
+}  // namespace detray::ksm::concepts

--- a/Detray/core/include/detray/algebra/common/ksm/detail/operator_substructure.hpp
+++ b/Detray/core/include/detray/algebra/common/ksm/detail/operator_substructure.hpp
@@ -1,0 +1,368 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+// Project include(s)
+#include "detray/algebra/common/ksm/detail/math_helpers.hpp"
+#include "detray/algebra/common/ksm/detail/symbolic.hpp"
+#include "detray/algebra/common/ksm/make_substructure.hpp"
+#include "detray/algebra/common/ksm/row.hpp"
+#include "detray/algebra/common/ksm/value.hpp"
+
+// System include(s)
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+
+// This file encodes the substructure of matrices that are the result of
+// certain operations like addition, subtraction, etc.
+//
+// All of these functions only work on canonical substructures. Always
+// canonicalize first!
+namespace detray::ksm::detail {
+/// @brief Type function that computes element (I, J) of the addition of
+/// substructures A+B.
+template <typename substructure_A, typename substructure_B, std::size_t I,
+          std::size_t J>
+  requires(concepts::is_canonical<substructure_A> &&
+           concepts::is_canonical<substructure_B>)
+struct get_addition_element {
+  using A_value_type = substructure_A::template value_at<I, J>;
+  using B_value_type = substructure_B::template value_at<I, J>;
+
+  // The result is simply defined as A_IJ + B_IJ.
+  using type = value_addition<A_value_type, B_value_type>;
+};
+
+/// @brief Type function that computes element (I, J) of the subtraction of
+/// substructures A-B.
+template <typename substructure_A, typename substructure_B, std::size_t I,
+          std::size_t J>
+  requires(concepts::is_canonical<substructure_A> &&
+           concepts::is_canonical<substructure_B>)
+struct get_subtraction_element {
+  using A_value_type = substructure_A::template value_at<I, J>;
+  using B_value_type = substructure_B::template value_at<I, J>;
+
+  // The result is simply defined as A_IJ - B_IJ.
+  using type = value_subtraction<A_value_type, B_value_type>;
+};
+
+/// @brief Type functions to compute a dot product of two rows.
+///
+/// Used to define matrix multiplication.
+///
+/// @{
+template <typename T, typename S>
+struct dot_product {};
+
+// The obvious first specialization here is for non-empty rows.
+template <typename T, typename... Ts, typename S, typename... Ss>
+struct dot_product<row<T, Ts...>, row<S, Ss...>> {
+  // Dot product is defined only for rows of equal size.
+  static_assert(sizeof...(Ts) == sizeof...(Ss));
+
+ private:
+  // We compute both the value at the head of the rows (i.e. the product of
+  // the first value in each row) and then we recurse into this function to
+  // get the remainder.
+  //
+  // NOTE: This computation is technically less strict than it could be, as
+  // it collapses the current value and remaining values to variables.
+  // However, there is relatively little structural advantage to be gained in
+  // matrix multiplication.
+  using rem_val = typename dot_product<row<Ts...>, row<Ss...>>::type;
+  using cur_val = decltype(resolve_symbolic<value_multiplication<T, S>>());
+
+ public:
+  // The resulting type is simply the resolved symbolic computation of the
+  // addition of the head and tail values.
+  using type = decltype(resolve_symbolic<value_addition<cur_val, rem_val>>());
+};
+
+// Then, as the dot product is the sum, the base case is simply the additive
+// identity, zero.
+template <>
+struct dot_product<row<>, row<>> {
+  using type = zero;
+};
+/// @}
+
+/// @brief Type function that computes element (I, J) of the multiplication of
+/// substructures A*B.
+///
+/// This is somewhat more complicated than addition or subtraction, as it needs
+/// a dot product!
+template <typename substructure_A, typename substructure_B, std::size_t I,
+          std::size_t J>
+  requires(concepts::is_canonical<substructure_A> &&
+           concepts::is_canonical<substructure_B>)
+struct get_multiplication_element {
+ private:
+  using A_row_type = typename substructure_A::template row_at<I>;
+  using B_column_type = typename substructure_B::template column_at<J>;
+
+  static_assert(A_row_type::num_values == B_column_type::num_values);
+
+ public:
+  using type = typename dot_product<A_row_type, B_column_type>::type;
+};
+
+/// @brief Type function that computes element (I, J) of a matrix A after
+/// applying the identity to it, i.e. just the element A_IJ!
+template <typename substructure_A, std::size_t I, std::size_t J>
+  requires(concepts::is_canonical<substructure_A>)
+struct get_identity_element {
+  using type = typename substructure_A::template value_at<I, J>;
+};
+
+/// @brief Type function that computes element (I, J) of a matrix A after
+/// negating it, i.e. -A_IJ.
+template <typename substructure_A, std::size_t I, std::size_t J>
+  requires(concepts::is_canonical<substructure_A>)
+struct get_negation_element {
+  using type = value_negation<typename substructure_A::template value_at<I, J>>;
+};
+
+/// @brief Type function that computes the substructure of the addition of
+/// substructures A+B.
+template <typename A, typename B>
+  requires(concepts::is_canonical<A> && concepts::is_canonical<B>)
+struct additive_substructure {
+  static_assert(A::columns == B::columns);
+  static_assert(A::rows == B::rows);
+
+  static constexpr std::size_t columns = A::columns;
+  static constexpr std::size_t rows = A::rows;
+
+  // We simply delegate all logic into a curried version of
+  // get_addition_element!
+  template <std::size_t I, std::size_t J>
+  using accessor = get_addition_element<A, B, I, J>;
+
+  using type =
+      typename generate_substructure_rows<accessor, columns,
+                                          std::make_index_sequence<rows>>::type;
+};
+
+/// @brief Type function that computes the substructure of the subtraction of
+/// substructures A-B.
+template <typename A, typename B>
+  requires(concepts::is_canonical<A> && concepts::is_canonical<B>)
+struct subtractive_substructure {
+  static_assert(A::columns == B::columns);
+  static_assert(A::rows == B::rows);
+
+  static constexpr std::size_t columns = A::columns;
+  static constexpr std::size_t rows = A::rows;
+
+  template <std::size_t I, std::size_t J>
+  using accessor = get_subtraction_element<A, B, I, J>;
+
+  using type =
+      typename generate_substructure_rows<accessor, columns,
+                                          std::make_index_sequence<rows>>::type;
+};
+
+/// @brief Type function that computes the substructure of the multiplication of
+/// substructures A*B.
+template <typename A, typename B>
+  requires(concepts::is_canonical<A> && concepts::is_canonical<B>)
+struct multiplicative_substructure {
+  static_assert(A::columns == B::rows);
+
+  static constexpr std::size_t columns = B::columns;
+  static constexpr std::size_t rows = A::rows;
+
+  template <std::size_t I, std::size_t J>
+  using accessor = get_multiplication_element<A, B, I, J>;
+
+  using type =
+      typename generate_substructure_rows<accessor, columns,
+                                          std::make_index_sequence<rows>>::type;
+};
+
+/// @brief Type function that computes the substructure of negated substructure
+/// -A.
+template <typename A>
+  requires(concepts::is_canonical<A>)
+struct negated_substructure {
+  static constexpr std::size_t columns = A::columns;
+  static constexpr std::size_t rows = A::rows;
+
+  template <std::size_t I, std::size_t J>
+  using accessor = get_negation_element<A, I, J>;
+
+  using type =
+      typename generate_substructure_rows<accessor, columns,
+                                          std::make_index_sequence<rows>>::type;
+};
+
+/// @brief Type function that computes the substructure of A, but with the
+/// upper triangle copied into the lower triangle.
+template <typename A>
+  requires((A::columns == A::rows))
+struct upper_symmetric_substructure {
+  static constexpr std::size_t columns = A::columns;
+  static constexpr std::size_t rows = A::rows;
+
+  template <std::size_t I, std::size_t J>
+  using accessor = std::conditional_t<(I < J), get_identity_element<A, I, J>,
+                                      get_identity_element<A, J, I>>;
+
+  using type =
+      typename generate_substructure_rows<accessor, columns,
+                                          std::make_index_sequence<rows>>::type;
+};
+
+/// @brief Helper function that conditionally upper-triangularizes a
+/// substructure.
+///
+/// Helpful for logic like "produce a symmetric substructure only if the input
+/// to a function is symmetric".
+///
+/// @{
+template <typename T, bool Sym>
+struct upper_symmetric_if {};
+
+template <typename T>
+struct upper_symmetric_if<T, false> {
+  using type = T;
+};
+
+template <typename T>
+struct upper_symmetric_if<T, true> {
+  using type = typename upper_symmetric_substructure<T>::type;
+};
+/// @}
+
+/// @brief Type functions that compute the substructure of inverted
+/// substructure A^-1.
+///
+/// @note This is only supported for dimensions 1 and 2 for now.
+template <typename A>
+struct inverted_substructure {};
+
+// The 1D case.
+template <typename A>
+  requires(concepts::is_canonical<A> && concepts::is_invertible<A> &&
+           A::rows == 1)
+struct inverted_substructure<A> {
+  static constexpr std::size_t columns = A::columns;
+  static constexpr std::size_t rows = A::rows;
+
+  template <std::size_t I, std::size_t J>
+  struct accessor {
+    using type = value_division<integral_value<1>,
+                                typename get_identity_element<A, 0, 0>::type>;
+  };
+
+  using raw_type = typename generate_substructure_rows<
+      accessor, columns, std::make_index_sequence<rows>>::type::canonical_type;
+
+  // Note that symmetrizing a 1D matrix makes little sense, although it also
+  // does no harm...
+  using type = upper_symmetric_if<raw_type, concepts::is_symmetric<A>>::type;
+};
+
+// The 2D case.
+template <typename A>
+  requires(concepts::is_canonical<A> && concepts::is_invertible<A> &&
+           A::rows == 2)
+struct inverted_substructure<A> {
+  static constexpr std::size_t columns = A::columns;
+  static constexpr std::size_t rows = A::rows;
+
+  using det = get_determinant_helper<A>::type;
+
+  template <std::size_t I, std::size_t J>
+  struct accessor {
+    // This just models the standard formula for 2x2 inversion.
+    using type = decltype([]() {
+      if constexpr (I == 0 && J == 0) {
+        return value_division<typename get_identity_element<A, 1, 1>::type,
+                              det>{};
+      } else if constexpr (I == 1 && J == 1) {
+        return value_division<typename get_identity_element<A, 0, 0>::type,
+                              det>{};
+      } else {
+        using neg = typename resolve_value<
+            value_subtraction<zero,
+                              typename get_identity_element<A, I, J>::type>,
+            false, false>::type;
+        return value_division<neg, det>{};
+      }
+    }());
+  };
+
+  using raw_type = typename generate_substructure_rows<
+      accessor, columns, std::make_index_sequence<rows>>::type::canonical_type;
+
+  // Here, we explicitly symmetrize the inverse of a symmetric 2D matrix, as
+  // this symmetry is difficult (but not impossible) to extract through
+  // canonicalization.
+  using type = upper_symmetric_if<raw_type, concepts::is_symmetric<A>>::type;
+};
+
+/// @brief Type functions that compute the substructure of transposed
+/// substructure A^T.
+template <typename A>
+  requires(concepts::is_canonical<A>)
+struct transposed_substructure {
+  static constexpr std::size_t columns = A::rows;
+  static constexpr std::size_t rows = A::columns;
+
+  // Here the identity element comes in handy, we just swap the arguments!
+  //
+  // That's functional programming for you.
+  template <std::size_t I, std::size_t J>
+  using accessor = get_identity_element<A, J, I>;
+
+  using type =
+      typename generate_substructure_rows<accessor, columns,
+                                          std::make_index_sequence<rows>>::type;
+};
+
+/// @brief Type functions that compute the substructure of congruence
+/// substructure ABA^T.
+template <typename A, typename B>
+  requires(concepts::is_canonical<A> && concepts::is_canonical<B>)
+struct congruence_substructure {
+  static_assert(A::columns == B::rows);
+  static_assert(B::columns == A::columns);
+
+  using AB_type =
+      typename multiplicative_substructure<A, B>::type::canonical_type;
+  using ABAT_type = typename multiplicative_substructure<
+      AB_type, typename transposed_substructure<A>::type::canonical_type>::
+      type::canonical_type;
+
+  // This substructure is also explicitly symmetric iff. B is symmetric.
+  //
+  // Proof:
+  //
+  // Q is symmetric if Q = Q^T
+  //
+  // ABA^T = (ABA^T)^T
+  //       = ((A^T)^T)(B^T)(A^T)
+  //       = AB^TA^T
+  //
+  // Iff B is symmetric, B = B^T so:
+  //
+  // AB^TA^T = ABA^T
+  using sym_ABAT_type =
+      typename upper_symmetric_substructure<ABAT_type>::type::canonical_type;
+  static_assert(concepts::is_symmetric<sym_ABAT_type>);
+
+  static constexpr std::size_t columns = A::rows;
+  static constexpr std::size_t rows = A::rows;
+
+  using type = sym_ABAT_type;
+};
+}  // namespace detray::ksm::detail

--- a/Detray/core/include/detray/algebra/common/ksm/detail/symbolic.hpp
+++ b/Detray/core/include/detray/algebra/common/ksm/detail/symbolic.hpp
@@ -1,0 +1,230 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+// Project include(s)
+#include "detray/algebra/common/ksm/concepts.hpp"
+#include "detray/algebra/common/ksm/detail/symbolic_definitions.hpp"
+#include "detray/algebra/common/ksm/value.hpp"
+
+// System include(s)
+#include <concepts>
+
+// This file describes how symbolic operations are built over values, and how
+// they are resolved back down to a value.
+namespace detray::ksm::detail {
+/// @brief Compute the negation of a value.
+template <typename value_t>
+constexpr auto negate_value() {
+  if constexpr (concepts::is_variable<value_t>) {
+    // The negation of a variable, is simply another variable.
+    static_assert(concepts::is_index_variable<value_t>);
+    return value_t{};
+  } else {
+    // The negation of a constant is also just a constant with the sign
+    // flipped.
+    return integral_value<-value_t::value>{};
+  }
+}
+
+/// @brief Resolve a symbolic operation.
+///
+/// @tparam symbolic_t The operation to resolve.
+/// @tparam FromSameMatrix Whether all operands in the operation are from the
+/// same matrix.
+/// @tparam CollapseToVariable Whether to collapse values to variables, or to
+/// keep them in simplified symbolic form.
+template <typename symbolic_t, bool FromSameMatrix = false,
+          bool CollapseToVariable = true>
+constexpr auto resolve_symbolic() {
+  // Check whether we are performing a division by zero statically.
+  static_assert(!(symbolic_t::operation == SymbolicOp::DIV &&
+                  std::same_as<typename symbolic_t::operandB, zero>));
+
+  // This code now branches (statically) across all possible operation types.
+  if constexpr (symbolic_t::operation == SymbolicOp::ADD) {
+    // For addition, we want to model the following function, where o is an
+    // arbitrary operand; if collapsing to a variable is turned on, the result
+    // at the end between parentheses is returned, if different from the result
+    // otherwise:
+    //
+    // (+) (Variable i) o = Symbolic + (Variable i) o (= AnonVariable)
+    // (+) o (Variable i) = Symbolic + o (Variable i) (= AnonVariable)
+    // (+) (Constant i) (Constant j) = Constant (i + j)
+    // (+) oi oj = Symbolic + oi oj (= AnonVariable)
+    //
+    // Note that the last line is unnecessarily generic; if oi or oj are
+    // symbolic operations, we can simplify further. But for now we just
+    // collapse them.
+    if constexpr (concepts::is_variable<typename symbolic_t::operandA> ||
+                  concepts::is_variable<typename symbolic_t::operandB>) {
+      if constexpr (CollapseToVariable) {
+        return variable{};
+      } else {
+        return symbolic_t{};
+      }
+    } else if constexpr (concepts::is_integral_value<
+                             typename symbolic_t::operandA> &&
+                         concepts::is_integral_value<
+                             typename symbolic_t::operandB>) {
+      return integral_value<symbolic_t::operandA::value +
+                            symbolic_t::operandB::value>{};
+    } else {
+      // Neither operand is a variable, and they are not both constants, so at
+      // least one of them has to be a symbolic operation.
+      static_assert(concepts::is_symbolic<typename symbolic_t::operandA> ||
+                    concepts::is_symbolic<typename symbolic_t::operandB>);
+      if constexpr (CollapseToVariable) {
+        return variable{};
+      } else {
+        return symbolic_t{};
+      }
+    }
+  } else if constexpr (symbolic_t::operation == SymbolicOp::SUB) {
+    // For subtraction, we model an almost identical function as addition:
+    //
+    // (-) (Variable i) o = Symbolic - (Variable i) o (= AnonVariable)
+    // (-) o (Variable i) = Symbolic - o (Variable i) (= AnonVariable)
+    // (-) (Constant i) (Constant j) = Constant (i - j)
+    // (-) oi oj = Symbolic - oi oj (= AnonVariable)
+    //
+    // With the critical difference that, if the objects are from the same
+    // matrix, we can return zero if subtracting a variable from itself.
+    if constexpr (FromSameMatrix &&
+                  std::same_as<typename symbolic_t::operandA,
+                               typename symbolic_t::operandB>) {
+      return zero{};
+    } else if constexpr (concepts::is_variable<typename symbolic_t::operandA> ||
+                         concepts::is_variable<typename symbolic_t::operandB>) {
+      if constexpr (CollapseToVariable) {
+        return variable{};
+      } else {
+        return symbolic_t{};
+      }
+    } else if constexpr (concepts::is_integral_value<
+                             typename symbolic_t::operandA> &&
+                         concepts::is_integral_value<
+                             typename symbolic_t::operandB>) {
+      return integral_value<symbolic_t::operandA::value -
+                            symbolic_t::operandB::value>{};
+    } else {
+      // As with addition: at least one operand must be a symbolic operation.
+      static_assert(concepts::is_symbolic<typename symbolic_t::operandA> ||
+                    concepts::is_symbolic<typename symbolic_t::operandB>);
+      if constexpr (CollapseToVariable) {
+        return variable{};
+      } else {
+        return symbolic_t{};
+      }
+    }
+  } else if constexpr (symbolic_t::operation == SymbolicOp::MUL) {
+    // For multiplication we model the following:
+    //
+    // (*) o (Constant 0) = Constant 0
+    // (*) (Constant 0) o = Constant 0
+    // (*) (Variable i) o = Symbolic * (Variable i) o (= AnonVariable)
+    // (*) o (Variable i) = Symbolic * o (Variable i) (= AnonVariable)
+    // (*) (Constant i) (Constant j) = Constant (i * j)
+    // (*) oi oj = Symbolic * oi oj (= AnonVariable)
+    if constexpr (std::same_as<typename symbolic_t::operandA, zero> ||
+                  std::same_as<typename symbolic_t::operandB, zero>) {
+      return zero{};
+    } else if constexpr (concepts::is_variable<typename symbolic_t::operandA> ||
+                         concepts::is_variable<typename symbolic_t::operandB>) {
+      if constexpr (CollapseToVariable) {
+        return variable{};
+      } else {
+        return symbolic_t{};
+      }
+    } else if constexpr (concepts::is_integral_value<
+                             typename symbolic_t::operandA> &&
+                         concepts::is_integral_value<
+                             typename symbolic_t::operandB>) {
+      return integral_value<symbolic_t::operandA::value *
+                            symbolic_t::operandB::value>{};
+    } else {
+      // As with addition: at least one operand must be a symbolic operation.
+      static_assert(concepts::is_symbolic<typename symbolic_t::operandA> ||
+                    concepts::is_symbolic<typename symbolic_t::operandB>);
+      if constexpr (CollapseToVariable) {
+        return variable{};
+      } else {
+        return symbolic_t{};
+      }
+    }
+  } else if constexpr (symbolic_t::operation == SymbolicOp::DIV) {
+    // For division we model the most complex function, but we simplify it
+    // quite a bit:
+    //
+    // (/) o (Constant 0) = Error
+    // (/) o (Constant 1) = o
+    // (/) (Constant 0) o = Constant 0
+    // (/) oi oj = Symbolic / oi oj (= AnonVariable)
+    if constexpr (std::same_as<typename symbolic_t::operandB, one>) {
+      return typename symbolic_t::operandA{};
+    } else if constexpr (std::same_as<typename symbolic_t::operandA, zero>) {
+      return zero{};
+    } else {
+      // Could handle division of constants here, but has only marginal returns.
+      if constexpr (CollapseToVariable) {
+        return variable{};
+      } else {
+        return symbolic_t{};
+      }
+    }
+  }
+}
+
+/// @brief Resolver for any value, including ones that are not symbolic
+/// operations.
+///
+/// @{
+template <typename value_t, bool = false, bool = true>
+struct resolve_value {};
+
+// For symbolic operations, call into resolve_symbolic.
+template <typename value_t, bool FromSameMatrix, bool CollapseToVariable>
+  requires(concepts::is_symbolic<value_t>)
+struct resolve_value<value_t, FromSameMatrix, CollapseToVariable> {
+  using type =
+      decltype(resolve_symbolic<value_t, FromSameMatrix, CollapseToVariable>());
+};
+
+// For non-operations, simply return the input!
+template <typename value_t, bool FromSameMatrix, bool CollapseToVariable>
+  requires(!concepts::is_symbolic<value_t>)
+struct resolve_value<value_t, FromSameMatrix, CollapseToVariable> {
+  using type = value_t;
+};
+/// @}
+
+/// @brief Helper functions for common operations
+///
+/// @{
+template <typename A, typename B>
+  requires(concepts::is_value<A> && concepts::is_value<B>)
+using value_addition = symbolic<SymbolicOp::ADD, A, B>;
+
+template <typename A, typename B>
+  requires(concepts::is_value<A> && concepts::is_value<B>)
+using value_subtraction = symbolic<SymbolicOp::SUB, A, B>;
+
+template <typename A, typename B>
+  requires(concepts::is_value<A> && concepts::is_value<B>)
+using value_multiplication = symbolic<SymbolicOp::MUL, A, B>;
+
+template <typename A, typename B>
+  requires(concepts::is_value<A> && concepts::is_value<B>)
+using value_division = symbolic<SymbolicOp::DIV, A, B>;
+
+template <typename value_t>
+  requires(concepts::is_value<value_t>)
+using value_negation = decltype(negate_value<value_t>());
+/// @}
+}  // namespace detray::ksm::detail

--- a/Detray/core/include/detray/algebra/common/ksm/detail/symbolic_definitions.hpp
+++ b/Detray/core/include/detray/algebra/common/ksm/detail/symbolic_definitions.hpp
@@ -1,0 +1,24 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+// This file defines a simple struct that models symbolic operations.
+namespace detray::ksm::detail {
+/// @brief Symbolic operators: addition, subtraction, multiplication, and
+/// division.
+enum class SymbolicOp { ADD, SUB, MUL, DIV };
+
+/// @brief Symbolic operator that models A OP B.
+template <SymbolicOp Op, typename A, typename B>
+struct symbolic {
+  static constexpr SymbolicOp operation = Op;
+  using operandA = A;
+  using operandB = B;
+};
+}  // namespace detray::ksm::detail

--- a/Detray/core/include/detray/algebra/common/ksm/fwd.hpp
+++ b/Detray/core/include/detray/algebra/common/ksm/fwd.hpp
@@ -1,0 +1,18 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+// This file contains just forward declarations.
+namespace detray::ksm {
+template <typename... value_ts>
+struct row;
+
+template <typename... row_ts>
+struct substructure;
+}  // namespace detray::ksm

--- a/Detray/core/include/detray/algebra/common/ksm/make_substructure.hpp
+++ b/Detray/core/include/detray/algebra/common/ksm/make_substructure.hpp
@@ -1,0 +1,161 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+// Project include(s)
+#include "detray/algebra/common/ksm/fwd.hpp"
+#include "detray/algebra/common/ksm/value.hpp"
+
+// System include(s)
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+
+// This file contains logic to create some common substructures.
+namespace detray::ksm {
+namespace detail {
+/// @brief The bread and butter of all substructure generation, these types
+/// respectively generate a row and a whole substructure using a callable.
+///
+/// @{
+///
+/// @brief Helper functions for @c generate_substructure_rows
+///
+/// @{
+template <template <std::size_t, std::size_t> typename C, std::size_t I,
+          typename T>
+struct generate_substructure_values {};
+
+template <template <std::size_t, std::size_t> typename C, std::size_t I,
+          std::size_t... Js>
+struct generate_substructure_values<C, I,
+                                    std::integer_sequence<std::size_t, Js...>> {
+  using type = row<typename C<I, Js>::type...>;
+};
+/// @}
+
+/// @brief Generate a substructure using a generator function and a size.
+///
+/// This type function takes a function (I, J) -> Value which generates the
+/// value at each index, then it takes a number of columns N, and a integer
+/// sequence of row indices Is...
+///
+/// @{
+template <template <std::size_t, std::size_t> typename C, std::size_t N,
+          typename T>
+struct generate_substructure_rows {};
+
+template <template <std::size_t, std::size_t> typename C, std::size_t N,
+          std::size_t... Is>
+struct generate_substructure_rows<C, N,
+                                  std::integer_sequence<std::size_t, Is...>> {
+  using type = substructure<typename generate_substructure_values<
+      C, Is, std::make_index_sequence<N>>::type...>;
+};
+/// @}
+/// @}
+
+/// @brief Helper function for @c symmetric_cell; computes the packed index of
+/// a cell of an NxN symmetric matrix, counting only the upper triangle.
+///
+/// A cell in the lower triangle is mirrored into the upper one first, so (i, j)
+/// and (j, i) get the same index, which is what makes them share a variable.
+/// The indices run 0 to N*(N+1)/2 - 1 in row-major order *within the upper
+/// triangle*, so they are not row-major indices of the full matrix: for N = 3,
+/// (1, 1) is 3 here and 4 there.
+template <std::size_t N>
+constexpr std::size_t symmetric_index(std::size_t i, std::size_t j) {
+  if (i > j) {
+    std::size_t t = i;
+    i = j;
+    j = t;
+  }
+  std::size_t idx = 0;
+  for (std::size_t r = 0; r < i; ++r)
+    idx += (N - r);
+  return idx + (j - i);
+}
+
+/// @brief Helper for fully dense matrices; always returns an anonymous
+/// variable.
+template <std::size_t I, std::size_t J>
+struct dense_cell {
+  using type = variable;  // every cell an independent variable
+};
+
+/// @brief Helper for diagonal matrices; variable on the diagonal and zero
+/// elsewhere.
+template <std::size_t I, std::size_t J>
+struct diagonal_cell {
+  using type = std::conditional_t<(I == J), variable, zero>;
+};
+
+/// @brief Helper for identity matrices; one on the diagonal and zero
+/// elsewhere.
+template <std::size_t I, std::size_t J>
+struct identity_cell {
+  using type = std::conditional_t<(I == J), one, zero>;
+};
+
+/// @brief Helper for symmetric matrices. A cell in the lower triangle names
+/// the same variable as its mirror in the upper triangle, so the two share one
+/// stored scalar.
+template <std::size_t N>
+struct symmetric_cell {
+  template <std::size_t I, std::size_t J>
+  struct cell {
+    using type = index_variable<symmetric_index<N>(I, J)>;
+  };
+};
+
+/// @brief Helper for matrices whose K leftmost columns hold variables, every
+/// further column being a structural zero.
+template <std::size_t K>
+struct left_columns_cell {
+  template <std::size_t I, std::size_t J>
+  struct cell {
+    using type = std::conditional_t<(J < K), variable, zero>;
+  };
+};
+
+}  // namespace detail
+
+/// @brief General substructure creator. Takes a helper function, a number
+/// of rows and columns, and generates a substructure.
+template <template <std::size_t, std::size_t> typename C, std::size_t Rows,
+          std::size_t Cols>
+using make_substructure = typename detail::generate_substructure_rows<
+    C, Cols, std::make_integer_sequence<std::size_t, Rows>>::type;
+
+/// @brief Generate a fully dense substructure.
+template <std::size_t Rows, std::size_t Cols = Rows>
+using make_dense_substructure =
+    make_substructure<detail::dense_cell, Rows, Cols>;
+
+/// @brief Generate a symmetric substructure.
+template <std::size_t N>
+using make_symmetric_substructure =
+    make_substructure<detail::symmetric_cell<N>::template cell, N, N>;
+
+/// @brief Generate a diagonal substructure.
+template <std::size_t N>
+using make_diagonal_substructure =
+    make_substructure<detail::diagonal_cell, N, N>;
+
+/// @brief Generate an identity substructure.
+template <std::size_t N>
+using make_identity_substructure =
+    make_substructure<detail::identity_cell, N, N>;
+
+/// @brief Generate a substructure whose K leftmost columns hold variables,
+/// every further column being a structural zero.
+template <std::size_t Rows, std::size_t Cols, std::size_t K>
+using make_left_columns_substructure =
+    make_substructure<detail::left_columns_cell<K>::template cell, Rows, Cols>;
+}  // namespace detray::ksm

--- a/Detray/core/include/detray/algebra/common/ksm/matrix.hpp
+++ b/Detray/core/include/detray/algebra/common/ksm/matrix.hpp
@@ -1,0 +1,686 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+// Project include(s)
+#include "detray/algebra/common/ksm/concepts.hpp"
+#include "detray/algebra/common/ksm/detail/math_helpers.hpp"
+#include "detray/algebra/common/ksm/substructure.hpp"
+#include "detray/algebra/common/ksm/value.hpp"
+#include "detray/algebra/concepts.hpp"
+#include "detray/definitions/algebra.hpp"
+#include "detray/definitions/detail/assert.hpp"
+#include "detray/definitions/detail/qualifiers.hpp"
+
+// System include(s)
+#include <array>
+#include <concepts>
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+
+// Silence a false positive nvcc warning.
+#ifdef __CUDACC__
+#pragma nv_diag_suppress 445
+#endif
+
+// This file defines the KSM matrix, which materializes a substructure into a
+// type that can actually be used.
+namespace detray::ksm {
+
+/// @brief The primary KSM matrix type.
+///
+/// This type is defined as a substructure and a scalar type, and manifests as
+/// a real, usable C++ type that can be used to perform matrix arithmetic.
+template <typename substructure_t, typename scalar_t>
+struct matrix {
+  /// @brief The substructure types, both as-is and the canonical variant
+  ///
+  /// @{
+  using substructure_type = substructure_t;
+  using canonical_substructure_type = typename substructure_t::canonical_type;
+  /// @}
+
+  // Protect against absolutely disastrous failures in the canonicalization
+  // algorithm
+  static_assert(substructure_type::columns ==
+                canonical_substructure_type::columns);
+  static_assert(substructure_type::rows == canonical_substructure_type::rows);
+  static_assert(std::same_as<canonical_substructure_type,
+                             typename detail::canonicalize_substructure<
+                                 canonical_substructure_type>::type>);
+  static_assert(concepts::is_canonical<canonical_substructure_type>);
+
+  /// @brief The scalar type stored inside this matrix.
+  using scalar_type = scalar_t;
+
+  /// @brief The shape of the matrix
+  ///
+  /// @{
+  static constexpr std::size_t rows = substructure_t::rows;
+  static constexpr std::size_t columns = substructure_t::columns;
+  /// @}
+
+  /// @brief Constant accessor for a value at a given index.
+  ///
+  /// Because substructures are compile-time, we must accept the indices I and
+  /// J as template arguments (unless we want to emit an enormous jumble of
+  /// if-else clauses).
+  template <std::size_t I, std::size_t J>
+  DETRAY_HOST_DEVICE scalar_t at() const {
+    using value_t =
+        typename canonical_substructure_type::template value_at<I, J>;
+
+    static_assert(concepts::is_canonical_value<value_t>);
+
+    // Decide whether the value is structural or not; if it is, just return
+    // the value as a scalar. If it is a runtime value, load it from memory
+    // using the element_index accessor.
+    if constexpr (concepts::is_index_variable<value_t>) {
+      return m_elems[canonical_substructure_type::template element_index<I, J>];
+    } else {
+      return static_cast<scalar_t>(
+          canonical_substructure_type::template value_at<I, J>::value);
+    }
+  }
+
+  /// @brief Mutable accessor for a value at a given index.
+  ///
+  /// Because a mutable accessor to a structural value makes no sense, this
+  /// function carries a requires clause which makes it a compile-time error
+  /// to try to assign a value to a structural cell. This may make the API of
+  /// this type less ergonomic at first, but it allows us to enforce structure
+  /// at compile time which is an enormously powerful tool.
+  template <std::size_t I, std::size_t J>
+    requires(concepts::is_index_variable<
+             typename canonical_substructure_type::template value_at<I, J>>)
+  DETRAY_HOST_DEVICE scalar_t &at() {
+    using value_t =
+        typename canonical_substructure_type::template value_at<I, J>;
+
+    static_assert(concepts::is_canonical_value<value_t>);
+    return m_elems[canonical_substructure_type::template element_index<I, J>];
+  }
+
+  /// @brief Constant accessor for a value at a given index, with detray
+  /// terminology.
+  template <std::size_t I, std::size_t J>
+  DETRAY_HOST_DEVICE scalar_t element() const {
+    return this->template at<I, J>();
+  }
+
+  /// @brief Mutable accessor for a value at a given index, with detray
+  /// terminology.
+  template <std::size_t I, std::size_t J>
+    requires(concepts::is_index_variable<
+             typename canonical_substructure_type::template value_at<I, J>>)
+  DETRAY_HOST_DEVICE scalar_t &element() {
+    return this->template at<I, J>();
+  }
+
+  /// @returns The identity matrix in this substructure.
+  ///
+  /// For this function to be usable, the substructure must have only
+  /// variables or static ones on the diagonal, and static zeroes or variables
+  /// on the other cells.
+  DETRAY_HOST_DEVICE static matrix identity()
+    requires(concepts::can_represent_identity<canonical_substructure_type>)
+  {
+    matrix rv{};
+    // fill_with already skips a cell without storage, and writes a shared one
+    // only through the cell that owns it. The requires clause above is what
+    // makes that the right thing to do: it rules out a constant cell that
+    // disagrees with the identity, and cells sharing a variable that want
+    // different values.
+    fill_with(rv, []<std::size_t I, std::size_t J>() {
+      return (I == J) ? scalar_t{1} : scalar_t{0};
+    });
+    return rv;
+  }
+
+  /// @brief Turn this matrix into a dense detray matrix with the same values.
+  template <::detray::concepts::algebra algebra_t>
+  DETRAY_HOST_DEVICE dmatrix<algebra_t, rows, columns> to_dense() const {
+    dmatrix<algebra_t, rows, columns> rv{};
+    to_dense_cells<algebra_t>(rv, std::make_index_sequence<rows * columns>{});
+    return rv;
+  }
+
+  /// @brief Create a structured matrix from a dense detray matrix.
+  template <::detray::concepts::algebra algebra_t>
+  DETRAY_HOST_DEVICE static matrix from_dense(
+      const dmatrix<algebra_t, rows, columns> &m) {
+    matrix rv{};
+    // Load first, then check. fill_with writes each stored value once, through
+    // the cell that owns it, and skips the cells the substructure fixes.
+    fill_with(rv, [&m]<std::size_t I, std::size_t J>() {
+      return static_cast<scalar_t>(getter::element<I, J>(m));
+    });
+    rv.check_dense_cells(m, std::make_index_sequence<rows * columns>{});
+    return rv;
+  }
+
+  /// @brief Copy every element of another matrix into this matrix, at a given
+  /// offset.
+  template <std::size_t RowOffset, std::size_t ColOffset, typename src_t>
+  DETRAY_HOST_DEVICE void copy_from(const src_t &src) {
+    constexpr auto src_rows =
+        static_cast<std::size_t>(::detray::traits::rows<src_t>);
+    constexpr auto src_columns =
+        static_cast<std::size_t>(::detray::traits::columns<src_t>);
+
+    static_assert(RowOffset + src_rows <= rows,
+                  "the copied elements do not fit the destination");
+    static_assert(ColOffset + src_columns <= columns,
+                  "the copied elements do not fit the destination");
+
+    const auto element_of =
+        [&src]<std::size_t I, std::size_t J>() -> decltype(auto) {
+      // Read cell (I, J) of src, which may be a dense matrix or a vector. A
+      // vector stands for a single column, so only its row index is meaningful.
+      if constexpr (::detray::concepts::matrix<src_t>) {
+        return ::detray::getter::element<I, J>(src);
+      } else {
+        static_assert(J == 0u, "a vector stands for a single column");
+        return ::detray::getter::element<I>(src);
+      }
+    };
+
+    [this, &element_of]<std::size_t... Ks>(std::index_sequence<Ks...>) {
+      ((this->template at<RowOffset + Ks / src_columns,
+                          ColOffset + Ks % src_columns>() =
+            static_cast<scalar_t>(
+                element_of.template
+                operator()<Ks / src_columns, Ks % src_columns>())),
+       ...);
+    }(std::make_index_sequence<src_rows * src_columns>{});
+  }
+
+  /// @brief Compute the product of this structured matrix with another.
+  template <typename other_substructure_t>
+  DETRAY_HOST_DEVICE auto operator*(
+      const matrix<other_substructure_t, scalar_t> &o) const {
+    using result_type = matrix<
+        typename canonical_substructure_type::template multiplication_type<
+            typename other_substructure_t::canonical_type>,
+        scalar_t>;
+
+    result_type rv{};
+    // For multiplication we fully rely on the `product_dot` helper function
+    // to compute the value at each cell.
+    fill_with(rv, [this, &o]<std::size_t I, std::size_t J>() {
+      return this->template product_dot<I, J>(
+          o, std::make_index_sequence<canonical_substructure_type::columns>{});
+    });
+    return rv;
+  }
+
+  /// @brief Compute the addition of this structured matrix with another.
+  template <typename other_substructure_t>
+  DETRAY_HOST_DEVICE auto operator+(
+      const matrix<other_substructure_t, scalar_t> &o) const {
+    using result_type =
+        matrix<typename canonical_substructure_type::template addition_type<
+                   typename other_substructure_t::canonical_type>,
+               scalar_t>;
+
+    result_type rv{};
+    fill_with(rv, [this, &o]<std::size_t I, std::size_t J>() {
+      // Here we essentially re-encode the algebra system defined in the
+      // substructure: A + 0 = A, 0 + A = A, and anything else we just add up
+      // as usual. This is important so we do not emit useless additions with
+      // zero.
+      using A_val =
+          typename canonical_substructure_type::template value_at<I, J>;
+      using B_val =
+          typename other_substructure_t::canonical_type::template value_at<I,
+                                                                           J>;
+      if constexpr (std::same_as<A_val, zero>) {
+        return o.template at<I, J>();
+      } else if constexpr (std::same_as<B_val, zero>) {
+        return this->template at<I, J>();
+      } else {
+        return this->template at<I, J>() + o.template at<I, J>();
+      }
+    });
+    return rv;
+  }
+
+  /// @brief Compute the subtraction of this structured matrix with another.
+  template <typename other_substructure_t>
+  DETRAY_HOST_DEVICE auto operator-(
+      const matrix<other_substructure_t, scalar_t> &o) const {
+    using result_type =
+        matrix<typename canonical_substructure_type::template subtraction_type<
+                   typename other_substructure_t::canonical_type>,
+               scalar_t>;
+
+    result_type rv{};
+    fill_with(rv, [this, &o]<std::size_t I, std::size_t J>() {
+      // Same logic as with addition. Note that we don't need to account for
+      // the case where we subtract something from itself, as the substructure
+      // will already have reduced that to a structural zero!
+      using A_val =
+          typename canonical_substructure_type::template value_at<I, J>;
+      using B_val =
+          typename other_substructure_t::canonical_type::template value_at<I,
+                                                                           J>;
+      if constexpr (std::same_as<A_val, zero>) {
+        return -o.template at<I, J>();
+      } else if constexpr (std::same_as<B_val, zero>) {
+        return this->template at<I, J>();
+      } else {
+        return this->template at<I, J>() - o.template at<I, J>();
+      }
+    });
+    return rv;
+  }
+
+  /// @brief Compute the congruence of this structured matrix with another,
+  /// i.e. compute this * other * this^T.
+  template <typename other_substructure_t>
+  DETRAY_HOST_DEVICE auto congruence(
+      const matrix<other_substructure_t, scalar_t> &o) const {
+    using result_type =
+        matrix<typename canonical_substructure_type::template congruence_type<
+                   typename other_substructure_t::canonical_type>,
+               scalar_t>;
+
+    // First we compute the product this * other, and then this^T separately.
+    const auto ab = *this * o;
+    const auto at = this->transpose();
+
+    result_type rv{};
+    // Note that, in this case, fill_with is smart enough to recognise that
+    // the result type (as decided by the substructure) is symmetric if the
+    // other matrix is symmetric, and it will compute and write the shared
+    // cells only once.
+    fill_with(rv, [&ab, &at]<std::size_t I, std::size_t J>() {
+      return ab.template product_dot<I, J>(
+          at, std::make_index_sequence<canonical_substructure_type::columns>{});
+    });
+    return rv;
+  }
+
+  /// @brief Compute the inverse of this structured matrix.
+  ///
+  /// @note Currently only works for dimensions 1 and 2.
+  DETRAY_HOST_DEVICE auto inverse() const {
+    using result_type = matrix<typename detail::inverted_substructure<
+                                   canonical_substructure_type>::type,
+                               scalar_t>;
+
+    result_type rv{};
+
+    // Check some constraints that are relevant for inversion.
+    static_assert(rows == 1 || rows == 2);
+    static_assert(concepts::is_invertible<canonical_substructure_type>);
+
+    using determinant_type =
+        detail::get_determinant_helper<canonical_substructure_type>::type;
+
+    static_assert(!std::same_as<determinant_type, zero>);
+
+    // HACK: This code is a big mess; hopefully we can refactor it in the
+    // future to be more readable.
+
+    scalar_t det;
+
+    // Compute the determinant first.
+    if constexpr (std::same_as<determinant_type, one>) {
+      // This should never be used, as we will use the structural knowledge
+      // to avoid division entirely.
+      det = scalar_t{0};
+    } else {
+      // If the determinant is not structurally one, compute it for the 1D and
+      // 2D cases.
+      if constexpr (rows == 1) {
+        det = this->template at<0, 0>();
+      } else {
+        det = this->template at<0, 0>() * this->template at<1, 1>() -
+              this->template at<1, 0>() * this->template at<0, 1>();
+      }
+    }
+
+    // Then compute the inverse.
+    if constexpr (rows == 1) {
+      // The 1D case is easy, we just divide by the determinant. Special case
+      // if the value of the sole element in the matrix is one.
+      fill_with(rv, [this, det]<std::size_t I, std::size_t J>() {
+        if constexpr (std::same_as<determinant_type, one>) {
+          return this->template at<I, J>();
+        } else {
+          return scalar_t{1} / det;
+        }
+      });
+    } else {
+      // My apologies for anyone reading this. This is the logic for turning
+      // the matrix [[a, b], [c, d]] into the matrix [[d, -b], [-c, a]].
+      fill_with(rv, [this, det]<std::size_t I, std::size_t J>() {
+        if constexpr (std::same_as<determinant_type, one>) {
+          if constexpr (I == 0 && J == 0) {
+            return this->template at<1, 1>();
+          } else if constexpr (I == 1 && J == 1) {
+            return this->template at<0, 0>();
+          } else {
+            return -this->template at<I, J>();
+          }
+        } else {
+          if constexpr (I == 0 && J == 0) {
+            return this->template at<1, 1>() / det;
+          } else if constexpr (I == 1 && J == 1) {
+            return this->template at<0, 0>() / det;
+          } else {
+            return -this->template at<I, J>() / det;
+          }
+        }
+      });
+    }
+
+    return rv;
+  }
+
+  /// @brief Compute the transpose of this structured matrix.
+  DETRAY_HOST_DEVICE auto transpose() const {
+    using result_type = matrix<typename detail::transposed_substructure<
+                                   canonical_substructure_type>::type,
+                               scalar_t>;
+
+    result_type rv{};
+    // This one is delightfully simple, we just get the position at the
+    // swapped indices!
+    fill_with(rv, [this]<std::size_t I, std::size_t J>() {
+      return this->template at<J, I>();
+    });
+    return rv;
+  }
+
+  /// @brief Compute the negative of this structured matrix.
+  DETRAY_HOST_DEVICE auto operator-() const {
+    using result_type = matrix<typename detail::negated_substructure<
+                                   canonical_substructure_type>::type,
+                               scalar_t>;
+
+    result_type rv{};
+    // This one is also easy.
+    fill_with(rv, [this]<std::size_t I, std::size_t J>() {
+      return -this->template at<I, J>();
+    });
+    return rv;
+  }
+
+ private:
+  /// @brief Write every cell, structural ones included, into a dense matrix.
+  template <typename algebra_t, typename dense_t, std::size_t... Ks>
+  DETRAY_HOST_DEVICE void to_dense_cells(dense_t &rv,
+                                         std::index_sequence<Ks...>) const {
+    ((getter::element<Ks / columns, Ks % columns>(rv) =
+          static_cast<dscalar<algebra_t>>(
+              this->template at<Ks / columns, Ks % columns>())),
+     ...);
+  }
+
+  /// @brief Check that cell (I, J) of the dense matrix holds what this
+  /// substructure needs.
+  ///
+  /// This functions as a debug assertion for `from_dense`.
+  ///
+  /// @{
+  template <std::size_t I, std::size_t J, typename dense_t>
+  DETRAY_HOST_DEVICE void check_dense_cell(
+      [[maybe_unused]] const dense_t &m) const {
+    using value_t =
+        typename canonical_substructure_type::template value_at<I, J>;
+
+    if constexpr (concepts::is_index_variable<value_t>) {
+      assert((static_cast<scalar_t>(getter::element<I, J>(m)) ==
+              this->template at<I, J>()));
+    } else {
+      assert((static_cast<scalar_t>(getter::element<I, J>(m)) ==
+              static_cast<scalar_t>(value_t::value)));
+    }
+  }
+
+  template <typename dense_t, std::size_t... Ks>
+  DETRAY_HOST_DEVICE void check_dense_cells(const dense_t &m,
+                                            std::index_sequence<Ks...>) const {
+    (check_dense_cell<Ks / columns, Ks % columns>(m), ...);
+  }
+  /// @}
+
+  /// @brief Helper function for the dot product, where both terms are
+  /// constants.
+  ///
+  /// Computes the product between A_IK and B_KJ, for use in the product of
+  /// row I of A and column J of B.
+  ///
+  /// @warning This returns 0, the additive identity, when either value is not
+  /// an integral value.
+  template <std::size_t I, std::size_t J, typename other_substructure_t,
+            std::size_t K>
+  DETRAY_HOST_DEVICE static constexpr long dot_term_constant() {
+    using A_val = typename canonical_substructure_type::template value_at<I, K>;
+    using B_val =
+        typename other_substructure_t::canonical_type::template value_at<K, J>;
+    if constexpr (concepts::is_integral_value<A_val> &&
+                  concepts::is_integral_value<B_val>) {
+      return static_cast<long>(A_val::value) * static_cast<long>(B_val::value);
+    } else {
+      return 0;
+    }
+  }
+
+  /// @brief Compute the sum of constants in the dot product of two rows.
+  template <std::size_t I, std::size_t J, typename other_substructure_t,
+            std::size_t... Ks>
+  DETRAY_HOST_DEVICE static constexpr long dot_constant_offset(
+      std::index_sequence<Ks...>) {
+    // Unlike everything we do at runtime on floating point numbers, we can
+    // add a zero at the front of this fold expression without any cost, as
+    // the compiler can elide that without risk.
+    //
+    // Recall that dot_term_constant computes the product of row I of A and
+    // column J of B, and Ks are the indices along those rows.
+    return (0 + ... + dot_term_constant<I, J, other_substructure_t, Ks>());
+  }
+
+  /// @brief Compute the value of the dot product for variables.
+  ///
+  /// This function uses the index K to determine the position along row I
+  /// of matrix A and column J of matrix B, and recurses with the tail Ks.
+  template <std::size_t I, std::size_t J, typename other_substructure_t,
+            std::size_t K, std::size_t... Ks>
+  DETRAY_HOST_DEVICE auto product_dot_vars(
+      const matrix<other_substructure_t, scalar_t> &o,
+      std::index_sequence<K, Ks...>) const {
+    using A_val = typename canonical_substructure_type::template value_at<I, K>;
+    using B_val =
+        typename other_substructure_t::canonical_type::template value_at<K, J>;
+
+    // First, we compute if this multiplication will result in a zero value
+    // because either operand is zero.
+    //
+    // NOTE: The substructure has already done this computation, but we do it
+    // again for the runtime logic here.
+    constexpr bool is_zero_term =
+        std::same_as<A_val, zero> || std::same_as<B_val, zero>;
+
+    // Second, check whether the result of this computation will be constant.
+    constexpr bool both_const = concepts::is_integral_value<A_val> &&
+                                concepts::is_integral_value<B_val>;
+
+    // Finally, check whether this will actually produce a variable.
+    constexpr bool is_var_term = !is_zero_term && !both_const;
+
+    // Check whether we have any additional tail to process. This logic is so
+    // complex simply to minimize the number of addition instructions we emit.
+    // At compile time we can emit as much nonsense as we want and it will not
+    // affect runtimes, but here we don't have that luxury so we have to
+    // carefully break down all cases.
+    if constexpr (sizeof...(Ks) > 0) {
+      // First, the case where we have a tail. First, recurse to find the
+      // value of the remainder of this dot product. Note that this might be
+      // a scalar or a compile-time constant!
+      const auto rem = product_dot_vars<I, J>(o, std::index_sequence<Ks...>{});
+      using rem_type = std::decay_t<decltype(rem)>;
+
+      if constexpr (!is_var_term) {
+        // If this case returns a non-variable, we simply return the
+        // remainder of the dot product.
+        //
+        // NOTE: The attentive reader will ask: "what about the constant value
+        // product of the values at K?!". The answer is that those structural
+        // constants will be pooled together by dot_term_constant in order to,
+        // again, minimize runtime flops.
+        return rem;
+      } else if constexpr (std::same_as<A_val, one>) {
+        // If we do return a variable but A is one, the value of this
+        // multiplication pair is determined entirely by B.
+        if constexpr (std::same_as<rem_type, zero>) {
+          // If the remainder is structurally zero, don't emit B + 0 but just
+          // B.
+          return o.template at<K, J>();
+        } else {
+          // If the remainder is non-zero, emit an addition flop.
+          return o.template at<K, J>() + rem;
+        }
+      } else if constexpr (std::same_as<B_val, one>) {
+        // Similar case to above, but this time B is one, so the product is
+        // determined by A.
+        if constexpr (std::same_as<rem_type, zero>) {
+          // If the remainder is zero, don't emit A + 0, but just A.
+          return this->template at<I, K>();
+        } else {
+          // Otherwise, emit the full addition.
+          return this->template at<I, K>() + rem;
+        }
+      } else {
+        // In all other cases, we have to compute the product of A and B,
+        // because we know them only at runtime.
+        if constexpr (std::same_as<rem_type, zero>) {
+          // Same logic as before. If the remainder is zero, emit just (A * B)
+          return this->template at<I, K>() * o.template at<K, J>();
+        } else {
+          // Otherwise, emit (A * B) + R.
+          return this->template at<I, K>() * o.template at<K, J>() + rem;
+        }
+      }
+    } else {
+      // If there is no tail to the dot product, the logic becomes simpler.
+      // This logic is mostly a mirror of the logic above without the branch
+      // on the value of the remainder.
+      if constexpr (!is_var_term) {
+        // If we produce a constant value, return a _structural_ zero. As
+        // before, the dot_term_constant function will collect the value of
+        // the constant products.
+        return zero{};
+      } else if constexpr (std::same_as<A_val, one>) {
+        // If A is one, just emit B.
+        return o.template at<K, J>();
+      } else if constexpr (std::same_as<B_val, one>) {
+        // If B is one, just emit A.
+        return this->template at<I, K>();
+      } else {
+        // And if neither is one, just emit the product (A * B).
+        return this->template at<I, K>() * o.template at<K, J>();
+      }
+    }
+  }
+
+  /// @brief Compute the value of the dot product between row I of this and
+  /// column J of the other matrix.
+  template <std::size_t I, std::size_t J, typename other_substructure_t,
+            std::size_t... Ks>
+  DETRAY_HOST_DEVICE auto product_dot(
+      const matrix<other_substructure_t, scalar_t> &o,
+      std::index_sequence<Ks...> seq) const {
+    // First, compute the sums of the constants as well as the sum of the
+    // variables.
+    constexpr long offset =
+        dot_constant_offset<I, J, other_substructure_t>(seq);
+    const auto var_sum = product_dot_vars<I, J>(o, seq);
+    using vs_type = std::decay_t<decltype(var_sum)>;
+
+    // Check what the type of the variable sum is.
+    if constexpr (std::same_as<vs_type, zero>) {
+      // If the variable sum is somehow zero, we simply convert the offset
+      // to a scalar. If the offset is zero, we still need to do this because
+      // this function _must_ return a runtime scalar.
+      return scalar_t(offset);
+    } else if constexpr (offset == 0) {
+      // If the offset is zero but the variable sum is not, just emit the
+      // variable sum.
+      return var_sum;
+    } else {
+      // If neither is zero, emit an addition flop.
+      return var_sum + scalar_t(offset);
+    }
+  }
+
+  /// @brief Helper logic for all cases in which we have to fill cells in KSM
+  /// matrices.
+  ///
+  /// @{
+  ///
+  /// @brief Fill cell (I, J) of rv with the value returned by f.
+  template <std::size_t I, std::size_t J, typename result_t,
+            typename callable_t>
+  DETRAY_HOST_DEVICE static void fill_cell(result_t &rv, callable_t &f) {
+    // Remember that we cannot write to structural cells, and anonymous
+    // variables don't exist in canonical substructures, so we only write to
+    // non-anonymous cells.
+    if constexpr (concepts::is_index_variable<
+                      typename result_t::canonical_substructure_type::
+                          template value_at<I, J>>) {
+      // We also don't want to do unnecessary work writing to non-anonymous
+      // shared variables twice, so we check that this is the first time the
+      // value appears.
+      if constexpr (detail::first_equal_flat_index_v<
+                        typename result_t::canonical_substructure_type,
+                        typename result_t::canonical_substructure_type::
+                            template value_at<I, J>> ==
+                    I * result_t::columns + J) {
+        // If this is a non-anonymous cell, and it is the first time it
+        // appears, call into f and set the value of the cell.
+        rv.template at<I, J>() = f.template operator()<I, J>();
+      }
+    }
+  }
+
+  /// @brief Helper function that takes a flat pack of indices Ks and turns
+  /// them into (I, J) pairs.
+  template <typename result_t, typename callable_t, std::size_t... Ks>
+  DETRAY_HOST_DEVICE static void fill_all(result_t &rv, callable_t &&f,
+                                          std::index_sequence<Ks...>) {
+    constexpr std::size_t C = result_t::canonical_substructure_type::columns;
+    (fill_cell<Ks / C, Ks % C>(rv, f), ...);
+  }
+
+  /// @brief Fill matrix cells using a callable object f.
+  template <typename result_t, typename callable_t>
+  DETRAY_HOST_DEVICE static void fill_with(result_t &rv, callable_t &&f) {
+    using result_sub = typename result_t::canonical_substructure_type;
+    fill_all(
+        rv, std::forward<callable_t>(f),
+        std::make_index_sequence<result_sub::rows * result_sub::columns>{});
+  }
+  /// @}
+
+  /// @brief The storage of the matrix elements.
+  std::array<scalar_t, canonical_substructure_type::num_variables> m_elems{};
+
+  // All KSM matrices are friends. <3
+  template <class, class>
+  friend struct matrix;
+};
+}  // namespace detray::ksm
+
+#ifdef __CUDACC__
+#pragma nv_diag_default 445
+#endif

--- a/Detray/core/include/detray/algebra/common/ksm/print.hpp
+++ b/Detray/core/include/detray/algebra/common/ksm/print.hpp
@@ -1,0 +1,125 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+// Project include(s)
+#include "detray/algebra/common/ksm/concepts.hpp"
+#include "detray/algebra/common/ksm/detail/canonicalization.hpp"
+#include "detray/algebra/common/ksm/matrix.hpp"
+#include "detray/algebra/common/ksm/value.hpp"
+#include "detray/definitions/detail/qualifiers.hpp"
+
+// System include(s).
+#include <concepts>
+#include <cstddef>
+#include <iomanip>
+#include <ostream>
+#include <sstream>
+#include <string>
+#include <utility>
+
+namespace detray::ksm {
+
+/// @brief Print a known-substructure matrix
+///
+/// A cell is addressable at compile time only, so the elements are visited
+/// through an index sequence rather than a loop. A structural cell has no
+/// storage, but @c at still yields its compile-time value, so the printed
+/// matrix is the full one and not only the stored part.
+///
+/// The kinds of cell are told apart in the output:
+///
+/// - a plain number is a scalar the matrix stores;
+/// - @c &V is a scalar it stores, but shares with an earlier cell, so it is
+///   not storage of its own -- the upper triangle of a symmetric matrix is
+///   plain and the lower one is marked;
+/// - @c . is a structural zero;
+/// - @c 'C is any other constant the substructure fixes at compile time.
+///
+/// A substructure therefore shows both its shape and what it actually costs
+/// at a glance: the unmarked cells are exactly the stored scalars.
+///
+/// @param out the stream to write to
+/// @param m the matrix to print
+///
+/// @returns @p out, so that the calls can be chained
+template <typename substructure_t, typename scalar_t>
+DETRAY_HOST std::ostream &operator<<(
+    std::ostream &out, const matrix<substructure_t, scalar_t> &m) {
+  using matrix_t = matrix<substructure_t, scalar_t>;
+
+  constexpr std::size_t n_rows{matrix_t::rows};
+  constexpr std::size_t n_cols{matrix_t::columns};
+
+  const auto print_cell = [&out, &m]<std::size_t I, std::size_t J>() {
+    // A cell is structural exactly when its canonical value is a constant: an
+    // index variable is stored, anything else the substructure fixes.
+    using value_t =
+        typename matrix_t::canonical_substructure_type::template value_at<I, J>;
+
+    // A stored cell shares its scalar with an earlier one exactly when the
+    // substructure names the same index variable in both places, so the cell
+    // that first claimed the storage is the one printed unmarked.
+    constexpr bool is_shared =
+        concepts::is_index_variable<value_t> &&
+        detail::first_equal_flat_index_v<
+            typename matrix_t::canonical_substructure_type, value_t> !=
+            I * n_cols + J;
+
+    const auto emit = [&out, &m](int width) {
+      // A marked value is padded as one piece, so that its digits keep the
+      // same right edge as an unmarked number in the column above it. How wide
+      // the piece is is only known once the scalar is formatted, hence the
+      // buffer; @c copyfmt carries over any precision or base the caller set
+      // on @p out, so a marked cell formats like an unmarked one.
+      const auto marked = [&out, &m](int w, char mark) {
+        std::ostringstream buf;
+        buf.copyfmt(out);
+        buf.width(0);
+        buf << mark << m.template at<I, J>();
+        out << std::setw(w) << buf.str();
+      };
+
+      if constexpr (std::same_as<value_t, zero>) {
+        out << std::setw(width) << ".";
+      } else if constexpr (concepts::is_integral_value<value_t>) {
+        marked(width, '\'');
+      } else if constexpr (is_shared) {
+        marked(width, '&');
+      } else {
+        out << std::setw(width) << m.template at<I, J>();
+      }
+    };
+
+    if constexpr (n_cols == 1u) {
+      emit(I == 0u ? 15 : 16);
+    } else {
+      if constexpr (J == 0u) {
+        out << (I == 0u ? "[" : " [");
+      }
+      emit(J == 0u ? 15 : 16);
+      if constexpr (J == n_cols - 1u) {
+        out << "]";
+        if constexpr (I != n_rows - 1u) {
+          out << "\n";
+        }
+      }
+    }
+  };
+
+  out << "[";
+  [&print_cell]<std::size_t... Ks>(std::index_sequence<Ks...>) {
+    (print_cell.template operator()<Ks / n_cols, Ks % n_cols>(), ...);
+  }(std::make_index_sequence<n_rows * n_cols>{});
+  out << "]";
+
+  return out;
+}
+
+}  // namespace detray::ksm

--- a/Detray/core/include/detray/algebra/common/ksm/row.hpp
+++ b/Detray/core/include/detray/algebra/common/ksm/row.hpp
@@ -1,0 +1,40 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+// Project include(s)
+#include "detray/algebra/common/ksm/concepts.hpp"
+
+// System include(s)
+#include <cstddef>
+#include <tuple>
+
+// This file describes how a single row of a substructure looks.
+namespace detray::ksm {
+/// @brief A single row of a substructure.
+///
+/// A row consists of a series of values, each of which may be an integral
+/// constant, a variable, or a symbolic operation. It carries no storage and no
+/// scalar type, just as a substructure does.
+///
+/// Note that in some cases, we might also use "row" to describe a column,
+/// like when we are performing a dot product. In that case, we simply take
+/// a column and transpose it into a row to avoid too much abuse of
+/// terminology.
+template <typename... value_ts>
+struct row {
+  static constexpr std::size_t num_values = sizeof...(value_ts);
+
+  static_assert((concepts::is_value<value_ts> && ...));
+
+  /// @brief Get the value at index I of this row.
+  template <std::size_t I>
+  using value_at = std::tuple_element<I, std::tuple<value_ts...>>::type;
+};
+}  // namespace detray::ksm

--- a/Detray/core/include/detray/algebra/common/ksm/substructure.hpp
+++ b/Detray/core/include/detray/algebra/common/ksm/substructure.hpp
@@ -1,0 +1,118 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+// Project include(s)
+#include "detray/algebra/common/ksm/concepts.hpp"
+#include "detray/algebra/common/ksm/detail/canonicalization.hpp"
+#include "detray/algebra/common/ksm/detail/index_table.hpp"
+#include "detray/algebra/common/ksm/detail/operator_substructure.hpp"
+#include "detray/algebra/common/ksm/row.hpp"
+
+// System include(s)
+#include <cstddef>
+#include <tuple>
+#include <utility>
+
+// This file defines what a KSM substructure looks like, which contains the
+// structural values but contains no storage and no scalar type.
+namespace detray::ksm {
+namespace detail {
+/// @brief Helpers to get a column out of a substructure
+///
+/// @{
+template <typename substructure_t, std::size_t J, typename T>
+struct column_getter_helper {};
+
+template <typename substructure_t, std::size_t J, std::size_t... Is>
+struct column_getter_helper<substructure_t, J,
+                            std::integer_sequence<std::size_t, Is...>> {
+  using type = row<typename substructure_t::template value_at<Is, J>...>;
+};
+/// @}
+}  // namespace detail
+
+/// @brief The main substructure class, defined as a list of rows, each of
+/// which is itself a list of values.
+template <typename... row_ts>
+struct substructure {
+  using this_t = substructure<row_ts...>;
+
+  // Grab the number of rows, then the number of columns from the first row
+  // and assert that all rows are the same size.
+  static constexpr std::size_t columns =
+      std::tuple_element<0, std::tuple<row_ts...>>::type::num_values;
+  static constexpr std::size_t rows = sizeof...(row_ts);
+  static_assert(((row_ts::num_values == columns) && ...),
+                "Rows do not all have the same size!");
+
+  /// @brief Helper to get a row at a certain index.
+  template <std::size_t I>
+  using row_at = typename std::tuple_element<I, std::tuple<row_ts...>>::type;
+
+  /// @brief Helper to get the value at a certain index pair.
+  template <std::size_t I, std::size_t J>
+  using value_at = typename row_at<I>::template value_at<J>;
+
+  /// @brief Compute the canonical version of this substructure, which will
+  /// be used for virtually all substructure-related operations.
+  using canonical_type =
+      typename detail::canonicalize_substructure<this_t>::type;
+
+  /// @brief Get the storage index of a given (I, J) coordinate. Although the
+  /// storage of values is not a substructure concern, we keep this here in
+  /// order to reuse the computation between matrices with e.g. the same
+  /// substructure but different scalar types.
+  template <std::size_t I, std::size_t J>
+  static constexpr std::size_t element_index =
+      detail::index_table<canonical_type>[I * columns + J];
+
+  /// @brief The number of unique variables.
+  static constexpr std::size_t num_variables =
+      detail::get_num_variables<canonical_type>;
+
+  static_assert((concepts::is_row<row_ts> && ...));
+
+  /// @brief Helper to get the column at a certain index; useful for matrix
+  /// multiplication.
+  template <std::size_t J>
+  using column_at = typename detail::column_getter_helper<
+      substructure<row_ts...>, J, std::make_index_sequence<rows>>::type;
+
+  /// @brief Helper to compute the substructure of this + X.
+  template <typename other_substructure_t>
+    requires(concepts::is_canonical<this_t> &&
+             concepts::is_canonical<other_substructure_t>)
+  using addition_type =
+      detail::additive_substructure<this_t,
+                                    other_substructure_t>::type::canonical_type;
+
+  /// @brief Helper to compute the substructure of this - X.
+  template <typename other_substructure_t>
+    requires(concepts::is_canonical<this_t> &&
+             concepts::is_canonical<other_substructure_t>)
+  using subtraction_type = detail::subtractive_substructure<
+      this_t, other_substructure_t>::type::canonical_type;
+
+  /// @brief Helper to compute the substructure of this * X.
+  template <typename other_substructure_t>
+    requires(concepts::is_canonical<this_t> &&
+             concepts::is_canonical<other_substructure_t>)
+  using multiplication_type = detail::multiplicative_substructure<
+      this_t, other_substructure_t>::type::canonical_type;
+
+  /// @brief Helper to compute the substructure of this * X * this^T.
+  template <typename other_substructure_t>
+    requires(concepts::is_canonical<this_t> &&
+             concepts::is_canonical<other_substructure_t> &&
+             concepts::is_symmetric<other_substructure_t>)
+  using congruence_type = detail::congruence_substructure<
+      this_t, other_substructure_t>::type::canonical_type;
+};
+}  // namespace detray::ksm

--- a/Detray/core/include/detray/algebra/common/ksm/traits.hpp
+++ b/Detray/core/include/detray/algebra/common/ksm/traits.hpp
@@ -1,0 +1,82 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+// Project include(s)
+#include "detray/algebra/common/ksm/concepts.hpp"
+#include "detray/algebra/common/ksm/matrix.hpp"
+
+// System include(s)
+#include <cstddef>
+
+// This file defines some of detray's traits for the known-substructure
+// matrices, so that the standard traits can be used with these types.
+namespace detray::traits {
+
+// The index type of any known-substructure matrix is trivially std::size_t,
+// at least for now.
+template <typename substructure_t, typename scalar_t>
+struct index<::detray::ksm::matrix<substructure_t, scalar_t>> {
+  using type = std::size_t;
+};
+
+// Similarly, a known-substructure matrix always has 2 dimensions, and we can
+// fetch the number of rows and columns from the substructure itself.
+template <typename substructure_t, typename scalar_t>
+struct dimensions<::detray::ksm::matrix<substructure_t, scalar_t>> {
+  using size_type = std::size_t;
+
+  static constexpr size_type _dim{2};
+  static constexpr size_type _rows{substructure_t::rows};
+  static constexpr size_type _columns{substructure_t::columns};
+};
+
+// Each known-substructure matrix also embeds a scalar type, which we can
+// use for the `scalar` trait.
+template <typename substructure_t, typename scalar_t>
+struct scalar<::detray::ksm::matrix<substructure_t, scalar_t>> {
+  using type = scalar_t;
+};
+
+// Symmetry and diagonality of a known-substructure matrix. This allows us to
+// make powerful assertions about the shape of a matrix at compile time. We
+// define these traits in two parts: whether we can statically assert a
+// property at all (e.g. a normal dense matrix has no way to assert symmetry,
+// that's a runtime property) and another trait to actually assert it.
+//
+// First, we define checks for symmetry using KSM's existing concepts.
+template <typename substructure_t, typename scalar_t>
+struct static_symmetric_assertable<
+    ::detray::ksm::matrix<substructure_t, scalar_t>> {
+  static constexpr bool value = true;
+};
+
+template <typename substructure_t, typename scalar_t>
+struct static_symmetric<::detray::ksm::matrix<substructure_t, scalar_t>> {
+  static constexpr bool value =
+      ::detray::ksm::concepts::is_symmetric<typename ::detray::ksm::matrix<
+          substructure_t, scalar_t>::canonical_substructure_type>;
+};
+
+// And then we define checks for diagonality. Again, nothing more involved
+// than reusing the existing KSM concepts.
+template <typename substructure_t, typename scalar_t>
+struct static_diagonal_assertable<
+    ::detray::ksm::matrix<substructure_t, scalar_t>> {
+  static constexpr bool value = true;
+};
+
+template <typename substructure_t, typename scalar_t>
+struct static_diagonal<::detray::ksm::matrix<substructure_t, scalar_t>> {
+  static constexpr bool value =
+      ::detray::ksm::concepts::is_diagonal<typename ::detray::ksm::matrix<
+          substructure_t, scalar_t>::canonical_substructure_type>;
+};
+
+}  // namespace detray::traits

--- a/Detray/core/include/detray/algebra/common/ksm/value.hpp
+++ b/Detray/core/include/detray/algebra/common/ksm/value.hpp
@@ -1,0 +1,42 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+// System include(s)
+#include <cstddef>
+
+// This file describes the values that a KSM matrix can take.
+namespace detray::ksm {
+/// @brief A constant integral value.
+///
+/// Note we don't support floating point constants right now, as static
+/// floating points can become a mess in terms of correctness. Two constants
+/// that are equal but not bit-identical would be distinct types, so
+/// canonicalization could never unify them; and eliding x * 0 is wrong when x
+/// is NaN or infinite.
+template <int I>
+struct integral_value {
+  static constexpr int value = I;
+};
+
+/// @brief An anonymous variable.
+struct variable {};
+
+/// @brief A non-anonymous variable.
+template <std::size_t I>
+struct index_variable {
+  static constexpr std::size_t index = I;
+};
+
+/// @brief A constant value zero.
+using zero = integral_value<0>;
+
+/// @brief A constant value one.
+using one = integral_value<1>;
+}  // namespace detray::ksm

--- a/Detray/core/include/detray/algebra/concepts.hpp
+++ b/Detray/core/include/detray/algebra/concepts.hpp
@@ -79,23 +79,65 @@ concept point3D = point<V> && (traits::size<V> == 3);
 
 /// Matrix concepts
 /// @{
+///
+/// True iff the type is a matrix.
 template <typename M>
 concept matrix = traits::is_matrix<M>;
 
-template <typename M>
-concept square_matrix = matrix<M> && traits::is_square<M>;
+/// True iff the type is a matrix of the given shape and scalar type
+///
+/// Optionally takes a row, column, and scalar
+/// type argument; if ROWS is zero, any number of rows is accepted. If COLS is
+/// zero, any number of COLS is accepted. If S is void, then any scalar type
+/// is accepted. If any of these is a non-default value, the respective
+/// quantity or type is statically asserted.
+///
+/// @note This is defined in terms of @c matrix so that it subsumes it. Every
+/// concept below is in turn defined in terms of this one, which keeps the
+/// whole matrix hierarchy ordered for overload resolution.
+template <typename M, std::size_t ROWS = 0, std::size_t COLS = 0,
+          typename S = void>
+concept sized_matrix =
+    matrix<M> && (ROWS == 0 || traits::rows<M> == ROWS) &&
+    (COLS == 0 || traits::columns<M> == COLS) &&
+    (std::same_as<S, void> || std::same_as<traits::scalar_t<M>, S>);
 
-template <typename M>
-concept row_matrix = matrix<M> && (traits::rows<M> == 1);
+template <typename M, std::size_t ROWS = 0, typename S = void>
+concept square_matrix = sized_matrix<M, ROWS, ROWS, S> && traits::is_square<M>;
 
-template <typename M>
-concept row_matrix3D = row_matrix<M> && (traits::rows<M> == 3);
+/// True iff the matrix is symmetric
+///
+/// @note For types of which the symmetry cannot be determined, this is only
+/// a readability hint. The concept will be true, even if symmetry can only
+/// be determined at runtime.
+template <typename M, std::size_t ROWS = 0, typename S = void>
+concept symmetric_matrix =
+    square_matrix<M, ROWS, S> && (!traits::static_symmetric_assertable_v<M> ||
+                                  traits::static_symmetric_v<M>);
 
-template <typename M>
-concept column_matrix = matrix<M> && (traits::columns<M> == 1);
+/// True iff the matrix is diagonal
+///
+/// A diagonal matrix is also symmetric, so this refines @c symmetric_matrix.
+///
+/// @note For types of which the diagonality cannot be determined, this is only
+/// a readability hint. The concept will be true, even if diagonality can only
+/// be determined at runtime.
+template <typename M, std::size_t ROWS = 0, typename S = void>
+concept diagonal_matrix =
+    symmetric_matrix<M, ROWS, S> &&
+    (!traits::static_diagonal_assertable_v<M> || traits::static_diagonal_v<M>);
 
-template <typename M>
-concept column_matrix3D = column_matrix<M> && (traits::rows<M> == 3);
+template <typename M, std::size_t COLS = 0, typename S = void>
+concept row_matrix = sized_matrix<M, 1, COLS, S>;
+
+template <typename M, typename S = void>
+concept row_matrix3D = row_matrix<M, 3, S>;
+
+template <typename M, std::size_t ROWS = 0, typename S = void>
+concept column_matrix = sized_matrix<M, ROWS, 1, S>;
+
+template <typename M, typename S = void>
+concept column_matrix3D = column_matrix<M, 3, S>;
 
 template <typename MA, typename MB>
 concept matrix_compatible =

--- a/Detray/core/include/detray/algebra/type_traits.hpp
+++ b/Detray/core/include/detray/algebra/type_traits.hpp
@@ -55,6 +55,58 @@ template <class M>
 using scalar_t = typename scalar<M>::type;
 /// @}
 
+/// Assertions on the symmetry of a matrix
+/// @{
+template <class M>
+struct static_symmetric_assertable {
+  static constexpr bool value = false;
+};
+
+/// True iff we can assert statically that a matrix type is symmetric
+///
+/// @note This does not mean that the type is statically symmetric, it only
+/// means we can assert that fact using @c static_symmetric_v.
+template <class M>
+inline constexpr bool static_symmetric_assertable_v =
+    static_symmetric_assertable<M>::value;
+
+template <class M>
+struct static_symmetric {
+  static constexpr bool value = false;
+};
+
+/// True iff we can assert statically that a matrix type is symmetric, _and_
+/// the type is actually symmetric
+template <class M>
+inline constexpr bool static_symmetric_v = static_symmetric<M>::value;
+/// @}
+
+/// Assertions on the diagonality of a matrix
+/// @{
+template <class M>
+struct static_diagonal_assertable {
+  static constexpr bool value = false;
+};
+
+/// True iff we can assert statically whether a matrix type is diagonal
+///
+/// @note This does not mean that the type is statically diagonal, it only
+/// means we can assert that fact using @c static_diagonal_v.
+template <class M>
+inline constexpr bool static_diagonal_assertable_v =
+    static_diagonal_assertable<M>::value;
+
+template <class M>
+struct static_diagonal {
+  static constexpr bool value = false;
+};
+
+/// True iff we can assert statically that a matrix type is diagonal, _and_
+/// the type is actually diagonal
+template <class M>
+inline constexpr bool static_diagonal_v = static_diagonal<M>::value;
+/// @}
+
 /// Vector type that is compatible with the matrix
 /// @{
 template <class M>

--- a/Detray/tests/include/detray/test/utils/op_counter.hpp
+++ b/Detray/tests/include/detray/test/utils/op_counter.hpp
@@ -1,0 +1,68 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+namespace detray::test {
+
+/// Struct for recording floating point operation counts
+struct op_counts {
+  long mul = 0, add = 0, sub = 0, neg = 0, div = 0;
+  long flops() const { return mul + add + sub + neg + div; }
+  friend op_counts operator+(op_counts a, op_counts b) {
+    return {a.mul + b.mul, a.add + b.add, a.sub + b.sub, a.neg + b.neg,
+            a.div + b.div};
+  }
+  op_counts &operator+=(op_counts o) { return *this = *this + o; }
+};
+
+/// Global object that is accessed by @c measure to provide accurate op
+/// counting for a code block. Do not use in a multi-threaded context.
+inline op_counts g_executed{};
+
+/// A scalar type annotated with an operation count.
+template <typename T>
+struct counted {
+  T v{};
+  op_counts ops{};
+  counted() = default;
+  counted(const counted &) = default;
+  counted(T x) : v(x) {}
+  counted(T x, op_counts o) : v(x), ops(o) {}
+  counted &operator=(const counted &o) {
+    // Realize this store's cost once.
+    g_executed = g_executed + o.ops;
+    v = o.v;
+    // Reset the count because the global state has been updated.
+    ops = {};
+    return *this;
+  }
+  friend counted operator*(counted a, counted b) {
+    return {a.v * b.v, a.ops + b.ops + op_counts{.mul = 1}};
+  }
+  friend counted operator+(counted a, counted b) {
+    return {a.v + b.v, a.ops + b.ops + op_counts{.add = 1}};
+  }
+  friend counted operator-(counted a, counted b) {
+    return {a.v - b.v, a.ops + b.ops + op_counts{.sub = 1}};
+  }
+  friend counted operator/(counted a, counted b) {
+    return {a.v / b.v, a.ops + b.ops + op_counts{.div = 1}};
+  }
+  counted operator-() const { return {-v, ops + op_counts{.neg = 1}}; }
+};
+
+/// Run a kernel with the op tally zeroed and return the ops it executed.
+template <typename F>
+op_counts measure(F &&run) {
+  g_executed = op_counts{};
+  run();
+  return g_executed;
+}
+
+}  // namespace detray::test

--- a/Detray/tests/unit_tests/cpu/CMakeLists.txt
+++ b/Detray/tests/unit_tests/cpu/CMakeLists.txt
@@ -21,6 +21,26 @@ detray_add_unit_test(cpu
    LINK_LIBRARIES GTest::gtest GTest::gtest_main detray::test_utils detray::core
 )
 
+# The known-substructure matrix test is very slow to compile, so it is opt-in
+# via DETRAY_BUILD_KNOWN_SUBSTRUCTURE_MATRIX_TEST (declared in the top level
+# CMakeLists.txt, which explains why). It gets its own target rather than being
+# a source of the test above, so that nothing of it is compiled when the option
+# is off, and its cost stays isolated to a target you can build and run on its
+# own when it is on.
+if(DETRAY_BUILD_KNOWN_SUBSTRUCTURE_MATRIX_TEST)
+    message(STATUS "Building the detray known-substructure matrix unit test")
+
+    # Links an algebra plugin rather than plain detray::core: the header's
+    # to_dense() needs dmatrix and getter::element, so it includes
+    # detray/definitions/algebra.hpp, which #errors without a plugin selected.
+    # The test itself is algebra agnostic, so one plugin is enough.
+    detray_add_unit_test(known_substructure_matrix
+       "utils/known_substructure_matrix.cpp"
+       LINK_LIBRARIES GTest::gtest GTest::gtest_main detray::test_utils
+       detray::core_array
+    )
+endif()
+
 # Macro setting up the CPU tests for a specific algebra plugin.
 macro(detray_add_cpu_test algebra)
     # Build the test executable.
@@ -97,6 +117,7 @@ macro(detray_add_cpu_test algebra)
        "utils/grids/populators.cpp"
        "utils/grids/serializers.cpp"
        "utils/hash_tree.cpp"
+       "utils/known_substructure_matrix_conversion.cpp"
        "utils/bounding_volume.cpp"
        "utils/curvilinear_frame.cpp"
        "utils/axis_rotation.cpp"

--- a/Detray/tests/unit_tests/cpu/utils/known_substructure_matrix.cpp
+++ b/Detray/tests/unit_tests/cpu/utils/known_substructure_matrix.cpp
@@ -1,0 +1,876 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Project include(s).
+#include "detray/algebra/common/known_substructure_matrix.hpp"
+
+#include "detray/test/utils/op_counter.hpp"
+
+// Google Test include(s).
+#include <gtest/gtest.h>
+
+// System include(s)
+#include <array>
+#include <cstddef>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+namespace {
+
+using namespace detray::ksm;
+using detray::test::counted;
+using detray::test::op_counts;
+
+template <typename A, typename B>
+concept addable = (A::rows == B::rows) && (A::columns == B::columns);
+
+template <typename A, typename B>
+concept multipliable = (A::columns == B::rows);
+
+template <typename A, typename B>
+concept congruable = concepts::is_symmetric<typename B::canonical_type> &&
+                     (A::columns == B::rows);
+
+// Count the structural zeros (cells whose value type is `zero`) of a
+// substructure. Inversion permutes the cofactor pattern, so the inverse must
+// carry exactly as many structural zeros as its input -- see the inverse block
+// in test_single.
+template <typename Sub, std::size_t... Ks>
+constexpr std::size_t count_structural_zeros(std::index_sequence<Ks...>) {
+  constexpr std::size_t C = Sub::columns;
+  return (std::size_t{0} + ... +
+          (std::is_same_v<typename Sub::template value_at<Ks / C, Ks % C>, zero>
+               ? std::size_t{1}
+               : std::size_t{0}));
+}
+
+// A matrix whose every cell is the same integer constant. Only used to test
+// that a uniform-integer add/subtract preserves the variable count (see
+// test_single); not a generally useful shape, so it lives here rather than in
+// the header's builders.
+template <int N>
+struct const_cell {
+  template <std::size_t I, std::size_t J>
+  struct cell {
+    using type = integral_value<N>;
+  };
+};
+template <std::size_t Rows, std::size_t Cols, int N>
+using make_const_substructure =
+    make_substructure<const_cell<N>::template cell, Rows, Cols>;
+
+// One operation's structure-aware cost paired with its structure-blind (dense)
+// baseline, which the dense-flop invariant is asserted against.
+struct op_stat {
+  op_counts ops{};    // structure-aware
+  op_counts naive{};  // dense baseline of the same shape
+};
+
+// The structure-blind substructure of the same shape as S.
+template <typename S>
+using dense_of = make_dense_substructure<S::rows, S::columns>;
+
+// Build a counted matrix for each substructure in Subs, apply op to them, and
+// tally the arithmetic ops the op executed (harvested at the result's stores by
+// counted::operator=, so shared intermediates are billed once -- see
+// op_counter.hpp).
+template <typename... Subs, typename Op>
+op_counts measure(Op op) {
+  return detray::test::measure(
+      [&] { (void)op(matrix<Subs, counted<double>>{}...); });
+}
+
+// The same op run on the structured Subs and on their dense equivalents: the
+// structure-aware count paired with the structure-blind baseline.
+template <typename... Subs, typename Op>
+op_stat measure_vs_dense(Op op) {
+  return {measure<Subs...>(op), measure<dense_of<Subs>...>(op)};
+}
+
+// --- runtime checking ------------------------------------------------------
+
+void check(bool cond, const std::string &name) {
+  EXPECT_TRUE(cond) << name;
+}
+
+// Hard invariant on the structure-blind baseline: a fully dense computation
+// must cost exactly the textbook flop count -- M*N for add/sub, M*P*(2N-1) for
+// an M*N by N*P multiply. If the dense path disagrees, the evaluator is doing
+// redundant work even with no structure to exploit, so raise an error.
+void require_dense_flops(long got, long expected, const std::string &what) {
+  EXPECT_EQ(got, expected) << what
+                           << ": dense flop count must be the textbook "
+                              "count with no structure to exploit";
+}
+
+template <typename Sub, std::size_t I, std::size_t J, typename S>
+void set_cell(matrix<Sub, S> &m, S v) {
+  using value_t = typename Sub::template value_at<I, J>;
+  if constexpr (std::is_same_v<value_t, variable>) {
+    m.template at<I, J>() = S{v + static_cast<S>((I + 1) * 412 + J)};
+  } else if constexpr (concepts::is_index_variable<value_t>) {
+    m.template at<I, J>() = S{v + static_cast<S>(value_t::index)};
+  }
+}
+
+template <typename Sub, std::size_t I, std::size_t J, typename S>
+void set_truth_cell(std::array<std::array<S, Sub::columns>, Sub::rows> &m,
+                    S v) {
+  using value_t = typename Sub::template value_at<I, J>;
+  if constexpr (std::is_same_v<value_t, variable>) {
+    m.at(I).at(J) = S{v + static_cast<S>((I + 1) * 412 + J)};
+  } else if constexpr (concepts::is_index_variable<value_t>) {
+    m.at(I).at(J) = S{v + static_cast<S>(value_t::index)};
+  } else {
+    m.at(I).at(J) = S{static_cast<S>(value_t::value)};
+  }
+}
+
+template <typename Sub, typename S, std::size_t... Ks>
+void fill_seq(matrix<Sub, S> &m, S base, std::index_sequence<Ks...>) {
+  (set_cell<Sub, Ks / Sub::columns, Ks % Sub::columns>(m, base), ...);
+}
+
+template <typename Sub, typename S, std::size_t... Ks>
+void fill_truth_seq(std::array<std::array<S, Sub::columns>, Sub::rows> &m,
+                    S base, std::index_sequence<Ks...>) {
+  (set_truth_cell<Sub, Ks / Sub::columns, Ks % Sub::columns>(m, base), ...);
+}
+
+template <typename S>
+bool check_eq(std::size_t i, std::size_t j, S a, S b) {
+  if (a == b) {
+    return true;
+  } else {
+    ADD_FAILURE() << "Different values at (" << i << ", " << j << "): " << a
+                  << " vs " << b;
+    return false;
+  }
+}
+
+template <typename MA, std::size_t... Ks>
+bool verify_truth_values(
+    const MA &a,
+    const std::array<std::array<typename MA::scalar_type, MA::columns>,
+                     MA::rows> &a_t,
+    std::index_sequence<Ks...>) {
+  constexpr std::size_t C = MA::substructure_type::columns;
+
+  return (... && check_eq(Ks / C, Ks % C, a_t.at(Ks / C).at(Ks % C),
+                          a.template at<Ks / C, Ks % C>()));
+}
+
+template <typename MA, typename MB, typename MR, std::size_t... Ks>
+bool verify_addition_values(
+    [[maybe_unused]] const MA &a, [[maybe_unused]] const MB &b, const MR &r,
+    const std::array<std::array<typename MA::scalar_type, MA::columns>,
+                     MA::rows> &a_t,
+    const std::array<std::array<typename MB::scalar_type, MB::columns>,
+                     MB::rows> &b_t,
+    std::index_sequence<Ks...>) {
+  static_assert(MR::substructure_type::columns ==
+                MA::substructure_type::columns);
+  static_assert(MR::substructure_type::columns ==
+                MB::substructure_type::columns);
+  static_assert(MR::substructure_type::rows == MA::substructure_type::rows);
+  static_assert(MR::substructure_type::rows == MB::substructure_type::rows);
+  constexpr std::size_t C = MR::substructure_type::columns;
+  std::array<std::array<typename MA::scalar_type, MA::columns>, MA::rows> r_t{};
+
+  ((r_t.at(Ks / C).at(Ks % C) =
+        a_t.at(Ks / C).at(Ks % C) + b_t.at(Ks / C).at(Ks % C)),
+   ...);
+
+  return (... && check_eq(Ks / C, Ks % C, r_t.at(Ks / C).at(Ks % C),
+                          r.template at<Ks / C, Ks % C>()));
+}
+
+template <typename MA, typename MB, typename MR, std::size_t... Ks>
+bool verify_subtraction_values(const MA &a, const MB &b, const MR &r,
+                               std::index_sequence<Ks...>) {
+  constexpr std::size_t C = MR::substructure_type::columns;
+  return (... &&
+          (r.template at<Ks / C, Ks % C>() ==
+           a.template at<Ks / C, Ks % C>() - b.template at<Ks / C, Ks % C>()));
+}
+
+template <typename MA, typename MR, std::size_t... Ks>
+bool verify_negation_values(const MA &a, const MR &r,
+                            std::index_sequence<Ks...>) {
+  constexpr std::size_t C = MR::substructure_type::columns;
+  return (... && (r.template at<Ks / C, Ks % C>() ==
+                  -a.template at<Ks / C, Ks % C>()));
+}
+
+// transpose(a)(j, i) must read back the same scalar as a(i, j). The index walk
+// is over a's M*N cells; the transposed matrix t is N*M, so cell (i, j) of a is
+// compared against cell (j, i) of t.
+template <typename MA, typename MT, std::size_t... Ks>
+bool verify_transpose_values(const MA &a, const MT &t,
+                             std::index_sequence<Ks...>) {
+  constexpr std::size_t C = MA::substructure_type::columns;
+  return (... && check_eq(Ks / C, Ks % C, a.template at<Ks / C, Ks % C>(),
+                          t.template at<Ks % C, Ks / C>()));
+}
+
+// transpose is an involution: transposing twice returns the original cell by
+// cell. tt has the same shape as a, so the comparison is position for position.
+template <typename MA, typename MTT, std::size_t... Ks>
+bool verify_involution_values(const MA &a, const MTT &tt,
+                              std::index_sequence<Ks...>) {
+  constexpr std::size_t C = MA::substructure_type::columns;
+  return (... && check_eq(Ks / C, Ks % C, a.template at<Ks / C, Ks % C>(),
+                          tt.template at<Ks / C, Ks % C>()));
+}
+
+// Two same-shape matrices agree cell by cell. Used to check a structure-aware
+// result against an independent reference matrix of the same dimensions.
+template <typename MA, typename MB, std::size_t... Ks>
+bool verify_equal_matrices(const MA &a, const MB &b,
+                           std::index_sequence<Ks...>) {
+  static_assert(MA::rows == MB::rows && MA::columns == MB::columns);
+  constexpr std::size_t C = MA::substructure_type::columns;
+  return (... && check_eq(Ks / C, Ks % C, a.template at<Ks / C, Ks % C>(),
+                          b.template at<Ks / C, Ks % C>()));
+}
+
+// Approximate cell comparison. Inverse introduces division, so its results are
+// no longer exact even for integer-valued fills; an absolute epsilon suffices
+// here because the only inverse value check is against the identity (0s and
+// 1s).
+bool check_close(std::size_t i, std::size_t j, double a, double b, double eps) {
+  double d = a - b;
+  if (d < 0)
+    d = -d;
+  if (d <= eps)
+    return true;
+  ADD_FAILURE() << "Not close at (" << i << ", " << j << "): " << a << " vs "
+                << b;
+  return false;
+}
+
+// A square product matrix equals the identity: 1 on the diagonal, 0 off it.
+template <typename MP, std::size_t... Ks>
+bool verify_identity(const MP &p, std::index_sequence<Ks...>) {
+  constexpr std::size_t C = MP::substructure_type::columns;
+  constexpr double eps = 1e-9;
+  return (... && check_close(Ks / C, Ks % C, p.template at<Ks / C, Ks % C>(),
+                             (Ks / C == Ks % C) ? 1.0 : 0.0, eps));
+}
+
+// Reference (fold-based) dot product of row I of `a` with column J of `b`.
+template <std::size_t I, std::size_t J, typename S, typename MA, typename MB,
+          std::size_t... Ks>
+S ref_dot(const MA &a, const MB &b, std::index_sequence<Ks...>) {
+  return (S{0} + ... + (a.template at<I, Ks>() * b.template at<Ks, J>()));
+}
+
+template <typename S, typename MA, typename MB, typename MR, std::size_t... Ks>
+bool verify_multiplication_values(const MA &a, const MB &b, const MR &r,
+                                  std::index_sequence<Ks...>) {
+  constexpr std::size_t C = MR::substructure_type::columns;
+  constexpr std::size_t K = MA::substructure_type::columns;
+  return (... &&
+          (r.template at<Ks / C, Ks % C>() ==
+           ref_dot<Ks / C, Ks % C, S>(a, b, std::make_index_sequence<K>{})));
+}
+
+// --- per-pair driver -------------------------------------------------------
+
+template <typename A, typename B>
+void test_pair(const std::string &an, const std::string &bn) {
+  using S = double;  // integer-valued fills keep == comparisons exact
+  const std::string pair = an + ", " + bn;
+  SCOPED_TRACE(pair);
+
+  [[maybe_unused]] constexpr auto a_indices =
+      std::make_index_sequence<A::rows * A::columns>{};
+  [[maybe_unused]] constexpr auto b_indices =
+      std::make_index_sequence<B::rows * B::columns>{};
+
+  matrix<A, S> ma;
+  matrix<B, S> mb;
+  fill_seq(ma, S{1}, a_indices);
+  fill_seq(mb, S{1000}, b_indices);
+  std::array<std::array<S, A::columns>, A::rows> A_truth{};
+  std::array<std::array<S, B::columns>, B::rows> B_truth{};
+  fill_truth_seq<A>(A_truth, S{1}, a_indices);
+  fill_truth_seq<B>(B_truth, S{1000}, b_indices);
+
+  bool vta = verify_truth_values(ma, A_truth, a_indices);
+  check(vta, an + ": A");
+  bool vtb = verify_truth_values(mb, B_truth, b_indices);
+  check(vtb, bn + ": B");
+
+  if constexpr (addable<A, B>) {
+    using ADD = typename A::canonical_type::template addition_type<
+        typename B::canonical_type>;
+    using SUB = typename A::canonical_type::template subtraction_type<
+        typename B::canonical_type>;
+    static_assert(ADD::rows == A::rows && ADD::columns == A::columns,
+                  "addition result has wrong shape");
+    static_assert(SUB::rows == A::rows && SUB::columns == A::columns,
+                  "subtraction result has wrong shape");
+
+    auto add = [](auto a, auto b) { return a + b; };
+    auto sub = [](auto a, auto b) { return a - b; };
+    op_stat as = measure_vs_dense<A, B>(add);
+    op_stat ss = measure_vs_dense<A, B>(sub);
+
+    const long elems =
+        static_cast<long>(A::rows) * static_cast<long>(A::columns);
+    require_dense_flops(as.naive.flops(), elems, pair + ": A + B dense");
+    require_dense_flops(ss.naive.flops(), elems, pair + ": A - B dense");
+
+    bool va =
+        verify_addition_values(ma, mb, ma + mb, A_truth, B_truth, a_indices);
+    check(va, pair + ": A + B (ops=" + std::to_string(as.ops.flops()) +
+                  ", naive=" + std::to_string(as.naive.flops()) + ")");
+    bool vb = verify_subtraction_values(ma, mb, ma - mb, a_indices);
+    check(vb, pair + ": A - B (ops=" + std::to_string(ss.ops.flops()) +
+                  ", naive=" + std::to_string(ss.naive.flops()) + ")");
+  }
+
+  if constexpr (multipliable<A, B>) {
+    using MUL = typename A::canonical_type::template multiplication_type<
+        typename B::canonical_type>;
+    static_assert(MUL::rows == A::rows && MUL::columns == B::columns,
+                  "multiplication result has wrong shape");
+    constexpr auto r_indices =
+        std::make_index_sequence<MUL::rows * MUL::columns>{};
+
+    auto mul = [](auto a, auto b) { return a * b; };
+    op_stat ms = measure_vs_dense<A, B>(mul);
+
+    const long M = static_cast<long>(A::rows),
+               N = static_cast<long>(A::columns),
+               P = static_cast<long>(B::columns);
+    require_dense_flops(ms.naive.flops(), M * P * (2 * N - 1),
+                        pair + ": A * B dense");
+
+    bool vm = verify_multiplication_values<S>(ma, mb, ma * mb, r_indices);
+    check(vm, pair + ": A * B (add=" + std::to_string(ms.ops.add) +
+                  ", mul=" + std::to_string(ms.ops.mul) +
+                  ", ops=" + std::to_string(ms.ops.flops()) +
+                  ", naive=" + std::to_string(ms.naive.flops()) + ")");
+  }
+
+  // Congruence A*B*A^T: only when B is symmetric (so the result is symmetric).
+  if constexpr (congruable<A, B>) {
+    using CONG = typename A::canonical_type::template congruence_type<
+        typename B::canonical_type>;
+    static_assert(CONG::rows == A::rows && CONG::columns == A::rows,
+                  "congruence result must be A.rows x A.rows");
+    constexpr auto c_indices =
+        std::make_index_sequence<CONG::rows * CONG::columns>{};
+
+    // Oracle: the plain triple product from already-tested ops. mb is
+    // numerically symmetric (its mirror cells share storage), so this is the
+    // genuine A*B*A^T.
+    auto cong = ma.congruence(mb);
+    auto naive = (ma * mb) * ma.transpose();
+
+    check(verify_equal_matrices(cong, naive, c_indices),
+          pair + ": congruence == A*B*transpose(A)");
+
+    // Flop pin against the naive implementation of the same product. Both paths
+    // form A*B and transpose(A); congruence() then fills only the stored cells
+    // of a result *declared* symmetric, where the plain triple product computes
+    // both mirror halves as independent dot products. Computing a subset of the
+    // same dot products can never cost more, so this is derived rather than a
+    // snapshot -- no constant to bump when the algebra improves. It is <=, not
+    // <: when the result's symmetry buys nothing (a 1x1 congruence, or a shape
+    // whose mirror cells were already shared) the two coincide exactly.
+    auto congruence_op = [](auto a, auto b) { return a.congruence(b); };
+    auto triple = [](auto a, auto b) { return (a * b) * a.transpose(); };
+    const long cong_flops = measure<A, B>(congruence_op).flops();
+    const long triple_flops = measure<A, B>(triple).flops();
+    check(cong_flops <= triple_flops,
+          pair + ": congruence costs <= naive A*B*transpose(A) (" +
+              std::to_string(cong_flops) +
+              " <= " + std::to_string(triple_flops) + ")");
+
+    // Declared structure: A*B*A^T is symmetric for symmetric B, the property a
+    // plain triple product drops (its mirror cells are distinct dot products).
+    check(concepts::is_symmetric<typename CONG::canonical_type>,
+          pair + ": congruence(A, symmetric B) is symmetric");
+
+    // Storage payoff: a symmetric m*m result stores at most the upper triangle,
+    // m(m+1)/2, versus up to m*m for the structure-blind product.
+    constexpr std::size_t m = CONG::rows;
+    constexpr std::size_t tri = m * (m + 1) / 2;
+    check(CONG::num_variables <= tri, pair +
+                                          ": congruence stores <= m(m+1)/2 (" +
+                                          std::to_string(CONG::num_variables) +
+                                          " <= " + std::to_string(tri) + ")");
+  }
+}
+
+// --- per-matrix driver -----------------------------------------------------
+//
+// Operations that act on a single matrix (currently negation) don't fit the
+// pair driver, so they get their own pass over the substructure list. Mirrors
+// test_pair: compile-time shape + stored-count checks, an op-count vs
+// dense-baseline measurement, and a runtime value check.
+
+template <typename A>
+void test_single(const std::string &an) {
+  using S = double;
+  SCOPED_TRACE(an);
+
+  constexpr auto a_indices = std::make_index_sequence<A::rows * A::columns>{};
+
+  matrix<A, S> ma;
+  fill_seq(ma, S{1}, a_indices);
+  std::array<std::array<S, A::columns>, A::rows> A_truth{};
+  fill_truth_seq<A>(A_truth, S{1}, a_indices);
+  check(verify_truth_values(ma, A_truth, a_indices), an + ": A");
+
+  using NEG =
+      typename detail::negated_substructure<typename A::canonical_type>::type;
+  static_assert(NEG::rows == A::rows && NEG::columns == A::columns,
+                "negation result has wrong shape");
+
+  auto neg = [](auto a) { return -a; };
+  op_stat ns = measure_vs_dense<A>(neg);
+
+  // Negating an M*N matrix is one negation per element.
+  const long elems = static_cast<long>(A::rows) * static_cast<long>(A::columns);
+  require_dense_flops(ns.naive.flops(), elems, an + ": -A dense");
+
+  bool vn = verify_negation_values(ma, -ma, a_indices);
+  check(vn, an + ": -A (ops=" + std::to_string(ns.ops.flops()) +
+                ", naive=" + std::to_string(ns.naive.flops()) + ")");
+
+  // Structure invariant: negation is a per-cell sign flip, so it preserves
+  // every equality between cells. -A must therefore store exactly as many
+  // values as A. (Runtime check, not static_assert: the current algebra
+  // collapses negated index_variables to anonymous variables and violates
+  // this for any matrix with shared variables.)
+  constexpr std::size_t a_vars = A::canonical_type::num_variables;
+  constexpr std::size_t neg_vars = NEG::num_variables;
+  check(neg_vars == a_vars, an + ": -A preserves stored count (" +
+                                std::to_string(a_vars) + " -> " +
+                                std::to_string(neg_vars) + ")");
+
+  // Structure invariant: if A is symmetric then A + A is symmetric with the
+  // same sharing, so A + A must store exactly as many values as A. Only checked
+  // for symmetric A; same caveat as above about the additive algebra.
+  if constexpr (concepts::is_symmetric<typename A::canonical_type>) {
+    using APA = typename A::canonical_type::template addition_type<
+        typename A::canonical_type>;
+    constexpr std::size_t apa_vars = APA::num_variables;
+    check(apa_vars == a_vars,
+          an + ": A+A preserves stored count when A symmetric (" +
+              std::to_string(a_vars) + " -> " + std::to_string(apa_vars) + ")");
+  }
+
+  // Structure invariant: adding or subtracting a matrix whose every cell is the
+  // *same* integer constant shifts values but touches no structure -- a
+  // variable cell stays that same variable (+/- c), a structural zero/constant
+  // stays constant, and equal cells stay equal -- so the stored-variable count
+  // is unchanged. Both conditions are load-bearing: a *non-uniform* constant
+  // would split a shared variable into distinct value_(add|sub)<var, c> slots,
+  // and an all-*variable* matrix would turn structural zeros into stored
+  // variables.
+  {
+    using ConstM = typename make_const_substructure<A::rows, A::columns,
+                                                    7>::canonical_type;
+    using APC = typename A::canonical_type::template addition_type<ConstM>;
+    using AMC = typename A::canonical_type::template subtraction_type<ConstM>;
+    constexpr std::size_t apc_vars = APC::num_variables;
+    constexpr std::size_t amc_vars = AMC::num_variables;
+    check(apc_vars == a_vars, an + ": A + const preserves stored count (" +
+                                  std::to_string(a_vars) + " -> " +
+                                  std::to_string(apc_vars) + ")");
+    check(amc_vars == a_vars, an + ": A - const preserves stored count (" +
+                                  std::to_string(a_vars) + " -> " +
+                                  std::to_string(amc_vars) + ")");
+  }
+
+  // -- transpose: the other single-matrix operation -------------------------
+  // Shape swaps M*N -> N*M and each cell mirrors the input. Since transpose
+  // only permutes cells it preserves the stored-value count and symmetry.
+  using TR = typename detail::transposed_substructure<
+      typename A::canonical_type>::type;
+  static_assert(TR::rows == A::columns && TR::columns == A::rows,
+                "transpose result has wrong shape");
+
+  auto mt = ma.transpose();
+  using MT = std::decay_t<decltype(mt)>;
+  static_assert(MT::rows == A::columns && MT::columns == A::rows,
+                "transpose() matrix has wrong shape");
+
+  check(verify_transpose_values(ma, mt, a_indices),
+        an + ": transpose(A)(j,i) == A(i,j)");
+  check(verify_involution_values(ma, mt.transpose(), a_indices),
+        an + ": transpose(transpose(A)) == A");
+
+  // Transpose permutes cells, so it stores exactly as many values as A.
+  constexpr std::size_t t_vars = TR::num_variables;
+  check(t_vars == a_vars, an + ": transpose preserves stored count (" +
+                              std::to_string(a_vars) + " -> " +
+                              std::to_string(t_vars) + ")");
+
+  // The transpose of a symmetric matrix is symmetric (in fact equal to the
+  // original, which the value check above already pins).
+  if constexpr (concepts::is_symmetric<typename A::canonical_type>) {
+    check(concepts::is_symmetric<typename TR::canonical_type>,
+          an + ": transpose(symmetric) stays symmetric");
+  }
+
+  // -- inverse: closed-form for small (1x1, 2x2) invertible matrices --------
+  // Gated on the library's is_invertible: singularity is semantic, not a shape
+  // predicate, so structurally-singular matrices (a det that folds to a
+  // compile-time zero) are excluded here rather than divided by. The defining
+  // property is S*inverse(S) == I; the inverse of a symmetric matrix is
+  // symmetric, reusing the upper-triangle storage; and 1/det introduces a
+  // division.
+  if constexpr ((A::rows == A::columns) && (A::rows <= 2) &&
+                concepts::is_invertible<typename A::canonical_type>) {
+    using CA = typename A::canonical_type;
+    using INV = typename detail::inverted_substructure<
+        typename CA::canonical_type>::type;
+    static_assert(INV::rows == CA::rows && INV::columns == CA::columns,
+                  "inverse has wrong shape");
+
+    // Defining property: S * inverse(S) == I.
+    check(verify_identity(ma * ma.inverse(), a_indices),
+          an + ": S * inverse(S) == I");
+
+    // The structure-aware inverse, paired with its naive baseline: the same
+    // inverse of a fully-dense matrix (no zeros, ones, or shared variables to
+    // exploit), which it saves against.
+    auto inv = [](auto a) { return a.inverse(); };
+    op_stat is = measure_vs_dense<A>(inv);
+
+    // 1/det normally introduces a division -- except when det folds to 1, where
+    // the inverse is just the adjugate and no division is performed. Pin both.
+    if constexpr (std::same_as<
+                      typename detail::get_determinant_helper<CA>::type, one>) {
+      check(is.ops.div == 0, an + ": inverse(det==1) uses no division (div=" +
+                                 std::to_string(is.ops.div) + ")");
+    } else {
+      check(is.ops.div >= 1, an + ": inverse uses division (div=" +
+                                 std::to_string(is.ops.div) + ")");
+    }
+
+    // For symmetric input the inverse is symmetric, so it stores only the upper
+    // triangle (m(m+1)/2), not m*m.
+    if constexpr (concepts::is_symmetric<CA>) {
+      check(concepts::is_symmetric<typename INV::canonical_type>,
+            an + ": inverse(symmetric) is symmetric");
+      constexpr std::size_t m = CA::rows;
+      constexpr std::size_t tri = m * (m + 1) / 2;
+      check(INV::num_variables <= tri, an + ": inverse stores <= m(m+1)/2 (" +
+                                           std::to_string(INV::num_variables) +
+                                           " <= " + std::to_string(tri) + ")");
+    }
+
+    // Structure preservation: inversion permutes the cofactor pattern, so the
+    // inverse keeps exactly as many structural zeros as the input -- a diagonal
+    // matrix inverts to a diagonal one. (When value_division was fed the
+    // cofactor *metafunctions* instead of their ::type, the operands never
+    // matched zero/one, every cell fell back to a dense variable, and the
+    // structural zeros were silently lost.)
+    constexpr std::size_t a_zeros = count_structural_zeros<CA>(
+        std::make_index_sequence<CA::rows * CA::columns>{});
+    constexpr std::size_t inv_zeros =
+        count_structural_zeros<typename INV::canonical_type>(
+            std::make_index_sequence<INV::rows * INV::columns>{});
+    check(inv_zeros == a_zeros,
+          an + ": inverse preserves structural-zero count (" +
+              std::to_string(a_zeros) + " -> " + std::to_string(inv_zeros) +
+              ")");
+  }
+}
+
+// --- direct dot-product flop-count checks ----------------------------------
+//
+// The cartesian harness measures savings against the dense ceiling but has no
+// "minimal" oracle, so these pin the *exact* op count for dot products that
+// mix constant and variable terms. The constant terms must fold to a single
+// compile-time offset, so however many constants a dot product contains they
+// cost at most one runtime add. Each matrix below is all-zero except row 0 of
+// A and column 0 of B, so the only non-trivial result cell is (0,0) and the
+// whole result's op count is that single dot product.
+
+// Each pair's (0,0) dot product realises one constant/variable evaluation-tree
+// shape; everything else is zero so (0,0) is the only non-trivial result cell.
+// These are reused below as S32-S37 of the cartesian list.
+
+// const + const + var :  row [2, 3, var] . col [4, 5, var]
+using cfd_ccv_a =
+    substructure<row<integral_value<2>, integral_value<3>, variable>,
+                 row<zero, zero, zero>, row<zero, zero, zero>>;
+using cfd_ccv_b =
+    substructure<row<integral_value<4>, zero, zero>,
+                 row<integral_value<5>, zero, zero>, row<variable, zero, zero>>;
+// const + var + const :  row [2, var, 3] . col [4, var, 5]
+using cfd_cvc_a =
+    substructure<row<integral_value<2>, variable, integral_value<3>>,
+                 row<zero, zero, zero>, row<zero, zero, zero>>;
+using cfd_cvc_b =
+    substructure<row<integral_value<4>, zero, zero>, row<variable, zero, zero>,
+                 row<integral_value<5>, zero, zero>>;
+// var + const + const + var :  row [var, 2, 3, var] . col [var, 4, 5, var]
+using cfd_vccv_a =
+    substructure<row<variable, integral_value<2>, integral_value<3>, variable>,
+                 row<zero, zero, zero, zero>, row<zero, zero, zero, zero>,
+                 row<zero, zero, zero, zero>>;
+using cfd_vccv_b = substructure<
+    row<variable, zero, zero, zero>, row<integral_value<4>, zero, zero, zero>,
+    row<integral_value<5>, zero, zero, zero>, row<variable, zero, zero, zero>>;
+
+template <typename A, typename B>
+void check_dot_ops(const std::string &name, long exp_mul, long exp_add) {
+  using S = double;
+  SCOPED_TRACE(name);
+  constexpr auto a_indices = std::make_index_sequence<A::rows * A::columns>{};
+  constexpr auto b_indices = std::make_index_sequence<B::rows * B::columns>{};
+  constexpr auto r_indices = std::make_index_sequence<A::rows * B::columns>{};
+
+  // Values must stay correct regardless of how the dot product is grouped.
+  matrix<A, S> ma;
+  matrix<B, S> mb;
+  fill_seq(ma, S{1}, a_indices);
+  fill_seq(mb, S{1000}, b_indices);
+  check(verify_multiplication_values<S>(ma, mb, ma * mb, r_indices),
+        name + " values");
+
+  // Op count must hit the structural minimum (constants folded to one offset).
+  op_counts mo = detray::test::measure([] {
+    (void)(matrix<A, counted<double>>{} * matrix<B, counted<double>>{});
+  });
+  check(mo.mul == exp_mul && mo.add == exp_add,
+        name + " ops (mul=" + std::to_string(mo.mul) + " exp " +
+            std::to_string(exp_mul) + ", add=" + std::to_string(mo.add) +
+            " exp " + std::to_string(exp_add) + ")");
+}
+
+/// A structural cell of a result has no storage, so nothing may be executed to
+/// produce it.
+///
+/// Only a class-type scalar can show this. For a built-in scalar, assigning to
+/// the prvalue the const accessor returns is ill formed, so a structural cell
+/// is skipped whatever the fill gate asks. For a class type the same
+/// assignment is well formed, because it is a call to @c operator=, so a gate
+/// that asks whether the assignment compiles -- rather than whether the cell
+/// is stored -- evaluates one cell per distinct structural constant and throws
+/// the result away. That is invisible in the values and shows up only here.
+///
+/// @c I - B is the smallest case that exposes it. Where @p B leaves a column
+/// structurally zero, that column of the result stays the identity's own
+/// constants, and every cell the result does store costs exactly one operation
+/// -- a subtraction on the diagonal, a negation off it. So the executed count
+/// must equal the stored count, for every @p K.
+template <std::size_t N, std::size_t K>
+void check_no_structural_evaluation(const std::string &name) {
+  SCOPED_TRACE(name);
+  using lhs_t = typename make_identity_substructure<N>::canonical_type;
+  using rhs_t =
+      typename make_left_columns_substructure<N, N, K>::canonical_type;
+  using result_t = typename lhs_t::template subtraction_type<rhs_t>;
+
+  auto sub = [](auto a, auto b) { return a - b; };
+  const long executed = measure<lhs_t, rhs_t>(sub).flops();
+  const long stored = static_cast<long>(result_t::num_variables);
+
+  check(executed == stored, name + ": executed " + std::to_string(executed) +
+                                " ops for " + std::to_string(stored) +
+                                " stored cells");
+}
+
+// --- the substructure list -------------------------------------------------
+
+using substructure_tuple = std::tuple<
+
+    substructure<row<one, variable>, row<zero, variable>>,
+    substructure<row<variable, variable>, row<variable, one>>,
+    substructure<row<integral_value<2>, variable>, row<one, integral_value<3>>>,
+    substructure<row<one, zero, variable>, row<variable, variable, zero>>,
+    substructure<row<variable, one>, row<zero, variable>, row<one, variable>>,
+    substructure<row<one, zero, zero>, row<zero, one, zero>,
+                 row<variable, variable, one>>,
+    substructure<row<variable, integral_value<-1>, zero>,
+                 row<zero, variable, variable>, row<one, zero, variable>>,
+    substructure<row<one, zero, zero, zero, zero, zero, zero, variable>,
+                 row<zero, one, zero, zero, zero, zero, variable, zero>,
+                 row<zero, zero, one, zero, zero, variable, zero, zero>,
+                 row<zero, zero, zero, one, variable, zero, zero, zero>,
+                 row<zero, zero, zero, variable, one, zero, zero, zero>,
+                 row<zero, zero, variable, zero, zero, one, zero, zero>,
+                 row<zero, variable, zero, zero, zero, zero, one, zero>,
+                 row<variable, zero, zero, zero, zero, zero, zero, one>>,
+    substructure<row<variable, variable, zero, zero, zero, zero, zero, one>,
+                 row<zero, variable, variable, zero, zero, zero, one, zero>,
+                 row<zero, zero, variable, variable, zero, one, zero, zero>,
+                 row<zero, zero, zero, variable, variable, zero, zero, zero>,
+                 row<one, zero, zero, zero, variable, variable, zero, zero>>,
+    substructure<row<variable, zero, zero, zero, one>,
+                 row<zero, variable, zero, one, zero>,
+                 row<zero, zero, variable, zero, zero>,
+                 row<zero, one, zero, variable, zero>,
+                 row<one, zero, zero, zero, variable>,
+                 row<variable, zero, one, zero, zero>,
+                 row<zero, variable, zero, zero, one>,
+                 row<zero, zero, variable, variable, zero>>,
+    substructure<row<one, variable, zero, zero, zero, zero>,
+                 row<variable, one, variable, zero, zero, zero>,
+                 row<zero, variable, one, variable, zero, zero>,
+                 row<zero, zero, variable, one, variable, zero>,
+                 row<zero, zero, zero, variable, one, variable>,
+                 row<zero, zero, zero, zero, variable, one>>,
+    substructure<row<variable, zero, zero, zero, zero, zero, one>,
+                 row<zero, variable, zero, zero, zero, one, zero>,
+                 row<zero, zero, variable, zero, one, zero, zero>,
+                 row<zero, zero, zero, variable, zero, zero, zero>,
+                 row<zero, zero, one, zero, variable, zero, zero>,
+                 row<zero, one, zero, zero, zero, variable, zero>,
+                 row<one, zero, zero, zero, zero, zero, variable>>,
+    substructure<row<variable, variable, variable, variable>>,
+    substructure<row<variable>, row<one>, row<variable>, row<zero>>,
+    substructure<row<variable, zero, variable, one, variable, variable>>,
+    substructure<row<variable>, row<variable>, row<one>, row<variable>,
+                 row<zero>, row<variable>>,
+    substructure<row<one, variable, zero, variable>>,
+    substructure<row<variable>, row<variable>, row<variable>, row<variable>>,
+    substructure<row<index_variable<0>, index_variable<1>, index_variable<2>>,
+                 row<index_variable<1>, index_variable<3>, index_variable<4>>,
+                 row<index_variable<2>, index_variable<4>, index_variable<5>>>,
+    substructure<row<index_variable<0>, index_variable<0>>,
+                 row<index_variable<0>, index_variable<0>>>,
+    substructure<row<index_variable<0>, zero, zero, zero>,
+                 row<zero, index_variable<0>, zero, zero>,
+                 row<zero, zero, index_variable<0>, zero>,
+                 row<zero, zero, zero, index_variable<0>>>,
+    substructure<row<index_variable<0>, variable, one>,
+                 row<zero, index_variable<1>, variable>,
+                 row<index_variable<0>, zero, index_variable<1>>>,
+    substructure<
+        row<index_variable<0>, variable, index_variable<1>, index_variable<0>>>,
+    substructure<row<index_variable<0>>, row<index_variable<1>>,
+                 row<index_variable<2>>, row<index_variable<3>>>,
+    substructure<row<index_variable<0>, index_variable<1>, index_variable<2>,
+                     index_variable<3>>,
+                 row<index_variable<0>, index_variable<1>, index_variable<2>,
+                     index_variable<3>>>,
+    substructure<row<index_variable<7>, variable, one>,
+                 row<zero, index_variable<0>, variable>,
+                 row<index_variable<0>, zero, index_variable<7>>>,
+    substructure<row<variable>>,                 // S26: 1x1, free variable
+    substructure<row<zero>>,                     // S27: 1x1, fixed 0 (singular)
+    substructure<row<integral_value<2>>>,        // S28: 1x1, fixed non-0
+    substructure<row<variable, variable>>,       // S29: 1x2
+    substructure<row<variable>, row<variable>>,  // S30: 2x1
+    substructure<row<integral_value<1>, integral_value<2>>,
+                 row<integral_value<2>, integral_value<4>>>,
+    cfd_ccv_a, cfd_ccv_b,    // S32, S33: 3x3
+    cfd_cvc_a, cfd_cvc_b,    // S34, S35: 3x3
+    cfd_vccv_a, cfd_vccv_b,  // S36, S37: 4x4
+    substructure<row<index_variable<0>, index_variable<1>>,
+                 row<index_variable<1>, index_variable<2>>>,
+    substructure<row<index_variable<0>, index_variable<1>, zero>,
+                 row<index_variable<1>, integral_value<2>, index_variable<2>>,
+                 row<zero, index_variable<2>, index_variable<3>>>,
+    substructure<row<variable, variable>, row<variable, variable>>,
+    substructure<row<index_variable<0>, zero>, row<zero, index_variable<0>>>,
+    substructure<row<index_variable<0>, index_variable<0>>,
+                 row<index_variable<0>, index_variable<3>>>>;
+
+inline constexpr std::size_t num_substructures =
+    std::tuple_size_v<substructure_tuple>;
+
+std::string sub_name(std::size_t i) {
+  return "S" + std::to_string(i);
+}
+
+/// A substructure paired with its position in @c substructure_tuple. The typed
+/// tests below run one case per substructure, and the wrapper is what lets a
+/// case name itself the way the original standalone harness did (S0, S1, ...)
+/// and recover its own index to drive the pair sweep. Wrapping also keeps the
+/// list duplicate-safe: two structurally identical entries stay distinct types.
+template <std::size_t I, typename Sub>
+struct numbered {
+  static constexpr std::size_t index = I;
+  using type = Sub;
+};
+
+template <typename Tuple, typename Seq>
+struct numbered_types;
+
+template <typename... Subs, std::size_t... Is>
+struct numbered_types<std::tuple<Subs...>, std::index_sequence<Is...>> {
+  using type = ::testing::Types<numbered<Is, Subs>...>;
+};
+
+using substructure_list =
+    typename numbered_types<substructure_tuple,
+                            std::make_index_sequence<num_substructures>>::type;
+
+/// Names the typed-test cases S0..S42 rather than 0..42.
+struct substructure_name {
+  template <typename T>
+  static std::string GetName(int i) {
+    return sub_name(static_cast<std::size_t>(i));
+  }
+};
+
+/// One row of the cartesian sweep: A against every B in the list.
+template <typename A, std::size_t Ai, std::size_t... Bi>
+void test_pair_row(std::index_sequence<Bi...>) {
+  (test_pair<A, std::tuple_element_t<Bi, substructure_tuple>>(sub_name(Ai),
+                                                              sub_name(Bi)),
+   ...);
+}
+
+}  // namespace
+
+template <typename T>
+class detray_ksm_substructure : public ::testing::Test {};
+
+TYPED_TEST_SUITE(detray_ksm_substructure, substructure_list, substructure_name);
+
+// Single-matrix operations: negation, transpose, inverse, and the structural
+// invariants those must preserve.
+TYPED_TEST(detray_ksm_substructure, unary_ops) {
+  test_single<typename TypeParam::type>(sub_name(TypeParam::index));
+}
+
+// This substructure paired against every substructure in the list: addition,
+// subtraction, multiplication and congruence, wherever the shapes allow.
+TYPED_TEST(detray_ksm_substructure, pairwise_ops) {
+  test_pair_row<typename TypeParam::type, TypeParam::index>(
+      std::make_index_sequence<num_substructures>{});
+}
+
+// Constant folding in a dot product: however many constant terms a dot product
+// contains, they must collapse to a single compile-time offset.
+GTEST_TEST(detray_ksm, constant_fold_dot) {
+  // 23 + v0*v1                 -> 1 mul, 1 add
+  check_dot_ops<cfd_ccv_a, cfd_ccv_b>("const+const+var", 1, 1);
+  // 23 + v0*v1                 -> 1 mul, 1 add
+  check_dot_ops<cfd_cvc_a, cfd_cvc_b>("const+var+const", 1, 1);
+  // v0*v1 + v2*v3 + 23         -> 2 mul, 2 add
+  check_dot_ops<cfd_vccv_a, cfd_vccv_b>("var+const+const+var", 2, 2);
+}
+
+// A cell the substructure fixes has no storage, so producing it must cost
+// nothing. K is how many columns of the subtrahend are stored: the rest are
+// structurally zero, so those columns of I - B remain the identity's constants.
+GTEST_TEST(detray_ksm, structural_cells_are_not_evaluated) {
+  // Every column structural: the whole result is constant and costs nothing.
+  check_no_structural_evaluation<6, 0>("6x6, no stored column");
+  check_no_structural_evaluation<6, 1>("6x6, one stored column");
+  check_no_structural_evaluation<6, 2>("6x6, two stored columns");
+  check_no_structural_evaluation<6, 3>("6x6, three stored columns");
+  // No column structural: the baseline, which was always counted correctly.
+  check_no_structural_evaluation<6, 6>("6x6, fully dense");
+}

--- a/Detray/tests/unit_tests/cpu/utils/known_substructure_matrix_conversion.cpp
+++ b/Detray/tests/unit_tests/cpu/utils/known_substructure_matrix_conversion.cpp
@@ -1,0 +1,151 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Project include(s).
+#include "detray/algebra/common/known_substructure_matrix.hpp"
+
+// Test include(s).
+#include "detray/test/cpu/algebra_fixture.hpp"
+
+// GoogleTest include(s).
+#include <gtest/gtest.h>
+
+// System include(s).
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+
+namespace detray::test {
+
+namespace {
+
+using ksm::one;
+using ksm::row;
+using ksm::substructure;
+using ksm::variable;
+using ksm::zero;
+
+/// The substructure of the full Jacobian.
+using j_full = substructure<
+    row<variable, variable, variable, variable, variable, zero>,
+    row<variable, variable, variable, variable, variable, zero>,
+    row<variable, variable, variable, variable, variable, zero>,
+    row<variable, variable, variable, variable, variable, zero>,
+    row<zero, zero, zero, zero, one, zero>,
+    row<variable, variable, variable, variable, variable, one>>::canonical_type;
+
+using sym6 = ksm::make_symmetric_substructure<6>::canonical_type;
+
+template <typename Sub, typename F>
+void for_each_cell(F f) {
+  [&f]<std::size_t... Ks>(std::index_sequence<Ks...>) {
+    (f.template operator()<Ks / Sub::columns, Ks % Sub::columns>(), ...);
+  }(std::make_index_sequence<Sub::rows * Sub::columns>{});
+}
+
+/// @returns a matrix whose free cells hold small distinct integers.
+template <typename Sub, typename scalar_t>
+ksm::matrix<Sub, scalar_t> filled(scalar_t base) {
+  ksm::matrix<Sub, scalar_t> m;
+
+  for_each_cell<Sub>([&m, base]<std::size_t I, std::size_t J>() {
+    using value_t = typename Sub::template value_at<I, J>;
+
+    if constexpr (ksm::concepts::is_index_variable<value_t>) {
+      m.template at<I, J>() = base + static_cast<scalar_t>(value_t::index);
+    }
+  });
+
+  return m;
+}
+
+}  // namespace
+
+/// Structural cells have no storage, so to_dense has to reconstruct them from
+/// their compile-time values.
+TEST_F(detray_algebra, ksm_to_dense_materialises_structure) {
+  const auto m = filled<j_full>(scalar{1});
+  const auto d = m.to_dense<algebra_t>();
+
+  static_assert(
+      std::is_same_v<std::decay_t<decltype(d)>, dmatrix<algebra_t, 6, 6>>);
+
+  // The two structural ones ...
+  EXPECT_EQ((getter::element<4, 4>(d)), scalar{1});
+  EXPECT_EQ((getter::element<5, 5>(d)), scalar{1});
+  // ... and a sample of the nine structural zeros.
+  EXPECT_EQ((getter::element<0, 5>(d)), scalar{0});
+  EXPECT_EQ((getter::element<4, 0>(d)), scalar{0});
+
+  // Every cell, structural or not, must read back what the ksm matrix says.
+  for_each_cell<j_full>([&d, &m]<std::size_t I, std::size_t J>() {
+    EXPECT_EQ((getter::element<I, J>(d)), (m.template at<I, J>()));
+  });
+}
+
+/// ksm -> dense -> ksm is the identity.
+TEST_F(detray_algebra, ksm_round_trip) {
+  const auto m = filled<j_full>(scalar{1});
+  const auto back = ksm::matrix<j_full, scalar>::from_dense<algebra_t>(
+      m.to_dense<algebra_t>());
+
+  for_each_cell<j_full>([&back, &m]<std::size_t I, std::size_t J>() {
+    EXPECT_EQ((back.template at<I, J>()), (m.template at<I, J>()));
+  });
+}
+
+/// The same, for a substructure whose mirrored cells share storage: from_dense
+/// writes each shared value once and checks that the rest agree.
+TEST_F(detray_algebra, ksm_round_trip_shared_cells) {
+  static_assert(sym6::num_variables == 21u);
+
+  const auto m = filled<sym6>(scalar{1});
+  const auto back =
+      ksm::matrix<sym6, scalar>::from_dense<algebra_t>(m.to_dense<algebra_t>());
+
+  for_each_cell<sym6>([&back, &m]<std::size_t I, std::size_t J>() {
+    EXPECT_EQ((back.template at<I, J>()), (m.template at<I, J>()));
+  });
+}
+
+/// The payoff check: skipping the structurally zero terms must not change the
+/// answer. The structure-aware product has to equal the dense one computed by
+/// the algebra plugin.
+TEST_F(detray_algebra, ksm_product_matches_dense) {
+  const auto a = filled<j_full>(scalar{1});
+  const auto b = filled<j_full>(scalar{100});
+
+  const auto structured = (a * b).to_dense<algebra_t>();
+  const dmatrix<algebra_t, 6, 6> dense =
+      a.to_dense<algebra_t>() * b.to_dense<algebra_t>();
+
+  for_each_cell<j_full>([&structured, &dense]<std::size_t I, std::size_t J>() {
+    EXPECT_EQ((getter::element<I, J>(structured)),
+              (getter::element<I, J>(dense)));
+  });
+}
+
+/// Congruence computes only the upper triangle of a result it knows to be
+/// symmetric. It must equal the plain triple product.
+TEST_F(detray_algebra, ksm_congruence_matches_dense) {
+  const auto a = filled<j_full>(scalar{1});
+  const auto c = filled<sym6>(scalar{1});
+
+  const auto structured = a.congruence(c).to_dense<algebra_t>();
+
+  const auto a_dense = a.to_dense<algebra_t>();
+  const dmatrix<algebra_t, 6, 6> dense =
+      a_dense * c.to_dense<algebra_t>() * detray::matrix::transpose(a_dense);
+
+  for_each_cell<j_full>([&structured, &dense]<std::size_t I, std::size_t J>() {
+    EXPECT_EQ((getter::element<I, J>(structured)),
+              (getter::element<I, J>(dense)));
+  });
+}
+
+}  // namespace detray::test


### PR DESCRIPTION
This commit adds a new algebra component to detray which allows the modelling of matrices with compile-time-known substructures.