### PR TITLE
refactor: Ask a GBTS layer what it is instead of decoding its id

### DIFF
--- a/Core/include/Acts/Seeding/GbtsGeometry.hpp
+++ b/Core/include/Acts/Seeding/GbtsGeometry.hpp
@@ -61,11 +61,11 @@ class GbtsGeometry final {
   /// @return Reference to layer
   const detail::GbtsLayer& layerByIndex(std::int32_t idx) const;
 
-  /// Get layer ID by index
+  /// Get the description of a layer by index
   /// @param idx Layer index
-  /// @return Layer ID
-  std::uint32_t layerIdByIndex(std::uint32_t idx) const {
-    return m_layers.at(idx).layerDescription().id;
+  /// @return Reference to the layer description
+  const GbtsLayerDescription& layerDescriptionByIndex(std::int32_t idx) const {
+    return layerByIndex(idx).layerDescription();
   }
 
   /// @param layerDescription Layer description for the layer

--- a/Core/include/Acts/Seeding/GbtsLayerDescription.hpp
+++ b/Core/include/Acts/Seeding/GbtsLayerDescription.hpp
@@ -12,8 +12,11 @@
 
 namespace Acts::Experimental {
 
-/// GBTS layer types
-enum class GbtsLayerType { Barrel = 0, Endcap = 1 };
+/// Where a GBTS layer sits, which fixes its coordinate convention.
+enum class GbtsLayerType : std::uint8_t { Barrel = 0, Endcap = 1 };
+
+/// Sensor technology of a GBTS layer, independent of GbtsLayerType.
+enum class GbtsLayerTechnology : std::uint8_t { Pixel = 0, Strip = 1 };
 
 /// Lightweight layer description for GBTS geometry.
 struct GbtsLayerDescription final {
@@ -21,7 +24,9 @@ struct GbtsLayerDescription final {
   std::int32_t id{};
   /// Layer type (barrel or endcap).
   GbtsLayerType type{};
-  /// Reference coordinate (z for barrel, r for endcap).
+  /// Sensor technology of the layer.
+  GbtsLayerTechnology technology{GbtsLayerTechnology::Pixel};
+  /// Reference coordinate (r for barrel, z for endcap).
   float refCoord{};
   /// Minimum boundary coordinate.
   float minBound{};

--- a/Core/include/Acts/Seeding/GbtsNodeStorage.hpp
+++ b/Core/include/Acts/Seeding/GbtsNodeStorage.hpp
@@ -130,8 +130,6 @@ class GbtsNodeStorage final {
 
   /// Configuration for node loading.
   struct Config {
-    /// Per-layer flag marking pixel layers. Indexed by dense layer index.
-    std::vector<bool> isPixelLayer;
     /// Enable the cluster width cuts: wide endcap rejection and tau narrowing.
     bool useClusterWidthCuts = false;
     /// Maximum endcap cluster width, applied to pixel endcap nodes when
@@ -150,7 +148,8 @@ class GbtsNodeStorage final {
   /// @param config Node loading configuration
   /// @param geometry Shared pointer to GBTS geometry
   /// @param tauLut Per-cluster-width tau bounds
-  GbtsNodeStorage(Config config, std::shared_ptr<const GbtsGeometry> geometry,
+  GbtsNodeStorage(const Config& config,
+                  std::shared_ptr<const GbtsGeometry> geometry,
                   detail::GbtsTauLookupTable tauLut);
 
   /// Get eta bin info by index

--- a/Core/include/Acts/Seeding/GraphBasedTrackSeeder.hpp
+++ b/Core/include/Acts/Seeding/GraphBasedTrackSeeder.hpp
@@ -283,7 +283,7 @@ class GraphBasedTrackSeeder {
   /// @param lutInputFile Path to the lookup table input file
   /// @return Parsed tau lookup table
   detail::GbtsTauLookupTable parseTauLookupTable(
-      const std::string& lutInputFile);
+      const std::string& lutInputFile) const;
 
   /// Build doublet graph from nodes.
   /// @param roi Region of interest descriptor

--- a/Core/include/Acts/Seeding/GraphBasedTrackSeeder.hpp
+++ b/Core/include/Acts/Seeding/GraphBasedTrackSeeder.hpp
@@ -182,9 +182,8 @@ class GraphBasedTrackSeeder {
   ///
   /// Fill it through GbtsNodeStorage::insert, then call
   /// GbtsNodeStorage::finalize before handing it to createSeeds.
-  /// @param isPixelLayer Information on if a layer is pixel or strip
   /// @return An empty node storage
-  GbtsNodeStorage makeNodeStorage(const std::vector<bool>& isPixelLayer) const;
+  GbtsNodeStorage makeNodeStorage() const;
 
   /// Create seeds from an ACTS space point container in a region of interest.
   ///
@@ -193,13 +192,11 @@ class GraphBasedTrackSeeder {
   /// columns.
   /// @param spacePoints Space point container
   /// @param roi Region of interest descriptor
-  /// @param isPixelLayer Information on if a layer is pixel or strip
   /// @param filter Tracking filter to be applied
   /// @param options Event based options such as magnetic field strength
   /// @param outputSeeds Container with generated seeds
   void createSeeds(const SpacePointContainer& spacePoints,
                    const GbtsRoiDescriptor& roi,
-                   const std::vector<bool>& isPixelLayer,
                    const GbtsTrackingFilter& filter, const Options& options,
                    SeedContainer& outputSeeds) const;
 
@@ -266,8 +263,10 @@ class GraphBasedTrackSeeder {
     float deltaPhi{};
     /// GBTS layer ID of the bin
     std::uint32_t layerId{};
-    /// whether the bin's layer is a pixel layer, hoisted out of the node loop
-    bool isPixel{true};
+    /// Type of the bin's layer.
+    GbtsLayerType type{};
+    /// Technology of the bin's layer.
+    GbtsLayerTechnology technology{};
   };
   DerivedConfig m_cfg;
 

--- a/Core/include/Acts/Seeding/detail/GbtsGraphTypes.hpp
+++ b/Core/include/Acts/Seeding/detail/GbtsGraphTypes.hpp
@@ -40,6 +40,10 @@ using GbtsTauLookupTable = std::vector<GbtsTauBounds>;
 /// Maximum number of neighbouring edges recorded per graph edge
 static constexpr std::uint32_t kGbtsMaxEdgeNeighbours = 6;
 
+/// Bins of the per-node z0 histogram, which is kept as a bit mask in
+/// GbtsNodeEdgeInfo::isConnected and so may not exceed its width.
+static constexpr std::int32_t kGbtsZ0HistogramBins = 16;
+
 //! [gbts node params]
 /// Per-node parameters used while building the graph.
 ///

--- a/Core/include/Acts/Seeding/detail/GbtsGraphTypes.hpp
+++ b/Core/include/Acts/Seeding/detail/GbtsGraphTypes.hpp
@@ -90,9 +90,10 @@ struct GbtsEtaBinInfo final {
   float maxRadius{};
   std::uint32_t layerId{0};
 
-  /// Whether the layer this bin belongs to is a pixel layer. Constant over a
-  /// bin, so the strip path is taken per bin rather than per node.
-  bool isPixel{true};
+  /// Type of the layer this bin belongs to.
+  GbtsLayerType type{};
+  /// Technology of the layer this bin belongs to.
+  GbtsLayerTechnology technology{};
 
   /// Check if bin is empty
   /// @return True if bin has no nodes
@@ -184,15 +185,17 @@ struct GbtsEdge final {
   /// @param n1_ Inner node index
   /// @param n2_ Outer node index
   /// @param n2LayerId_ GBTS layer ID of the outer node
+  /// @param n2Type_ Layer type of the outer node
   /// @param p1_ First fit parameter
   /// @param p2_ Second fit parameter
   /// @param p3_ Third fit parameter
   GbtsEdge(SpacePointIndex n1_, SpacePointIndex n2_, std::uint32_t n2LayerId_,
-           float p1_, float p2_, float p3_)
+           GbtsLayerType n2Type_, float p1_, float p2_, float p3_)
       : n1{n1_},
         n2{n2_},
         level{1},
         next{1},
+        n2Type{n2Type_},
         p{p1_, p2_, p3_},
         n2LayerId{n2LayerId_} {}
 
@@ -205,6 +208,11 @@ struct GbtsEdge final {
   std::int8_t next{-1};
 
   std::uint8_t nNei{0};
+
+  /// Layer type of the outer node. Cached so the innermost neighbour loop does
+  /// not have to chase the node's bin.
+  GbtsLayerType n2Type{};
+
   std::array<float, 3> p{};
 
   /// GBTS layer ID of the outer node. Cached next to the fit parameters so the

--- a/Core/include/Acts/Seeding/detail/GbtsGraphTypes.hpp
+++ b/Core/include/Acts/Seeding/detail/GbtsGraphTypes.hpp
@@ -185,17 +185,17 @@ struct GbtsEdge final {
   /// @param n1_ Inner node index
   /// @param n2_ Outer node index
   /// @param n2LayerId_ GBTS layer ID of the outer node
-  /// @param n2Type_ Layer type of the outer node
+  /// @param n2PixelBarrel_ Whether the outer node is on a pixel barrel layer
   /// @param p1_ First fit parameter
   /// @param p2_ Second fit parameter
   /// @param p3_ Third fit parameter
   GbtsEdge(SpacePointIndex n1_, SpacePointIndex n2_, std::uint32_t n2LayerId_,
-           GbtsLayerType n2Type_, float p1_, float p2_, float p3_)
+           bool n2PixelBarrel_, float p1_, float p2_, float p3_)
       : n1{n1_},
         n2{n2_},
         level{1},
         next{1},
-        n2Type{n2Type_},
+        n2PixelBarrel{n2PixelBarrel_},
         p{p1_, p2_, p3_},
         n2LayerId{n2LayerId_} {}
 
@@ -209,9 +209,11 @@ struct GbtsEdge final {
 
   std::uint8_t nNei{0};
 
-  /// Layer type of the outer node. Cached so the innermost neighbour loop does
-  /// not have to chase the node's bin.
-  GbtsLayerType n2Type{};
+  /// Whether the outer node is on a pixel barrel layer, the only thing the
+  /// innermost neighbour loop asks about it. Cached so that loop does not have
+  /// to chase the node's bin, and in what was padding so the edge does not
+  /// grow.
+  bool n2PixelBarrel{};
 
   std::array<float, 3> p{};
 

--- a/Core/src/Seeding/GbtsNodeStorage.cpp
+++ b/Core/src/Seeding/GbtsNodeStorage.cpp
@@ -167,8 +167,9 @@ void GbtsNodeStorage::finalize() {
     binInfo.nodes.second = m_nodes.size();
     binInfo.minRadius = minRadius;
     binInfo.maxRadius = maxRadius;
+    // every node in a bin is on the same layer, so any of them will do
     const GbtsLayerDescription& description =
-        m_geometry->layerDescriptionByIndex(m_staged[sorted.front()].layer);
+        m_geometry->layerDescriptionByIndex(m_staged[staged.front()].layer);
     binInfo.layerId = static_cast<std::uint32_t>(description.id);
     binInfo.type = description.type;
     binInfo.technology = description.technology;

--- a/Core/src/Seeding/GbtsNodeStorage.cpp
+++ b/Core/src/Seeding/GbtsNodeStorage.cpp
@@ -20,10 +20,10 @@
 
 namespace Acts::Experimental {
 
-GbtsNodeStorage::GbtsNodeStorage(Config config,
+GbtsNodeStorage::GbtsNodeStorage(const Config& config,
                                  std::shared_ptr<const GbtsGeometry> geometry,
                                  detail::GbtsTauLookupTable tauLut)
-    : m_cfg(std::move(config)),
+    : m_cfg(config),
       m_geometry(std::move(geometry)),
       m_tauLut(std::move(tauLut)),
       m_nodes(SpacePointColumns::CopiedFromIndex |
@@ -48,14 +48,12 @@ std::optional<std::uint32_t> GbtsNodeStorage::insert(
     const float clusterWidth, const float localPositionY,
     const OuterStripSpacePointCalibrationDetails* strip) {
   const detail::GbtsLayer& layer = m_geometry->layerByIndex(layerIndex);
-
-  const bool isBarrel = layer.layerDescription().type == GbtsLayerType::Barrel;
+  const GbtsLayerDescription& description = layer.layerDescription();
 
   // wide pixel endcap clusters are dropped when the width cuts are on
-  if (m_cfg.useClusterWidthCuts && !isBarrel &&
-      clusterWidth > m_cfg.maxEndcapClusterWidth &&
-      layerIndex < m_cfg.isPixelLayer.size() &&
-      m_cfg.isPixelLayer[layerIndex]) {
+  if (m_cfg.useClusterWidthCuts && description.type == GbtsLayerType::Endcap &&
+      description.technology == GbtsLayerTechnology::Pixel &&
+      clusterWidth > m_cfg.maxEndcapClusterWidth) {
     return std::nullopt;
   }
 
@@ -67,10 +65,10 @@ std::optional<std::uint32_t> GbtsNodeStorage::insert(
   const auto bin = static_cast<std::uint32_t>(binIndex);
 
   std::uint32_t stripIndex = detail::kNoStrip;
-  // A pair on a layer the configuration calls a pixel layer would never be
-  // read, the strip path being taken per bin rather than per node.
-  if (strip != nullptr && layerIndex < m_cfg.isPixelLayer.size() &&
-      !m_cfg.isPixelLayer[layerIndex]) {
+  // A strip pair on a pixel layer is never read: the seeder takes the strip
+  // path per bin.
+  if (strip != nullptr &&
+      description.technology == GbtsLayerTechnology::Strip) {
     stripIndex = static_cast<std::uint32_t>(m_strips.size());
     // Derived once here rather than once per pair in the graph: it is six
     // cross products and a node takes part in many pairs.
@@ -169,11 +167,11 @@ void GbtsNodeStorage::finalize() {
     binInfo.nodes.second = m_nodes.size();
     binInfo.minRadius = minRadius;
     binInfo.maxRadius = maxRadius;
-    const std::uint16_t layer = m_staged[sorted.front()].layer;
-    binInfo.layerId = m_geometry->layerIdByIndex(layer);
-    // constant over a bin, a bin belonging to one layer
-    binInfo.isPixel =
-        layer >= m_cfg.isPixelLayer.size() || m_cfg.isPixelLayer[layer];
+    const GbtsLayerDescription& description =
+        m_geometry->layerDescriptionByIndex(m_staged[sorted.front()].layer);
+    binInfo.layerId = static_cast<std::uint32_t>(description.id);
+    binInfo.type = description.type;
+    binInfo.technology = description.technology;
   }
 
   // Created now that the container has its final size, so that each column is
@@ -223,13 +221,12 @@ void GbtsNodeStorage::finalize() {
 
 void GbtsNodeStorage::applyTauCuts(const StagedNode& staged,
                                    detail::GbtsNodeParams& params) const {
-  const detail::GbtsLayer& layer = m_geometry->layerByIndex(staged.layer);
+  const GbtsLayerDescription& description =
+      m_geometry->layerDescriptionByIndex(staged.layer);
 
-  // skip strips volumes: layers in range [1200X-1400X]
-  if (layer.layerDescription().id < 20000) {
-    return;
-  }
-  if (layer.layerDescription().type != GbtsLayerType::Barrel) {
+  // the table is trained on pixel barrel clusters
+  if (description.technology != GbtsLayerTechnology::Pixel ||
+      description.type != GbtsLayerType::Barrel) {
     return;
   }
 

--- a/Core/src/Seeding/GbtsTrackingFilter.cpp
+++ b/Core/src/Seeding/GbtsTrackingFilter.cpp
@@ -356,7 +356,7 @@ bool GbtsTrackingFilter::update(const detail::GbtsNodeView& nodeView,
 
 GbtsLayerType GbtsTrackingFilter::getLayerType(
     const std::uint32_t layerIndex) const {
-  return m_geometry->layerByIndex(layerIndex).layerDescription().type;
+  return m_geometry->layerDescriptionByIndex(layerIndex).type;
 }
 
 }  // namespace Acts::Experimental

--- a/Core/src/Seeding/GraphBasedTrackSeeder.cpp
+++ b/Core/src/Seeding/GraphBasedTrackSeeder.cpp
@@ -51,26 +51,23 @@ GraphBasedTrackSeeder::GraphBasedTrackSeeder(
   m_tauLut = parseTauLookupTable(m_cfg.lutInputFile);
 }
 
-GbtsNodeStorage GraphBasedTrackSeeder::makeNodeStorage(
-    const std::vector<bool>& isPixelLayer) const {
+GbtsNodeStorage GraphBasedTrackSeeder::makeNodeStorage() const {
   GbtsNodeStorage::Config config;
-  config.isPixelLayer = isPixelLayer;
   config.useClusterWidthCuts = m_cfg.useClusterWidthCuts;
   config.maxEndcapClusterWidth = m_cfg.maxEndcapClusterWidth;
   config.moduleHalfLengthY = m_cfg.moduleHalfLengthY;
   config.moduleEdgeTolerance = m_cfg.moduleEdgeTolerance;
   config.phiSliceWidth = m_cfg.phiSliceWidth;
 
-  return GbtsNodeStorage(std::move(config), m_geometry, m_tauLut);
+  return GbtsNodeStorage(config, m_geometry, m_tauLut);
 }
 
 void GraphBasedTrackSeeder::createSeeds(const SpacePointContainer& spacePoints,
                                         const GbtsRoiDescriptor& roi,
-                                        const std::vector<bool>& isPixelLayer,
                                         const GbtsTrackingFilter& filter,
                                         const Options& options,
                                         SeedContainer& outputSeeds) const {
-  GbtsNodeStorage nodeStorage = makeNodeStorage(isPixelLayer);
+  GbtsNodeStorage nodeStorage = makeNodeStorage();
 
   const auto layerColumn = spacePoints.column<std::uint32_t>("layerId");
   const auto clusterWidthColumn = spacePoints.column<float>("clusterWidth");
@@ -248,7 +245,8 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
 
     const std::uint32_t layerId1 = B1.layerId;
 
-    const bool isBarrel1 = (layerId1 / 10000) == 8;
+    const bool isBarrel1 = B1.type == GbtsLayerType::Barrel;
+    const bool isPixel1 = B1.technology == GbtsLayerTechnology::Pixel;
 
     // prepare a sliding window for each non-empty bin2 in the group
 
@@ -285,11 +283,9 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
       window.numPhiNodes = static_cast<std::uint32_t>(B2.phiNodes.size());
       window.deltaPhi = deltaPhi;
       window.layerId = B2.layerId;
-      window.isPixel = B2.isPixel;
+      window.type = B2.type;
+      window.technology = B2.technology;
     }
-
-    // a property of the bin, so the strip path costs nothing per pair
-    const bool isPixel1 = B1.isPixel;
 
     // in GBTSv3 the outer loop goes over n1 nodes in the Layer 1 bin
     for (SpacePointIndex n1Idx = B1.nodes.first; n1Idx < B1.nodes.second;
@@ -323,9 +319,9 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
       for (auto& slw : phiSlidingWindow) {
         const std::uint32_t lk2 = slw.layerId;
 
-        const bool isBarrel2 = (lk2 / 10000) == 8;
+        const bool isBarrel2 = slw.type == GbtsLayerType::Barrel;
 
-        const bool isPixel2 = slw.isPixel;
+        const bool isPixel2 = slw.technology == GbtsLayerTechnology::Pixel;
         const bool stripPair = calibrate && (!isPixel1 || !isPixel2);
 
         const float deltaPhi = slw.deltaPhi;
@@ -507,7 +503,7 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
           const float dPhi1 = curv * r1c;
 
           if (nEdges < m_cfg.nMaxEdges) {
-            edgeStorage.emplace_back(n1Idx, n2Idx, lk2, expEta, curv,
+            edgeStorage.emplace_back(n1Idx, n2Idx, lk2, slw.type, expEta, curv,
                                      phi1 + dPhi1);
 
             ++numCreatedEdges;
@@ -536,7 +532,7 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
 
               const std::uint32_t lk3 = pS->n2LayerId;
 
-              const bool isBarrel3 = (lk3 / 10000) == 8;
+              const bool isBarrel3 = pS->n2Type == GbtsLayerType::Barrel;
 
               float addTauRatioCorr = 0;
 

--- a/Core/src/Seeding/GraphBasedTrackSeeder.cpp
+++ b/Core/src/Seeding/GraphBasedTrackSeeder.cpp
@@ -122,7 +122,7 @@ void GraphBasedTrackSeeder::createSeeds(GbtsNodeStorage& nodeStorage,
 }
 
 detail::GbtsTauLookupTable GraphBasedTrackSeeder::parseTauLookupTable(
-    const std::string& lutInputFile) {
+    const std::string& lutInputFile) const {
   if (!m_cfg.useClusterWidthCuts) {
     return {};
   }
@@ -682,7 +682,7 @@ std::int32_t GraphBasedTrackSeeder::runCCA(
       for (std::uint32_t nIdx = 0; nIdx < pS->nNei; ++nIdx) {
         const std::uint32_t nextEdgeIdx = pS->vNei[nIdx];
 
-        detail::GbtsEdge* pN = &(edgeStorage[nextEdgeIdx]);
+        const detail::GbtsEdge* pN = &(edgeStorage[nextEdgeIdx]);
 
         if (pS->level == pN->level) {
           nextLevel = pS->level + 1;

--- a/Core/src/Seeding/GraphBasedTrackSeeder.cpp
+++ b/Core/src/Seeding/GraphBasedTrackSeeder.cpp
@@ -245,8 +245,11 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
 
     const std::uint32_t layerId1 = B1.layerId;
 
-    const bool isBarrel1 = B1.type == GbtsLayerType::Barrel;
     const bool isPixel1 = B1.technology == GbtsLayerTechnology::Pixel;
+    // The adaptive tau corrections and the triplet validation below were tuned
+    // on the pixel barrel and are keyed on it, which is what ATLAS's
+    // (layerId / 10000) == 8 selects: its strip barrel is numbered 13xxx.
+    const bool isPixelBarrel1 = isPixel1 && B1.type == GbtsLayerType::Barrel;
 
     // prepare a sliding window for each non-empty bin2 in the group
 
@@ -319,9 +322,10 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
       for (auto& slw : phiSlidingWindow) {
         const std::uint32_t lk2 = slw.layerId;
 
-        const bool isBarrel2 = slw.type == GbtsLayerType::Barrel;
-
         const bool isPixel2 = slw.technology == GbtsLayerTechnology::Pixel;
+        const bool isPixelBarrel2 =
+            isPixel2 && slw.type == GbtsLayerType::Barrel;
+
         const bool stripPair = calibrate && (!isPixel1 || !isPixel2);
 
         const float deltaPhi = slw.deltaPhi;
@@ -503,8 +507,8 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
           const float dPhi1 = curv * r1c;
 
           if (nEdges < m_cfg.nMaxEdges) {
-            edgeStorage.emplace_back(n1Idx, n2Idx, lk2, slw.type, expEta, curv,
-                                     phi1 + dPhi1);
+            edgeStorage.emplace_back(n1Idx, n2Idx, lk2, isPixelBarrel2, expEta,
+                                     curv, phi1 + dPhi1);
 
             ++numCreatedEdges;
 
@@ -532,12 +536,12 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
 
               const std::uint32_t lk3 = pS->n2LayerId;
 
-              const bool isBarrel3 = pS->n2Type == GbtsLayerType::Barrel;
+              const bool isPixelBarrel3 = pS->n2PixelBarrel;
 
               float addTauRatioCorr = 0;
 
               if (m_cfg.useAdaptiveCuts) {
-                if (isBarrel1 && isBarrel2 && isBarrel3) {
+                if (isPixelBarrel1 && isPixelBarrel2 && isPixelBarrel3) {
                   const bool noGap =
                       ((lk3 - lk2) == 1000) && ((lk2 - layerId1) == 1000);
 
@@ -546,7 +550,8 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
                     addTauRatioCorr = m_cfg.tauRatioCorr;
                   }
                 } else {
-                  bool mixedTriplet = isBarrel1 && isBarrel2 && !isBarrel3;
+                  bool mixedTriplet =
+                      isPixelBarrel1 && isPixelBarrel2 && !isPixelBarrel3;
                   if (mixedTriplet) {
                     addTauRatioCorr = m_cfg.tauRatioCorr;
                   }
@@ -586,8 +591,7 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
 
               // final check: cuts on pT and d0
               if (m_cfg.validateTriplets) {
-                // Pixel barrel
-                if (isBarrel1 && isBarrel2 && isBarrel3) {
+                if (isPixelBarrel1 && isPixelBarrel2 && isPixelBarrel3) {
                   const std::array<SpacePointIndex, 3> candidateTriplet = {
                       n1Idx, n2Idx, pS->n2};
 

--- a/Core/src/Seeding/GraphBasedTrackSeeder.cpp
+++ b/Core/src/Seeding/GraphBasedTrackSeeder.cpp
@@ -200,10 +200,8 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
   std::uint32_t nEdges = 0;
 
   // scale factor to get indexes of binned beamspot
-  // assuming 16-bit z0 bitmask
-
-  const std::uint32_t zBins = 16;
-  const float z0HistoCoeff = zBins / (m_cfg.maxZ0 - m_cfg.minZ0 + 1e-6);
+  const float z0HistoCoeff =
+      detail::kGbtsZ0HistogramBins / (m_cfg.maxZ0 - m_cfg.minZ0 + 1e-6);
 
   const detail::GbtsNodeView nodeView = nodeStorage.nodeView();
   const std::span<const detail::GbtsNodeParams> params =
@@ -301,7 +299,7 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
 
       bool isConnected = false;
 
-      std::array<std::uint8_t, 16> z0Histo = {};
+      std::array<std::uint8_t, detail::kGbtsZ0HistogramBins> z0Histo = {};
 
       const detail::GbtsNodeParams& n1pars = params[n1Idx];
 
@@ -608,12 +606,15 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
 
               isConnected = true;  // there is at least one good match
 
-              // edge confirmed - update z0 histogram
+              // edge confirmed - update z0 histogram. Only doubletFilterRZ
+              // holds z0 to the histogram range, and it is optional.
+              const auto z0BinIndex =
+                  static_cast<std::int32_t>(z0HistoCoeff * (z0 - m_cfg.minZ0));
 
-              const std::uint32_t z0BinIndex =
-                  static_cast<std::uint32_t>(z0HistoCoeff * (z0 - m_cfg.minZ0));
-
-              ++z0Histo[z0BinIndex];
+              if (z0BinIndex >= 0 &&
+                  z0BinIndex < detail::kGbtsZ0HistogramBins) {
+                ++z0Histo[z0BinIndex];
+              }
 
               nConnections++;
             }
@@ -628,7 +629,8 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
       if (isConnected) {
         std::uint16_t z0BitMask = 0x0;
 
-        for (std::uint32_t bIdx = 0; bIdx < 16; ++bIdx) {
+        for (std::int32_t bIdx = 0; bIdx < detail::kGbtsZ0HistogramBins;
+             ++bIdx) {
           if (z0Histo[bIdx] == 0) {
             continue;
           }
@@ -1026,10 +1028,17 @@ bool GraphBasedTrackSeeder::checkZ0BitMask(const std::uint16_t z0BitMask,
     return true;
   }
 
+  // z0 is not yet range checked here -- doubletFilterRZ runs after this -- so
+  // a bin outside the histogram is reachable and must not reach the shift.
+  const auto isSet = [z0BitMask](const std::int32_t bin) {
+    return bin >= 0 && bin < detail::kGbtsZ0HistogramBins &&
+           ((z0BitMask >> bin) & 1) != 0;
+  };
+
   const float dz = z0 - minZ0;
   const std::int32_t z0BinIndex = static_cast<std::int32_t>(z0HistoCoeff * dz);
 
-  if (((z0BitMask >> z0BinIndex) & 1) != 0) {
+  if (isSet(z0BinIndex)) {
     return true;
   }
 
@@ -1041,20 +1050,16 @@ bool GraphBasedTrackSeeder::checkZ0BitMask(const std::uint16_t z0BitMask,
 
   std::int32_t nextBin = static_cast<std::int32_t>(z0HistoCoeff * dzm);
 
-  if (nextBin >= 0 && nextBin != z0BinIndex) {
-    if (((z0BitMask >> nextBin) & 1) != 0) {
-      return true;
-    }
+  if (nextBin != z0BinIndex && isSet(nextBin)) {
+    return true;
   }
 
   const float dzp = dz + z0Resolution;
 
   nextBin = static_cast<std::int32_t>(z0HistoCoeff * dzp);
 
-  if (nextBin < 16 && nextBin != z0BinIndex) {
-    if (((z0BitMask >> nextBin) & 1) != 0) {
-      return true;
-    }
+  if (nextBin != z0BinIndex && isSet(nextBin)) {
+    return true;
   }
 
   return false;

--- a/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/GraphBasedSeedingAlgorithm.hpp
+++ b/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/GraphBasedSeedingAlgorithm.hpp
@@ -95,9 +95,6 @@ class GraphBasedSeedingAlgorithm final : public IAlgorithm {
   /// used to assign LayerIds to the GbtsActsMap
   std::map<std::uint32_t, std::uint32_t> m_layerIdMap{};
 
-  /// used to tell if a layer is a strip or pixel layer
-  std::vector<bool> m_isPixelLayer{};
-
   /// used to define region of interest
   std::optional<Acts::Experimental::GbtsRoiDescriptor> m_internalRoi;
 

--- a/Examples/Algorithms/TrackFinding/src/GraphBasedSeedingAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFinding/src/GraphBasedSeedingAlgorithm.cpp
@@ -48,9 +48,6 @@ GraphBasedSeedingAlgorithm::GraphBasedSeedingAlgorithm(
   const auto layerGeometry =
       layerNumbering(Acts::GeometryContext::dangerouslyDefaultConstruct());
 
-  // as all layers in examples are pixel, we set entire vector to true
-  m_isPixelLayer.resize(layerGeometry.size(), true);
-
   // option that allows for adding custom eta binning (default is at 0.2)
   if (m_cfg.seedFinderConfig.etaBinWidthOverride != 0.0f) {
     layerConnectionMap.etaBinWidth = m_cfg.seedFinderConfig.etaBinWidthOverride;
@@ -92,8 +89,7 @@ ProcessCode GraphBasedSeedingAlgorithm::execute(
   // The node storage is filled straight from the input space points. It takes
   // plain scalars, so no intermediate space point container is needed and the
   // seeds come back indexed into the input container directly.
-  Acts::Experimental::GbtsNodeStorage nodeStorage =
-      m_finder->makeNodeStorage(m_isPixelLayer);
+  Acts::Experimental::GbtsNodeStorage nodeStorage = m_finder->makeNodeStorage();
 
   std::uint32_t nUnmapped = 0;
 
@@ -333,9 +329,14 @@ GraphBasedSeedingAlgorithm::layerNumbering(const Acts::GeometryContext &gctx) {
 
     } else {  // end so doesn't exists
       // make new if one with Gbts ID doesn't exist:
-      Acts::Experimental::GbtsLayerDescription newGbtsId(
-          combinedId, barrelEc, rc, minBound, maxBound);
-      inputVector.push_back(newGbtsId);
+      // every layer the examples framework feeds GBTS is a pixel layer
+      inputVector.push_back(Acts::Experimental::GbtsLayerDescription{
+          .id = combinedId,
+          .type = barrelEc,
+          .technology = Acts::Experimental::GbtsLayerTechnology::Pixel,
+          .refCoord = rc,
+          .minBound = minBound,
+          .maxBound = maxBound});
       // so the element exists and not divinding by 0
       countVector.push_back(1);
 

--- a/Tests/UnitTests/Core/Seeding/GbtsSeedingTests.cpp
+++ b/Tests/UnitTests/Core/Seeding/GbtsSeedingTests.cpp
@@ -39,6 +39,7 @@ namespace Acts::Test {
 namespace {
 
 using namespace Acts::UnitLiterals;
+using Experimental::GbtsLayerTechnology;
 using Experimental::GbtsLayerType;
 
 /// Half-length in z of every barrel layer, reused as the z0 and RoI z range.
@@ -51,13 +52,13 @@ constexpr float kDiscMaxR = 220.f;
 /// Eta bin width declared by the connector table, as in createLinkingScheme.py.
 constexpr float kEtaBinWidth = 0.2f;
 
-/// One layer of the toy detector. GBTS reads the subdetector off the layer id:
-/// 8xxxx is barrel, 9xxxx the positive and 7xxxx the negative endcap. 80000 is
-/// the innermost barrel layer (extra z0 cuts), barrel ids 1000 apart are
-/// adjacent.
+/// One layer of the toy detector. The ids follow ATLAS, which the seeder still
+/// keys on: 80000 is the innermost barrel layer (extra z0 cuts) and barrel ids
+/// 1000 apart are adjacent.
 struct LayerSpec {
   std::int32_t id{};
   GbtsLayerType type{};
+  GbtsLayerTechnology technology{GbtsLayerTechnology::Pixel};
   /// r for a barrel layer, z for an endcap disc.
   float refCoord{};
   /// z range for a barrel layer, r range for an endcap disc.
@@ -66,11 +67,19 @@ struct LayerSpec {
 };
 
 constexpr LayerSpec barrelLayer(std::int32_t id, float radius) {
-  return {id, GbtsLayerType::Barrel, radius, -kBarrelHalfZ, kBarrelHalfZ};
+  return {.id = id,
+          .type = GbtsLayerType::Barrel,
+          .refCoord = radius,
+          .minBound = -kBarrelHalfZ,
+          .maxBound = kBarrelHalfZ};
 }
 
 constexpr LayerSpec discLayer(std::int32_t id, float z) {
-  return {id, GbtsLayerType::Endcap, z, kDiscMinR, kDiscMaxR};
+  return {.id = id,
+          .type = GbtsLayerType::Endcap,
+          .refCoord = z,
+          .minBound = kDiscMinR,
+          .maxBound = kDiscMaxR};
 }
 
 /// Layers plus the connector links between them, outer (src) to inner (dst).
@@ -142,6 +151,7 @@ std::shared_ptr<Experimental::GbtsGeometry> makeGeometry(
     Experimental::GbtsLayerDescription layer;
     layer.id = spec.id;
     layer.type = spec.type;
+    layer.technology = spec.technology;
     layer.refCoord = spec.refCoord;
     layer.minBound = spec.minBound;
     layer.maxBound = spec.maxBound;
@@ -277,17 +287,15 @@ constexpr float kStereoAngle = 26e-3f;
 constexpr float kModuleGap = 2.f;
 constexpr float kStripHalfLength = 24.f;
 
-/// The same hits, with the outer barrel layers read out as strip layers: each
-/// point displaced along its strip by `walk` and carrying the stereo pair.
+/// The same hits, with every strip layer of the detector displaced along its
+/// strip by `walk` and carrying the stereo pair it was formed from.
 ///
 /// @param detector the toy detector
 /// @param tracks the tracks crossing it
-/// @param firstStripLayer index of the innermost layer to read out as strips
 /// @param walk how far along the strip the beam spot puts the point
 /// @return the space points
 SpacePointContainer makeStripSpacePoints(const ToyDetector& detector,
                                          const std::vector<Track>& tracks,
-                                         std::size_t firstStripLayer,
                                          float walk) {
   SpacePointContainer container(
       SpacePointColumns::CopiedFromIndex | SpacePointColumns::X |
@@ -314,7 +322,8 @@ SpacePointContainer makeStripSpacePoints(const ToyDetector& detector,
       }
       const auto [r, z] = *crossing;
       const std::array<float, 3> point{r * cosPhi, r * sinPhi, z};
-      const bool strip = layer >= firstStripLayer;
+      const bool strip =
+          detector.layers[layer].technology == GbtsLayerTechnology::Strip;
 
       auto sp = container.createSpacePoint();
       sp.x() = point[0];
@@ -369,7 +378,6 @@ struct SeederSetup {
   Experimental::GbtsTrackingFilter filter;
   Experimental::GbtsRoiDescriptor roi;
   Experimental::GraphBasedTrackSeeder::Options options;
-  std::vector<bool> isPixelLayer;
 };
 
 /// @param detector the toy detector
@@ -386,8 +394,6 @@ SeederSetup makeSeeder(const ToyDetector& detector,
     return quiet ? getDummyLogger().clone()
                  : getDefaultLogger("GbtsTest", Logging::Level::WARNING);
   };
-
-  const auto numLayers = static_cast<std::uint32_t>(detector.layers.size());
 
   Experimental::GraphBasedTrackSeeder::Config config;
   config.minPt = 1_GeV;
@@ -407,7 +413,7 @@ SeederSetup makeSeeder(const ToyDetector& detector,
       .roi = Experimental::GbtsRoiDescriptor(-4.5, 4.5, -kBarrelHalfZ,
                                              kBarrelHalfZ),
       .options = Experimental::GraphBasedTrackSeeder::Options(2_T),
-      .isPixelLayer = std::vector<bool>(numLayers, true)};
+  };
 }
 
 SeedContainer runSeeding(const ToyDetector& detector,
@@ -417,8 +423,8 @@ SeedContainer runSeeding(const ToyDetector& detector,
   SeedContainer seeds;
   seeds.assignSpacePointContainer(spacePoints);
 
-  setup.seeder.createSeeds(spacePoints, setup.roi, setup.isPixelLayer,
-                           setup.filter, setup.options, seeds);
+  setup.seeder.createSeeds(spacePoints, setup.roi, setup.filter, setup.options,
+                           seeds);
 
   return seeds;
 }
@@ -532,8 +538,7 @@ BOOST_AUTO_TEST_CASE(SeedsFromCallerFilledNodeStorage) {
 
   const SeederSetup setup = makeSeeder(detector);
 
-  Experimental::GbtsNodeStorage storage =
-      setup.seeder.makeNodeStorage(setup.isPixelLayer);
+  Experimental::GbtsNodeStorage storage = setup.seeder.makeNodeStorage();
 
   // r and phi as stored, so both paths see the same numbers - deriving them
   // from x and y instead costs the last bits and the seed quality with it
@@ -697,26 +702,25 @@ BOOST_AUTO_TEST_CASE(SeedsFromDenseForwardTracks) {
 // clear of both ends: the triplet tau ratio gives up past 1.9 mm, the filter's
 // chi2 against the nominal positions past 4.4 mm.
 BOOST_AUTO_TEST_CASE(StripLayersNeedTheirPairResolved) {
-  const ToyDetector detector = barrelDetector();
   const std::vector<Track> tracks = makeSparseTracks();
   constexpr float kWalk = 3.f;
   constexpr std::size_t kFirstStripLayer = 2;
 
-  std::vector<bool> isPixelLayer(detector.layers.size(), true);
-  for (std::size_t layer = kFirstStripLayer; layer < isPixelLayer.size();
+  ToyDetector detector = barrelDetector();
+  for (std::size_t layer = kFirstStripLayer; layer < detector.layers.size();
        ++layer) {
-    isPixelLayer[layer] = false;
+    detector.layers[layer].technology = GbtsLayerTechnology::Strip;
   }
 
   const auto seed = [&](const float walk, const bool calibrate) {
     const SpacePointContainer spacePoints =
-        makeStripSpacePoints(detector, tracks, kFirstStripLayer, walk);
+        makeStripSpacePoints(detector, tracks, walk);
     // a graph with no connections is the point of the unresolved case, so the
     // warning that says so is not one here
     const SeederSetup setup = makeSeeder(detector, calibrate, /*quiet=*/true);
     SeedContainer seeds;
     seeds.assignSpacePointContainer(spacePoints);
-    setup.seeder.createSeeds(spacePoints, setup.roi, isPixelLayer, setup.filter,
+    setup.seeder.createSeeds(spacePoints, setup.roi, setup.filter,
                              setup.options, seeds);
     return seeds.size();
   };


### PR DESCRIPTION
`GbtsLayerDescription` already says whether a layer is barrel or endcap, and
every part of GBTS reads it -- except the seeder, which decodes
`(layerId / 10000) == 8` at three sites. On ATLAS's numbering that test does not
say "barrel": pixel barrel is 8xxxx but strip barrel is 13xxx, so what it
selects is the *pixel* barrel, which is what the two adaptive tau corrections
and the triplet validation were tuned on. It is held up only by the ids the
examples mapping happens to build; any other detector gets `false` everywhere
and silently loses all three. The seeder now asks the layer both halves of that
question instead. A bin already caches its layer id, so it caches its type and
technology too, and an edge carries the one bit its neighbour loop needs in what
was padding.

Pixel versus strip is the second half. It arrived as a `std::vector<bool>`
threaded through two public entry points, indexed by dense layer index and
bounds-checked at three sites, where falling off the end meant pixel at two of
them and strip at the third -- so a short vector was a silent misconfiguration,
and not even a consistent one. It becomes `GbtsLayerTechnology` on the layer
description, orthogonal to
`GbtsLayerType` because the two answer different questions: where a layer sits,
and what it measures with.

That leaves `applyTauCuts`, which asked a third way -- `id < 20000`, in a
numbering incompatible with both of the above -- and so ignored the vector
entirely. It now asks the layer. This is the one behaviour change here, and it
reaches only a configuration with `useClusterWidthCuts` on and strip layers
declared.

Separately, `checkZ0BitMask` shifted by an unchecked bin index. `doubletFilterRZ`
is the only thing that holds z0 to the histogram range and it runs *after* the
mask is consulted, so a z0 below `minZ0` shifted by a negative count -- while the
two adjacent-bin lookups right below it were already guarded. The bin count
becomes a named constant and all three lookups, plus the fill, are guarded the
same way.
