### PR TITLE
fix: Correct z-axis upper bound in covfie field conversion

### DIFF
--- a/Plugins/Covfie/src/FieldConversion.cpp
+++ b/Plugins/Covfie/src/FieldConversion.cpp
@@ -40,7 +40,7 @@ auto newBuilder(const magnetic_field_t& magneticField,
   std::array<double, 3> maxima = {
       std::nexttoward(max[0], -std::numeric_limits<double>::infinity()),
       std::nexttoward(max[1], -std::numeric_limits<double>::infinity()),
-      std::nexttoward(max[1], -std::numeric_limits<double>::infinity()),
+      std::nexttoward(max[2], -std::numeric_limits<double>::infinity()),
   };
 
   Field field(covfie::make_parameter_pack(

--- a/Tests/UnitTests/Plugins/Covfie/CovfieFieldConversionTest.cpp
+++ b/Tests/UnitTests/Plugins/Covfie/CovfieFieldConversionTest.cpp
@@ -214,6 +214,46 @@ BOOST_AUTO_TEST_CASE(SolenoidBField1) {
   checkMagneticFieldEqual(actsField, cache, view, points, 0.0001);
 }
 
+BOOST_AUTO_TEST_CASE(AsymmetricRangesZAxis) {
+  auto localToGlobalBin_xyz = [](std::array<std::size_t, 3> binsXYZ,
+                                 std::array<std::size_t, 3> nBinsXYZ) {
+    return (binsXYZ.at(0) * (nBinsXYZ.at(1) * nBinsXYZ.at(2)) +
+            binsXYZ.at(1) * nBinsXYZ.at(2) + binsXYZ.at(2));
+  };
+
+  std::vector<double> xPos = {0., 1., 2., 3.};
+  std::vector<double> yPos = {0., 1., 2., 3.};
+  std::vector<double> zPos = {0., 2., 4., 6.};
+
+  std::vector<Vector3> bField_xyz;
+  for (int i = 0; i < 64; i++) {
+    bField_xyz.push_back(Vector3(i, i * 0.5, i * 2));
+  }
+
+  MagneticFieldContext fieldContext;
+  auto actsField = fieldMapXYZ(localToGlobalBin_xyz, xPos, yPos, zPos,
+                               bField_xyz, 1, 1, false);
+  MagneticFieldProvider::Cache cache = actsField.makeCache(fieldContext);
+
+  Covfie::InterpolatedField field = Covfie::covfieField(actsField);
+  typename Covfie::InterpolatedField::view_t view(field);
+
+  std::array<std::array<float, 3>, 10> points = {{
+      {0.f, 0.f, 0.f},
+      {1.f, 1.f, 1.f},
+      {2.f, 2.f, 2.f},
+      {1.f, 1.f, 4.f},
+      {1.f, 1.f, 5.f},
+      {1.5f, 2.5f, 5.5f},
+      {0.5f, 0.5f, 3.5f},
+      {2.5f, 1.5f, 4.5f},
+      {1.0f, 2.0f, 5.9f},
+      {2.9f, 2.9f, 5.9f},
+  }};
+
+  checkMagneticFieldEqual(actsField, cache, view, points, 0.0001f);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }  // namespace ActsTests


### PR DESCRIPTION
This fixes an issue in Covfie's magnetic-field conversion sampler where the z-axis upper sampling bound was calculated using the y-axis. The incorrect bound was updated and a regression test was added that converts an asymmetric interpolated field map.