### PR TITLE
perf: Specialise the sympy dense step on covariance transport

### DIFF
--- a/Core/include/Acts/Propagator/detail/SympyStepperDenseStep.hpp
+++ b/Core/include/Acts/Propagator/detail/SympyStepperDenseStep.hpp
@@ -26,7 +26,10 @@ namespace detail {
 ///
 /// Kept in its own translation unit so that the dense kernel is not
 /// instantiated next to SympyStepper::step, where it would share a stack frame
-/// and a register allocation with the vacuum path.
+/// and a register allocation with the vacuum path. Specialised on covariance
+/// transport, a translation unit each.
+///
+/// @tparam WithJac whether the jacobian is transported
 ///
 /// @param [in] stepper the stepper, for field access
 /// @param [in,out] state the stepper state, read for the start parameters and
@@ -38,15 +41,23 @@ namespace detail {
 /// @param [out] lastField the field at the last sampled point, to seed the
 ///        next step
 /// @param [out] fieldErr the error of a failed field lookup
-/// @param [in,out] jac the bound-to-free jacobian, empty to skip transport
+/// @param [in,out] jac the bound-to-free jacobian, unread without @c WithJac
 ///
 /// @return whether the step was accepted, rejected or hit a field error
+template <bool WithJac>
 Rk4Status sympyDenseStep(const SympyStepper& stepper,
                          SympyStepper::State& state,
                          const IVolumeMaterial& material, double h,
                          double errTol, double& errorEstimate,
                          Vector3& lastField, std::error_code& fieldErr,
                          std::span<double> jac);
+
+extern template Rk4Status sympyDenseStep<true>(
+    const SympyStepper&, SympyStepper::State&, const IVolumeMaterial&, double,
+    double, double&, Vector3&, std::error_code&, std::span<double>);
+extern template Rk4Status sympyDenseStep<false>(
+    const SympyStepper&, SympyStepper::State&, const IVolumeMaterial&, double,
+    double, double&, Vector3&, std::error_code&, std::span<double>);
 
 }  // namespace detail
 }  // namespace Acts

--- a/Core/src/Propagator/CMakeLists.txt
+++ b/Core/src/Propagator/CMakeLists.txt
@@ -7,6 +7,8 @@ target_sources(
         SympyStepper.cpp
         detail/SympyStepVacuumJac.cpp
         detail/SympyStepVacuumNoJac.cpp
+        detail/SympyStepDenseJac.cpp
+        detail/SympyStepDenseNoJac.cpp
         NavigationTarget.cpp
         PropagatorError.cpp
         StraightLineStepper.cpp
@@ -16,7 +18,6 @@ target_sources(
         detail/JacobianEngine.cpp
         detail/SympyCovarianceEngine.cpp
         detail/SympyJacobianEngine.cpp
-        detail/SympyStepperDenseStep.cpp
 )
 
 include(ActsCodegen)

--- a/Core/src/Propagator/SympyStepper.cpp
+++ b/Core/src/Propagator/SympyStepper.cpp
@@ -189,14 +189,18 @@ Result<double> SympyStepper::step(State& state, Direction propDir,
                                   const IVolumeMaterial* material) const {
   if (state.options.doDense &&
       (material != nullptr || !state.materialEffectsAccumulator.isVacuum())) {
-    return detail::sympyStep<detail::SympyStepMode::Dense>(*this, state,
-                                                           propDir, material);
+    if (state.covTransport) {
+      return detail::sympyStep<detail::SympyStepMode::Dense, true>(
+          *this, state, propDir, material);
+    }
+    return detail::sympyStep<detail::SympyStepMode::Dense, false>(
+        *this, state, propDir, material);
   }
   if (state.covTransport) {
-    return detail::sympyStep<detail::SympyStepMode::VacuumJac>(
+    return detail::sympyStep<detail::SympyStepMode::Vacuum, true>(
         *this, state, propDir, nullptr);
   }
-  return detail::sympyStep<detail::SympyStepMode::VacuumNoJac>(
+  return detail::sympyStep<detail::SympyStepMode::Vacuum, false>(
       *this, state, propDir, nullptr);
 }
 

--- a/Core/src/Propagator/detail/SympyStepDenseJac.cpp
+++ b/Core/src/Propagator/detail/SympyStepDenseJac.cpp
@@ -8,11 +8,16 @@
 
 // One instantiation per translation unit; see the header.
 
+#include "SympyStepperDenseStepImpl.hpp"
 #include "SympyStepperStepImpl.hpp"
 
 namespace Acts {
 
-template Result<double> detail::sympyStep<detail::SympyStepMode::Vacuum, false>(
+template detail::Rk4Status detail::sympyDenseStep<true>(
+    const SympyStepper&, SympyStepper::State&, const IVolumeMaterial&, double,
+    double, double&, Vector3&, std::error_code&, std::span<double>);
+
+template Result<double> detail::sympyStep<detail::SympyStepMode::Dense, true>(
     const SympyStepper&, SympyStepper::State&, Direction,
     const IVolumeMaterial*);
 

--- a/Core/src/Propagator/detail/SympyStepDenseNoJac.cpp
+++ b/Core/src/Propagator/detail/SympyStepDenseNoJac.cpp
@@ -8,11 +8,16 @@
 
 // One instantiation per translation unit; see the header.
 
+#include "SympyStepperDenseStepImpl.hpp"
 #include "SympyStepperStepImpl.hpp"
 
 namespace Acts {
 
-template Result<double> detail::sympyStep<detail::SympyStepMode::Vacuum, false>(
+template detail::Rk4Status detail::sympyDenseStep<false>(
+    const SympyStepper&, SympyStepper::State&, const IVolumeMaterial&, double,
+    double, double&, Vector3&, std::error_code&, std::span<double>);
+
+template Result<double> detail::sympyStep<detail::SympyStepMode::Dense, false>(
     const SympyStepper&, SympyStepper::State&, Direction,
     const IVolumeMaterial*);
 

--- a/Core/src/Propagator/detail/SympyStepVacuumJac.cpp
+++ b/Core/src/Propagator/detail/SympyStepVacuumJac.cpp
@@ -12,7 +12,7 @@
 
 namespace Acts {
 
-template Result<double> detail::sympyStep<detail::SympyStepMode::VacuumJac>(
+template Result<double> detail::sympyStep<detail::SympyStepMode::Vacuum, true>(
     const SympyStepper&, SympyStepper::State&, Direction,
     const IVolumeMaterial*);
 

--- a/Core/src/Propagator/detail/SympyStepperDenseStepImpl.hpp
+++ b/Core/src/Propagator/detail/SympyStepperDenseStepImpl.hpp
@@ -6,22 +6,22 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#include "Acts/Propagator/detail/SympyStepperDenseStep.hpp"
+#pragma once
 
 #include "Acts/Definitions/PdgParticle.hpp"
 #include "Acts/Definitions/Units.hpp"
 #include "Acts/Material/IVolumeMaterial.hpp"
 #include "Acts/Material/Interactions.hpp"
 #include "Acts/Material/MaterialSlab.hpp"
-#include "Acts/Propagator/EigenStepperError.hpp"
+#include "Acts/Propagator/detail/SympyStepperDenseStep.hpp"
 
 #include <cmath>
 
-#include "SympyStepperStepImpl.hpp"
 #include "codegen/sympy_stepper_math.hpp"
 
 namespace Acts {
 
+template <bool WithJac>
 detail::Rk4Status detail::sympyDenseStep(
     const SympyStepper& stepper, SympyStepper::State& state,
     const IVolumeMaterial& material, double h, double errTol,
@@ -60,20 +60,28 @@ detail::Rk4Status detail::sympyDenseStep(
                                  static_cast<float>(l), absQ);
   };
 
-  return rk4_dense(
-      std::span<const double, 3>(pos.data(), 3),
-      std::span<const double, 3>(dir.data(), 3), t, h, qop, m, q, pabs,
-      std::span<const double, 3>(state.field->data(), 3), getB, getG,
-      errorEstimate, errTol, fieldErr,
-      std::span<double, 3>(state.pars.segment<3>(eFreePos0).data(), 3),
-      state.pars[eFreeTime],
-      std::span<double, 3>(state.pars.segment<3>(eFreeDir0).data(), 3),
-      state.pars[eFreeQOverP], std::span<double, 3>(lastField.data(), 3),
-      std::span<double, 8>(state.derivative.data(), 8), jac);
+  if constexpr (WithJac) {
+    return rk4_dense_jac(
+        std::span<const double, 3>(pos.data(), 3),
+        std::span<const double, 3>(dir.data(), 3), t, h, qop, m, q, pabs,
+        std::span<const double, 3>(state.field->data(), 3), getB, getG,
+        errorEstimate, errTol, fieldErr,
+        std::span<double, 3>(state.pars.segment<3>(eFreePos0).data(), 3),
+        state.pars[eFreeTime],
+        std::span<double, 3>(state.pars.segment<3>(eFreeDir0).data(), 3),
+        state.pars[eFreeQOverP], std::span<double, 3>(lastField.data(), 3),
+        std::span<double, 8>(state.derivative.data(), 8), jac);
+  } else {
+    return rk4_dense_nojac(
+        std::span<const double, 3>(pos.data(), 3),
+        std::span<const double, 3>(dir.data(), 3), t, h, qop, m, q, pabs,
+        std::span<const double, 3>(state.field->data(), 3), getB, getG,
+        errorEstimate, errTol, fieldErr,
+        std::span<double, 3>(state.pars.segment<3>(eFreePos0).data(), 3),
+        state.pars[eFreeTime],
+        std::span<double, 3>(state.pars.segment<3>(eFreeDir0).data(), 3),
+        state.pars[eFreeQOverP], std::span<double, 3>(lastField.data(), 3));
+  }
 }
-
-template Result<double> detail::sympyStep<detail::SympyStepMode::Dense>(
-    const SympyStepper&, SympyStepper::State&, Direction,
-    const IVolumeMaterial*);
 
 }  // namespace Acts

--- a/Core/src/Propagator/detail/SympyStepperStep.hpp
+++ b/Core/src/Propagator/detail/SympyStepperStep.hpp
@@ -18,39 +18,44 @@ class IVolumeMaterial;
 
 namespace detail {
 
-/// What a step has to carry: the dense path, or the vacuum one specialised on
-/// covariance transport so the kernel does not test an empty jacobian span on
-/// every trial.
+/// Which path a step takes
 enum class SympyStepMode {
-  VacuumNoJac,
-  VacuumJac,
+  Vacuum,
   Dense,
 };
 
 /// @brief A whole Runge-Kutta step
 ///
-/// One body for all three modes, instantiated once per mode in a translation
-/// unit of its own; sharing one costs more than the branches it saves.
+/// One body for every combination, instantiated once per combination in a
+/// translation unit of its own; sharing one costs more than the branches it
+/// saves.
+///
+/// @tparam Mode which path the step takes
+/// @tparam WithJac whether the jacobian is transported; specialising on it
+///         keeps the kernel from testing an empty jacobian span on every trial
 ///
 /// @param [in] stepper the stepper, for field access and accessors
 /// @param [in,out] state the stepper state
 /// @param [in] propDir the propagation direction
-/// @param [in] material the volume material, `Dense` only, and null there when
-///        just the accumulator still has material to flush
+/// @param [in] material the volume material, @c Dense only, and null there
+///        when just the accumulator still has material to flush
 ///
 /// @return the step length taken, or an error
-template <SympyStepMode Mode>
+template <SympyStepMode Mode, bool WithJac>
 Result<double> sympyStep(const SympyStepper& stepper,
                          SympyStepper::State& state, Direction propDir,
                          const IVolumeMaterial* material);
 
-extern template Result<double> sympyStep<SympyStepMode::VacuumNoJac>(
+extern template Result<double> sympyStep<SympyStepMode::Vacuum, false>(
     const SympyStepper&, SympyStepper::State&, Direction,
     const IVolumeMaterial*);
-extern template Result<double> sympyStep<SympyStepMode::VacuumJac>(
+extern template Result<double> sympyStep<SympyStepMode::Vacuum, true>(
     const SympyStepper&, SympyStepper::State&, Direction,
     const IVolumeMaterial*);
-extern template Result<double> sympyStep<SympyStepMode::Dense>(
+extern template Result<double> sympyStep<SympyStepMode::Dense, false>(
+    const SympyStepper&, SympyStepper::State&, Direction,
+    const IVolumeMaterial*);
+extern template Result<double> sympyStep<SympyStepMode::Dense, true>(
     const SympyStepper&, SympyStepper::State&, Direction,
     const IVolumeMaterial*);
 

--- a/Core/src/Propagator/detail/SympyStepperStepImpl.hpp
+++ b/Core/src/Propagator/detail/SympyStepperStepImpl.hpp
@@ -25,7 +25,7 @@
 
 namespace Acts {
 
-template <detail::SympyStepMode Mode>
+template <detail::SympyStepMode Mode, bool WithJac>
 Result<double> detail::sympyStep(const SympyStepper& stepper,
                                  SympyStepper::State& state, Direction propDir,
                                  const IVolumeMaterial* material) {
@@ -105,10 +105,11 @@ Result<double> detail::sympyStep(const SympyStepper& stepper,
     if constexpr (isDense) {
       const std::span<double, 8> derivative(state.derivative.data(), 8);
       const std::span<double> jac =
-          state.covTransport ? std::span<double>(state.jacToGlobal.data(),
-                                                 state.jacToGlobal.size())
-                             : std::span<double>();
+          WithJac ? std::span<double>(state.jacToGlobal.data(),
+                                      state.jacToGlobal.size())
+                  : std::span<double>();
       if (material == nullptr) {
+        // the combined kernel: this cold branch wants no more inlined into it
         status = rk4_vacuum(startPos, startDir, t, h, qop, m, pabs,
                             std::span<const double, 3>(state.field->data(), 3),
                             getB, errorEstimate, 4 * stepTolerance, fieldError,
@@ -116,10 +117,11 @@ Result<double> detail::sympyStep(const SympyStepper& stepper,
                             std::span<double, 3>(lastField.data(), 3),
                             derivative, jac);
       } else {
-        status = sympyDenseStep(stepper, state, *material, h, 4 * stepTolerance,
-                                errorEstimate, lastField, fieldError, jac);
+        status = sympyDenseStep<WithJac>(stepper, state, *material, h,
+                                         4 * stepTolerance, errorEstimate,
+                                         lastField, fieldError, jac);
       }
-    } else if constexpr (Mode == SympyStepMode::VacuumJac) {
+    } else if constexpr (WithJac) {
       status =
           rk4_vacuum_jac(startPos, startDir, t, h, qop, m, pabs,
                          std::span<const double, 3>(state.field->data(), 3),

--- a/Core/src/Propagator/generate_sympy_stepper.py
+++ b/Core/src/Propagator/generate_sympy_stepper.py
@@ -876,41 +876,51 @@ def print_rk4_vacuum_b2f(
     return "\n".join(lines)
 
 
-def print_rk4_dense(name_exprs: list[NamedExpr], run_cse: bool = True) -> str:
+def print_rk4_dense(
+    name_exprs: list[NamedExpr], run_cse: bool = True, mode: str = "jac"
+) -> str:
+    """Print the dense kernel, `jac` or `nojac`.
+
+    Specialised on covariance transport like the vacuum kernel, so it does not
+    test an empty jacobian span on every trial.
+    """
     printer = cxx_printer
-    outputs = [
-        find_by_name(name_exprs, name)[0]
-        for name in [
-            "pos2",
-            "qop2",
-            "qop3",
-            "pos3",
-            "qop4",
-            "err",
-            "new_B",
-            "new_pos",
-            "new_time",
-            "new_dir",
-            "new_qop",
-            "path_derivatives",
-            "new_M",
-        ]
+    jac = mode != "nojac"
+    output_names = [
+        "pos2",
+        "qop2",
+        "qop3",
+        "pos3",
+        "qop4",
+        "err",
+        "new_B",
+        "new_pos",
+        "new_time",
+        "new_dir",
+        "new_qop",
     ]
+    if jac:
+        output_names += ["path_derivatives", "new_M"]
+    outputs = [find_by_name(name_exprs, name)[0] for name in output_names]
 
     lines = []
 
+    fn_name = {"jac": "rk4_dense_jac", "nojac": "rk4_dense_nojac"}[mode]
+    jac_params = ", std::span<T, 8> path_derivatives, std::span<T> M" if jac else ""
     lines.append(
         "template <typename T, typename GetB, typename GetG>\n"
-        f"{STATUS_TYPE} rk4_dense(std::span<const T, 3> pos,"
+        f"inline __attribute__((always_inline)) {STATUS_TYPE} {fn_name}("
+        "std::span<const T, 3> pos,"
         " std::span<const T, 3> dir, const T time, const T h, const T qop, const T mass,"
         " const T charge, const T p_abs, std::span<const T, 3> B1, GetB getB,"
         " GetG getG, T& err, const T errTol, std::error_code& fieldErr,"
         " std::span<T, 3> new_pos, T& new_time,"
-        " std::span<T, 3> new_dir, T& new_qop, std::span<T, 3> new_B,"
-        " std::span<T, 8> path_derivatives, std::span<T> M) {"
+        " std::span<T, 3> new_dir, T& new_qop, std::span<T, 3> new_B"
+        f"{jac_params}) {{"
     )
     lines.append(INPUT_ASSERTS)
-    lines.append(f"  assert(M.empty() || M.size() == {_B2F.size});")
+    if jac:
+        lines.append(f"  assert(M.size() == {_B2F.size});")
 
     lines.append("  const auto dEds1 = getG(pos, qop);")
 
@@ -938,10 +948,6 @@ def print_rk4_dense(name_exprs: list[NamedExpr], run_cse: bool = True) -> str:
             return "const auto dEds4 = getG(std::span<const T, 3>(pos3), qop4);"
         if str(var) == "err":
             return f"if (err > errTol) {{\n  return {STATUS_TYPE}::Rejected;\n}}"
-        if str(var) == "new_qop":
-            # new_qop carries the energy loss, so it belongs to the step and
-            # has to be written before the jacobian-only part is skipped
-            return f"if (M.empty()) {{\n  return {STATUS_TYPE}::Accepted;\n}}"
         if str(var) == "new_M":
             return "\n".join(
                 f"M[{_B2F.flat_index(i, j)}] = new_M[{k}];"
@@ -1320,10 +1326,16 @@ def main(argv: list[str]) -> None:
         # taylor_norm and run_cse are off for the vacuum kernel: neither is
         # faster, and both obscure the correspondence to the ATLAS code.
         vacuum_exprs = rk4_vacuum_b2f_atlasexpr(taylor_norm=False)
-        for vacuum_mode in ("combined", "jac", "nojac"):
-            out.write(print_rk4_vacuum_b2f(vacuum_exprs, mode=vacuum_mode))
-            out.write("\n\n")
-        out.write(print_rk4_dense(rk4_dense_tangentexpr(), run_cse=True))
+        kernels = [
+            print_rk4_vacuum_b2f(vacuum_exprs, mode=mode)
+            for mode in ("combined", "jac", "nojac")
+        ]
+        dense_exprs = rk4_dense_tangentexpr()
+        kernels += [
+            print_rk4_dense(dense_exprs, run_cse=True, mode=mode)
+            for mode in ("jac", "nojac")
+        ]
+        out.write("\n\n".join(kernels))
         out.write("\n")
 
 

--- a/docs/groups/sympy_codegen.md
+++ b/docs/groups/sympy_codegen.md
@@ -7,9 +7,10 @@
 > interface and the rest of the propagation machinery see @ref propagation.
 
 The @ref Acts::SympyStepper does not contain a hand-written Runge-Kutta step.
-Its two inner kernels — `rk4_vacuum` and `rk4_dense` — are emitted at build
-time by `Core/src/Propagator/generate_sympy_stepper.py`, which derives them
-symbolically with [sympy](https://www.sympy.org) and prints them as C++.
+Its two inner kernels — the vacuum one and the dense one, each emitted with and
+without covariance transport — come out of
+`Core/src/Propagator/generate_sympy_stepper.py` at build time, which derives
+them symbolically with [sympy](https://www.sympy.org) and prints them as C++.
 
 ## Why generate them
 
@@ -181,8 +182,8 @@ so the generator forms the chain-rule product as well and checks the two agree
 (`Derivation.check_same`).
 
 @f$\lambda@f$ and @f$M_{\lambda\lambda}@f$ are constant across a vacuum step, so
-it carries the scaled form into itself; `rk4_dense` moves @f$\lambda@f$ and
-converts explicitly. The stepper state holds the scaled form, and
+it carries the scaled form into itself; the dense kernel moves
+@f$\lambda@f$ and converts explicitly. The stepper state holds the scaled form, and
 `detail::sympy::toScaledBoundToFree` and its inverse convert where the
 covariance engine wants the plain Jacobian. The convention is singular at
 @f$\lambda = 0@f$, where the plain column already is.


### PR DESCRIPTION
The covariance-transport split of #5977, now for the dense step. The dense kernel is emitted twice, with the jacobian half kept or dropped, and `sympyDenseStep` takes the choice as a template parameter, a translation unit each, so neither body tests an empty jacobian span on every trial.

The step mode is now a path and a jacobian flag rather than three named modes, since the two are independent.

Measured on the dense step: -1% with covariance transport, -3% without.