### PR TITLE
fix(detray): resolve benchmark clang-tidy findings

### DIFF
--- a/Detray/core/include/detray/utils/tuple.hpp
+++ b/Detray/core/include/detray/utils/tuple.hpp
@@ -96,7 +96,9 @@ struct tuple<T, Ts...> {
   }
 
   T v;
-  tuple<Ts...> r{};
+  // Value-initialization would require every tail element to be default
+  // constructible, which is not a requirement of this tuple type.
+  tuple<Ts...> r;  // NOLINT(cppcoreguidelines-pro-type-member-init)
 };
 
 template <typename T1, typename T2>

--- a/Detray/core/include/detray/utils/tuple.hpp
+++ b/Detray/core/include/detray/utils/tuple.hpp
@@ -96,7 +96,7 @@ struct tuple<T, Ts...> {
   }
 
   T v;
-  tuple<Ts...> r;
+  tuple<Ts...> r{};
 };
 
 template <typename T1, typename T2>

--- a/Detray/plugins/algebra/smatrix/include/algebra/utils/data_generator.hpp
+++ b/Detray/plugins/algebra/smatrix/include/algebra/utils/data_generator.hpp
@@ -83,7 +83,7 @@ inline void fill_random_matrix(std::vector<matrix_t> &collection) {
   std::mt19937 mt(rd());
   std::uniform_real_distribution<scalar_t> dist(0.f, 1.f);
   auto rand_obj = [&]() {
-    matrix_t m;
+    matrix_t m{};
 
     for (unsigned int j = 0u; j < detray::traits::columns<matrix_t>; ++j) {
       for (unsigned int i = 0u; i < detray::traits::rows<matrix_t>; ++i) {

--- a/Detray/tests/benchmarks/include/detray/benchmarks/cpu/matrix_benchmark.hpp
+++ b/Detray/tests/benchmarks/include/detray/benchmarks/cpu/matrix_benchmark.hpp
@@ -17,6 +17,7 @@
 
 // System include(s)
 #include <string_view>
+#include <utility>
 #include <vector>
 
 namespace detray {
@@ -24,10 +25,10 @@ namespace detray {
 namespace algebra {
 
 template <detray::concepts::matrix matrix_t>
-void fill_random_matrix(std::vector<matrix_t>&);
+void fill_random_matrix(std::vector<matrix_t>& collection);
 
 template <detray::concepts::vector vector_t>
-void fill_random_vec(std::vector<vector_t>&);
+void fill_random_vec(std::vector<vector_t>& collection);
 
 }  // namespace algebra
 
@@ -46,7 +47,8 @@ struct matrix_bm : public benchmark_base {
   matrix_bm() = delete;
 
   /// Construct from an externally provided configuration @param cfg
-  explicit matrix_bm(benchmark_base::configuration cfg) : benchmark_base{cfg} {
+  explicit matrix_bm(const benchmark_base::configuration& cfg)
+      : benchmark_base{cfg} {
     const auto n_data{static_cast<std::size_t>(this->m_cfg.n_samples())};
 
     a.reserve(n_data);
@@ -74,7 +76,7 @@ struct matrix_unaryOP_bm : public matrix_bm<matrix_t> {
 
   matrix_unaryOP_bm() = delete;
   explicit matrix_unaryOP_bm(benchmark_base::configuration cfg)
-      : base_type{cfg} {}
+      : base_type{std::move(cfg)} {}
   matrix_unaryOP_bm(const matrix_unaryOP_bm& bm) = default;
   matrix_unaryOP_bm& operator=(matrix_unaryOP_bm& other) = default;
 
@@ -105,7 +107,7 @@ struct matrix_binaryOP_bm : public matrix_bm<matrix_t> {
 
   matrix_binaryOP_bm() = delete;
   explicit matrix_binaryOP_bm(benchmark_base::configuration cfg)
-      : base_type{cfg} {}
+      : base_type{std::move(cfg)} {}
   matrix_binaryOP_bm(const matrix_binaryOP_bm& bm) = default;
   matrix_binaryOP_bm& operator=(matrix_binaryOP_bm& other) = default;
 
@@ -137,7 +139,7 @@ struct matrix_vector_bm : public matrix_bm<matrix_t> {
 
   matrix_vector_bm() = delete;
   explicit matrix_vector_bm(benchmark_base::configuration cfg)
-      : base_type{cfg} {
+      : base_type{std::move(cfg)} {
     v.reserve(static_cast<std::size_t>(this->m_cfg.n_samples()));
 
     detray::algebra::fill_random_vec(v);

--- a/Detray/tests/benchmarks/include/detray/benchmarks/cpu/transform_benchmark.hpp
+++ b/Detray/tests/benchmarks/include/detray/benchmarks/cpu/transform_benchmark.hpp
@@ -17,6 +17,7 @@
 #include <iostream>
 #include <string_view>
 #include <thread>
+#include <utility>
 #include <vector>
 
 namespace detray {
@@ -24,7 +25,7 @@ namespace detray {
 namespace algebra {
 
 template <detray::concepts::transform3D transform3_t>
-void fill_random_trf(std::vector<transform3_t>&);
+void fill_random_trf(std::vector<transform3_t>& collection);
 
 }  // namespace algebra
 
@@ -45,7 +46,8 @@ struct transform3_bm : public vector_bm<typename transform3_t::vector3> {
   /// No default construction: Cannot prepare data
   transform3_bm() = delete;
   /// Construct from an externally provided configuration @param cfg
-  explicit transform3_bm(benchmark_base::configuration cfg) : base_type{cfg} {
+  explicit transform3_bm(benchmark_base::configuration cfg)
+      : base_type{std::move(cfg)} {
     trfs.reserve(static_cast<std::size_t>(this->m_cfg.n_samples()));
 
     detray::algebra::fill_random_trf(trfs);

--- a/Detray/tests/benchmarks/include/detray/benchmarks/cpu/vector_benchmark.hpp
+++ b/Detray/tests/benchmarks/include/detray/benchmarks/cpu/vector_benchmark.hpp
@@ -20,6 +20,7 @@
 #include <iostream>
 #include <string_view>
 #include <thread>
+#include <utility>
 #include <vector>
 
 namespace detray {
@@ -27,7 +28,7 @@ namespace detray {
 namespace algebra {
 
 template <concepts::vector vector_t>
-void fill_random_vec(std::vector<vector_t> &);
+void fill_random_vec(std::vector<vector_t> &collection);
 
 }  // namespace algebra
 
@@ -47,7 +48,8 @@ struct vector_bm : public benchmark_base {
   vector_bm() = delete;
 
   /// Construct from an externally provided configuration @param cfg
-  explicit vector_bm(benchmark_base::configuration cfg) : benchmark_base{cfg} {
+  explicit vector_bm(const benchmark_base::configuration &cfg)
+      : benchmark_base{cfg} {
     const auto n_data{static_cast<std::size_t>(this->m_cfg.n_samples())};
 
     a.reserve(n_data);
@@ -75,7 +77,7 @@ struct vector_unaryOP_bm : public vector_bm<vector_t<scalar_t>> {
 
   vector_unaryOP_bm() = delete;
   explicit vector_unaryOP_bm(benchmark_base::configuration cfg)
-      : base_type{cfg} {}
+      : base_type{std::move(cfg)} {}
   vector_unaryOP_bm(const vector_unaryOP_bm &bm) = default;
   vector_unaryOP_bm &operator=(vector_unaryOP_bm &other) = default;
 
@@ -107,7 +109,7 @@ struct vector_binaryOP_bm : public vector_bm<vector_t<scalar_t>> {
 
   vector_binaryOP_bm() = delete;
   explicit vector_binaryOP_bm(benchmark_base::configuration cfg)
-      : base_type{cfg} {}
+      : base_type{std::move(cfg)} {}
   vector_binaryOP_bm(const vector_binaryOP_bm &bm) = default;
   vector_binaryOP_bm &operator=(vector_binaryOP_bm &other) = default;
 


### PR DESCRIPTION
Clang-tidy reports these as errors in a full sweep on main.