### PR TITLE
refactor: Give the GBTS cuts names

### DIFF
--- a/Core/include/Acts/Seeding/GbtsGeometry.hpp
+++ b/Core/include/Acts/Seeding/GbtsGeometry.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "Acts/Definitions/Units.hpp"
 #include "Acts/Seeding/GbtsLayerConnection.hpp"
 #include "Acts/Seeding/GbtsLayerDescription.hpp"
 #include "Acts/Seeding/detail/GbtsLayer.hpp"
@@ -23,15 +24,26 @@ class GbtsNodeStorage;
 class GbtsTrackingFilter;
 class GraphBasedTrackSeeder;
 
+/// z0 range two eta bins must share a trajectory within, which fixes the bin
+/// table. A separate cut from `GraphBasedTrackSeeder::Config::minZ0`.
+struct GbtsZ0Range final {
+  /// Minimum z0.
+  float min = -168.0f * UnitConstants::mm;
+  /// Maximum z0.
+  float max = 168.0f * UnitConstants::mm;
+};
+
 /// Geometry helper built from layers and connectors.
 class GbtsGeometry final {
  public:
   /// Constructor
   /// @param layerDescriptions Layer descriptions for the layers
   /// @param layerConnections Layer connections map
+  /// @param z0Range z0 range the bin table is built against
   /// @param logger Logging instance, only used during construction
   GbtsGeometry(const std::vector<GbtsLayerDescription>& layerDescriptions,
                const GbtsLayerConnectionMap& layerConnections,
+               const GbtsZ0Range& z0Range = {},
                const Logger& logger = getDummyLogger());
 
  private:

--- a/Core/include/Acts/Seeding/GbtsLayerConnection.hpp
+++ b/Core/include/Acts/Seeding/GbtsLayerConnection.hpp
@@ -37,15 +37,16 @@ struct GbtsLayerConnectionMap {
  public:
   /// Create a GbtsLayerConnectionMap from an input stream
   /// @param inStream Input stream containing the connection data
-  /// @param lrtMode Enable LRT (Large Radius Tracking) mode
+  /// @param stripConnections Keep the strip-to-strip connections rather than the pixel-to-pixel ones
   /// @return A GbtsLayerConnectionMap instance populated with the data from the stream
   static GbtsLayerConnectionMap fromStream(std::istream& inStream,
-                                           bool lrtMode);
+                                           bool stripConnections);
   /// Create a GbtsLayerConnectionMap from a file
   /// @param inFile Input configuration file path
-  /// @param lrtMode Enable LRT (Large Radius Tracking) mode
+  /// @param stripConnections Keep the strip-to-strip connections rather than the pixel-to-pixel ones
   /// @return A GbtsLayerConnectionMap instance populated with the data from the file
-  static GbtsLayerConnectionMap fromFile(std::string& inFile, bool lrtMode);
+  static GbtsLayerConnectionMap fromFile(std::string& inFile,
+                                         bool stripConnections);
 
   /// Group of connections targeting a destination layer.
   struct LayerGroup {

--- a/Core/include/Acts/Seeding/GbtsNodeStorage.hpp
+++ b/Core/include/Acts/Seeding/GbtsNodeStorage.hpp
@@ -35,6 +35,9 @@ class GbtsGeometry;
 /// the derived per-node data in dynamic columns on that container.
 class GbtsNodeStorage final {
  public:
+  /// Maximum `Config::phiSortBuckets`; sizes the fixed bucket array.
+  static constexpr std::uint32_t kMaxPhiSortBuckets = 31;
+
   /// Filled storage is not relocatable: the column proxies point into the
   /// space point container held by value.
   GbtsNodeStorage(const GbtsNodeStorage&) = delete;
@@ -143,6 +146,13 @@ class GbtsNodeStorage final {
     float moduleEdgeTolerance = 0.3f;
     /// Width of the phi slice used to build the phi indexing.
     float phiSliceWidth = 0.f;
+    /// Multiples of `phiSliceWidth` duplicated either side of the wrap-around,
+    /// so a sliding window never has to wrap.
+    float phiIndexMargin = 1.5f;
+    /// Buckets used to sort a bin by phi, at most `kMaxPhiSortBuckets`.
+    std::uint32_t phiSortBuckets = 31;
+    /// Cluster width covered by one bin of the tau lookup table.
+    float tauLutBinWidth = 0.05f;
   };
 
   /// @param config Node loading configuration

--- a/Core/include/Acts/Seeding/GbtsTrackingFilter.hpp
+++ b/Core/include/Acts/Seeding/GbtsTrackingFilter.hpp
@@ -13,6 +13,7 @@
 #include "Acts/Seeding/detail/GbtsFilterTypes.hpp"
 #include "Acts/Utilities/Logger.hpp"
 
+#include <array>
 #include <cstdint>
 #include <memory>
 #include <vector>
@@ -58,6 +59,11 @@ class GbtsTrackingFilter final {
     float maxCurvature = 1e-3f / Acts::UnitConstants::mm;
     /// Maximum longitudinal impact parameter.
     float maxZ0 = 170.0 * Acts::UnitConstants::mm;
+
+    /// Initial variance of the transverse state (y, dy/dx, d2y/dx2).
+    std::array<float, 3> initialVarianceX = {0.25f, 0.001f, 0.001f};
+    /// Initial variance of the longitudinal state (z, dz/dr).
+    std::array<float, 2> initialVarianceY = {1.5f, 0.001f};
   };
 
   /// @param config Configuration for seed finder

--- a/Core/include/Acts/Seeding/GraphBasedTrackSeeder.hpp
+++ b/Core/include/Acts/Seeding/GraphBasedTrackSeeder.hpp
@@ -53,14 +53,14 @@ class GraphBasedTrackSeeder {
     bool matchBeforeCreate = false;
     /// Use legacy tuning parameters.
     bool useOldTunings = false;
-    /// optional validation for abrrel triplets
+    /// optional validation for barrel triplets
     bool validateTriplets = true;
     /// widens allowed variation in tau ratio
     /// if layer is missed in edge connecting
     bool useAdaptiveCuts = true;
-    /// optionally add 3 sp seeds within a cirtain eta range
+    /// optionally add 3 sp seeds within a certain eta range
     ///
-    /// @note Worth little until `maxAbsEtaAddTripelts` is opened past
+    /// @note Worth little until `maxAbsEtaAddTriplets` is opened past
     ///       `edgeMaskMinEta`; matters most where there are few layers.
     bool addTriplets = false;
     /// Tau ratio cut threshold.
@@ -76,7 +76,7 @@ class GraphBasedTrackSeeder {
     float tauRatioCorrStrip = 0.03f;
     /// the maximum allowed eta value in which
     /// three spacepoint seeds are passed through
-    float maxAbsEtaAddTripelts = 1.5;
+    float maxAbsEtaAddTriplets = 1.5;
     /// Eta bin width override (0 uses default from connection file).
     /// specify non-zero to override eta bin width from connection file (default
     /// 0.2 in createLinkingScheme.py)
@@ -86,6 +86,9 @@ class GraphBasedTrackSeeder {
     float nMaxPhiSlice = 53;  // used to calculate phi slices
     /// Minimum transverse momentum.
     float minPt = 1.0f * UnitConstants::GeV;
+    /// Fraction of `minPt` a triplet may fall to, allowing for three-point
+    /// pT resolution.
+    float tripletPtFraction = 0.8f;
 
     // graph building options
     /// Use eta binning from geometry structure.
@@ -105,25 +108,75 @@ class GraphBasedTrackSeeder {
     float cutDPhiMax = 0.012f;
     /// Maximum allowed curvature tolerance for candidate edge connections
     float cutDCurvMax = 0.001f;
-    /// Minimum z0 value, set as optionl as if in pixel mode,
-    /// The value is picked from the ROI
+    /// Minimum z0 value. In pixel mode the value is picked from the RoI.
     float minZ0 = -600;
-    /// Minimum z0 value, set as optionl as if in pixel mode,
-    /// The value is picked from the ROI
+    /// Maximum z0 value. In pixel mode the value is picked from the RoI.
     float maxZ0 = 600;
     /// When old tunings are used, this defines the minimum phi window used
     float minDeltaPhi = 0.001f;
+
+    /// pT the default cut coefficients were tuned at; they scale by
+    /// `tuningPt / minPt`.
+    float tuningPt = 0.9f * UnitConstants::GeV;
+    /// Maximum |curvature| above `curvatureSplitAbsTau`, before that scaling.
+    float maxCurvatureHighEta = 4.75e-4f / UnitConstants::mm;
+    /// Maximum |curvature| below `curvatureSplitAbsTau`, before that scaling.
+    float maxCurvatureLowEta = 3.75e-4f / UnitConstants::mm;
+    /// |cot(theta)| separating the two curvature cuts, |eta| of about 2.1.
+    float curvatureSplitAbsTau = 4.0f;
+    /// Squared fraction of the maximum curvature the old tunings cut at above
+    /// `curvatureSplitAbsTau`.
+    float oldTuningsCurvatureHighEtaFraction = 0.8f;
+    /// Squared fraction of the same below `curvatureSplitAbsTau`.
+    float oldTuningsCurvatureLowEtaFraction = 0.6f;
+    /// Fraction of the maximum curvature the old tunings open the phi window
+    /// by, per unit of radial separation.
+    float oldTuningsPhiWindowFraction = 0.68f;
+    /// Radial separation splitting the two phi window slopes below.
+    float phiWindowSplitDeltaRadius = 60.0f * UnitConstants::mm;
+    /// Phi window below `phiWindowSplitDeltaRadius`, as offset plus slope times
+    /// the radial separation.
+    float phiWindowNearOffset = 0.002f;
+    /// Slope of the near phi window, per unit radial separation. Scaled by
+    /// `tuningPt / minPt`.
+    float phiWindowNearSlope = 4.33e-4f / UnitConstants::mm;
+    /// Phi window above `phiWindowSplitDeltaRadius`, in the same form.
+    float phiWindowFarOffset = 0.015f;
+    /// Slope of the far phi window, per unit radial separation. Scaled by
+    /// `tuningPt / minPt`.
+    float phiWindowFarSlope = 2.2e-4f / UnitConstants::mm;
+    /// Incoming edge count below which a node is accepted without a tau match.
+    std::uint32_t matchBeforeCreateMaxEdges = 2;
+    /// Layers whose nodes are cut against the z0 histogram of their outer
+    /// neighbourhood, and whose isolated nodes are skipped.
+    std::vector<std::uint32_t> z0HistogramLayerIds{80000};
+    /// Layers `matchBeforeCreate` applies to, when it is enabled.
+    std::vector<std::uint32_t> matchBeforeCreateLayerIds{80000, 81000};
+    /// Half-width of the z0 window a node is matched against in the histogram.
+    float z0Resolution = 2.5f * UnitConstants::mm;
     /// Maximum radius of pixel detector
     float maxOuterRadius = 550.0f;
 
     /// Resolve a doublet's strip endpoints against its own direction before
     /// cutting on them. Nothing is written back; the correction is the pair's.
     bool calibrateStrips = true;
-    /// How far outside its strips a crossing may still be recovered, as a
-    /// multiple of the strip half-length.
-    float stripLengthTolerance = 1.1f;
+    /// How far along a strip a crossing may land and still be recovered, as a
+    /// multiple of the strip half-length, so 1 is the strip itself. The same
+    /// quantity as `TripletSeedFinder::Config::toleranceParam`.
+    float maxStripLengthFraction = 1.1f;
 
     // Seed extraction options
+    /// Maximum number of connected-component iterations.
+    std::uint32_t ccaMaxIterations = 15;
+    /// Chain length a seed candidate must reach: a triplet plus one
+    /// confirmation.
+    std::uint32_t minSeedLevel = 3;
+    /// Chain length required in large radius tracking mode.
+    std::uint32_t lrtMinSeedLevel = 2;
+    /// Smallest seed size that is split into drop-out candidates.
+    std::uint32_t minSplitSeedSize = 4;
+    /// Largest seed size that is split.
+    std::uint32_t maxSplitSeedSize = 5;
     /// Minimum eta for edge masking.
     float edgeMaskMinEta = 1.5;
     /// Threshold for hit sharing between seeds.
@@ -141,6 +194,14 @@ class GraphBasedTrackSeeder {
     /// Distance to the module edge below which a cluster may be shortened,
     /// which switches to the tau lookup table's near-edge bounds.
     float moduleEdgeTolerance = 0.3 * Acts::UnitConstants::mm;
+    /// Cluster width covered by one bin of the tau lookup table.
+    float tauLutBinWidth = 0.05 * Acts::UnitConstants::mm;
+    /// Multiples of the phi slice width duplicated either side of the
+    /// wrap-around, so a sliding window never has to wrap.
+    float phiIndexMargin = 1.5f;
+    /// Buckets used to sort an eta bin by phi, at most
+    /// `GbtsNodeStorage::kMaxPhiSortBuckets`.
+    std::uint32_t phiSortBuckets = 31;
   };
 
   /// Derived configuration struct that contains calculated parameters based on
@@ -319,10 +380,9 @@ class GraphBasedTrackSeeder {
   /// beamspot
   /// @param z0BitMask Sets allowed bins of allowed z value
   /// @param z0 Estimated z0 of segments z value at beamspot
-  /// @param minZ0 Minimum value of beam spot z coordinate
   /// @param z0HistoCoeff Scalfactor that converts z coodindate into bin index
   /// @return Whether segment is within beamspot range
-  bool checkZ0BitMask(std::uint16_t z0BitMask, float z0, float minZ0,
+  bool checkZ0BitMask(std::uint16_t z0BitMask, float z0,
                       float z0HistoCoeff) const;
 
   /// Estimate the inverse radius of the circle through three nodes.

--- a/Core/include/Acts/Seeding/GraphBasedTrackSeeder.hpp
+++ b/Core/include/Acts/Seeding/GraphBasedTrackSeeder.hpp
@@ -45,14 +45,21 @@ class GraphBasedTrackSeeder {
     /// Look-up table input file path.
     std::string lutInputFile;
 
-    /// Enable Large Radius Tracking mode.
-    bool lrtMode = false;
+    /// Take the strip-to-strip layer connections from the connector file
+    /// instead of the pixel-to-pixel ones. Read where the file is loaded, not
+    /// by the seeder itself.
+    bool useStripConnections = false;
     /// Enable the cluster width cuts: wide endcap rejection and tau narrowing.
     bool useClusterWidthCuts = false;
     /// Match seeds before creating them.
     bool matchBeforeCreate = false;
-    /// Use legacy tuning parameters.
-    bool useOldTunings = false;
+    /// Bound the curvature by the pT the triplet has to reach in the actual
+    /// field, times `oldTuningsCurvature*Fraction`, instead of the tuned
+    /// `maxCurvature*Eta` constants.
+    bool useOldTuningsCurvature = false;
+    /// Open the phi window as `minDeltaPhi` plus a fraction of that same
+    /// curvature bound, instead of the two-slope `phiWindow*` model.
+    bool useOldTuningsPhiWindow = false;
     /// optional validation for barrel triplets
     bool validateTriplets = true;
     /// widens allowed variation in tau ratio
@@ -112,7 +119,7 @@ class GraphBasedTrackSeeder {
     float minZ0 = -600;
     /// Maximum z0 value. In pixel mode the value is picked from the RoI.
     float maxZ0 = 600;
-    /// When old tunings are used, this defines the minimum phi window used
+    /// Offset of the phi window under `useOldTuningsPhiWindow`.
     float minDeltaPhi = 0.001f;
 
     /// pT the default cut coefficients were tuned at; they scale by
@@ -124,13 +131,14 @@ class GraphBasedTrackSeeder {
     float maxCurvatureLowEta = 3.75e-4f / UnitConstants::mm;
     /// |cot(theta)| separating the two curvature cuts, |eta| of about 2.1.
     float curvatureSplitAbsTau = 4.0f;
-    /// Squared fraction of the maximum curvature the old tunings cut at above
-    /// `curvatureSplitAbsTau`.
+    /// Squared fraction of the pT-derived curvature bound cut at above
+    /// `curvatureSplitAbsTau`, under `useOldTuningsCurvature`. Large radius
+    /// tracking cuts at the bound itself, so 1.
     float oldTuningsCurvatureHighEtaFraction = 0.8f;
     /// Squared fraction of the same below `curvatureSplitAbsTau`.
     float oldTuningsCurvatureLowEtaFraction = 0.6f;
-    /// Fraction of the maximum curvature the old tunings open the phi window
-    /// by, per unit of radial separation.
+    /// Fraction of the same the phi window opens by, per unit of radial
+    /// separation, under `useOldTuningsPhiWindow`.
     float oldTuningsPhiWindowFraction = 0.68f;
     /// Radial separation splitting the two phi window slopes below.
     float phiWindowSplitDeltaRadius = 60.0f * UnitConstants::mm;
@@ -169,10 +177,8 @@ class GraphBasedTrackSeeder {
     /// Maximum number of connected-component iterations.
     std::uint32_t ccaMaxIterations = 15;
     /// Chain length a seed candidate must reach: a triplet plus one
-    /// confirmation.
+    /// confirmation. Large radius tracking asks for the triplet alone, so 2.
     std::uint32_t minSeedLevel = 3;
-    /// Chain length required in large radius tracking mode.
-    std::uint32_t lrtMinSeedLevel = 2;
     /// Smallest seed size that is split into drop-out candidates.
     std::uint32_t minSplitSeedSize = 4;
     /// Largest seed size that is split.

--- a/Core/include/Acts/Seeding/detail/GbtsFilterTypes.hpp
+++ b/Core/include/Acts/Seeding/detail/GbtsFilterTypes.hpp
@@ -28,7 +28,11 @@ struct GbtsEdgeState final {
   /// Initialize from edge
   /// @param pS Edge to initialize from
   /// @param nodeView View of the node positions and layers
-  void initialize(const GbtsEdge& pS, const GbtsNodeView& nodeView);
+  /// @param varianceX Initial variance of the transverse state
+  /// @param varianceY Initial variance of the longitudinal state
+  void initialize(const GbtsEdge& pS, const GbtsNodeView& nodeView,
+                  const std::array<float, 3>& varianceX,
+                  const std::array<float, 2>& varianceY);
 
   bool initialized{false};
 

--- a/Core/include/Acts/Seeding/detail/GbtsGraphTypes.hpp
+++ b/Core/include/Acts/Seeding/detail/GbtsGraphTypes.hpp
@@ -43,6 +43,8 @@ static constexpr std::uint32_t kGbtsMaxEdgeNeighbours = 6;
 /// Bins of the per-node z0 histogram, which is kept as a bit mask in
 /// GbtsNodeEdgeInfo::isConnected and so may not exceed its width.
 static constexpr std::int32_t kGbtsZ0HistogramBins = 16;
+static_assert(kGbtsZ0HistogramBins <=
+              std::numeric_limits<std::uint16_t>::digits);
 
 //! [gbts node params]
 /// Per-node parameters used while building the graph.

--- a/Core/src/Seeding/GbtsGeometry.cpp
+++ b/Core/src/Seeding/GbtsGeometry.cpp
@@ -323,11 +323,11 @@ using BinConnections =
 
 GbtsGeometry::GbtsGeometry(
     const std::vector<GbtsLayerDescription>& layerDescriptions,
-    const GbtsLayerConnectionMap& layerConnections, const Logger& logger)
+    const GbtsLayerConnectionMap& layerConnections, const GbtsZ0Range& z0Range,
+    const Logger& logger)
     : m_etaBinWidth(layerConnections.etaBinWidth) {
-  // TODO configurable z0 range
-  const float minZ0 = -168.0f;
-  const float maxZ0 = 168.0f;
+  const float minZ0 = z0Range.min;
+  const float maxZ0 = z0Range.max;
 
   for (const GbtsLayerDescription& layer : layerDescriptions) {
     const detail::GbtsLayer& pL = createLayer(layer, m_nEtaBins);

--- a/Core/src/Seeding/GbtsLayerConnection.cpp
+++ b/Core/src/Seeding/GbtsLayerConnection.cpp
@@ -20,7 +20,7 @@
 namespace Acts::Experimental {
 
 GbtsLayerConnectionMap GbtsLayerConnectionMap::fromStream(
-    std::istream& inStream, bool lrtMode) {
+    std::istream& inStream, bool stripConnections) {
   GbtsLayerConnectionMap connectionMap;
 
   std::uint32_t nLinks{};
@@ -53,7 +53,7 @@ GbtsLayerConnectionMap GbtsLayerConnectionMap::fromStream(
 
     bool srcIsStrip = (srcvol_id == 13 || srcvol_id == 12 || srcvol_id == 14);
     bool dstIsStrip = (dstvol_id == 13 || dstvol_id == 12 || dstvol_id == 14);
-    if (lrtMode) {
+    if (stripConnections) {
       if (!srcIsStrip || !dstIsStrip) {
         continue;
       }
@@ -189,9 +189,9 @@ GbtsLayerConnectionMap GbtsLayerConnectionMap::fromStream(
 }
 
 GbtsLayerConnectionMap GbtsLayerConnectionMap::fromFile(std::string& inFile,
-                                                        bool lrtMode) {
+                                                        bool stripConnections) {
   std::ifstream inputStream(inFile.c_str());
-  return fromStream(inputStream, lrtMode);
+  return fromStream(inputStream, stripConnections);
 }
 
 }  // namespace Acts::Experimental

--- a/Core/src/Seeding/GbtsNodeStorage.cpp
+++ b/Core/src/Seeding/GbtsNodeStorage.cpp
@@ -98,9 +98,10 @@ void GbtsNodeStorage::extend(
 
 std::vector<std::uint32_t> GbtsNodeStorage::sortBinByPhi(
     const std::vector<std::uint32_t>& staged) const {
-  // TODO config
-  constexpr std::uint32_t nBuckets = 31;
-  std::array<std::vector<std::pair<float, std::uint32_t>>, 32> phiBuckets;
+  const std::uint32_t nBuckets = m_cfg.phiSortBuckets;
+  std::array<std::vector<std::pair<float, std::uint32_t>>,
+             kMaxPhiSortBuckets + 1>
+      phiBuckets;
 
   for (const std::uint32_t stagedIdx : staged) {
     const float phi = m_staged[stagedIdx].phi;
@@ -110,14 +111,14 @@ std::vector<std::uint32_t> GbtsNodeStorage::sortBinByPhi(
   }
 
   // Nodes with identical phi are ordered by insertion index.
-  for (auto& bucket : phiBuckets) {
-    std::ranges::sort(bucket);
+  for (std::uint32_t bucket = 0; bucket <= nBuckets; ++bucket) {
+    std::ranges::sort(phiBuckets[bucket]);
   }
 
   std::vector<std::uint32_t> sorted;
   sorted.reserve(staged.size());
-  for (const auto& bucket : phiBuckets) {
-    for (const auto& [phi, stagedIdx] : bucket) {
+  for (std::uint32_t bucket = 0; bucket <= nBuckets; ++bucket) {
+    for (const auto& [phi, stagedIdx] : phiBuckets[bucket]) {
       sorted.push_back(stagedIdx);
     }
   }
@@ -212,7 +213,7 @@ void GbtsNodeStorage::finalize() {
 
   m_strips = std::move(strips);
 
-  generatePhiIndexing(1.5f * m_cfg.phiSliceWidth);
+  generatePhiIndexing(m_cfg.phiIndexMargin * m_cfg.phiSliceWidth);
 
   m_staged.clear();
   m_staged.shrink_to_fit();
@@ -231,9 +232,12 @@ void GbtsNodeStorage::applyTauCuts(const StagedNode& staged,
     return;
   }
 
-  // lut bin width is 0.05 mm
+  // by the reciprocal, not the division: 1/0.05f is exactly 20, the division
+  // is not, and the difference lands on the bin edges
   const auto lutBinIdx =
-      static_cast<std::int32_t>(std::floor(20 * staged.clusterWidth)) - 1;
+      static_cast<std::int32_t>(
+          std::floor(staged.clusterWidth * (1.0f / m_cfg.tauLutBinWidth))) -
+      1;
 
   if (lutBinIdx < 0 ||
       lutBinIdx >= static_cast<std::int32_t>(m_tauLut.size())) {

--- a/Core/src/Seeding/GbtsTrackingFilter.cpp
+++ b/Core/src/Seeding/GbtsTrackingFilter.cpp
@@ -21,7 +21,9 @@
 namespace Acts::Experimental::detail {
 
 void detail::GbtsEdgeState::initialize(const detail::GbtsEdge& pS,
-                                       const detail::GbtsNodeView& nodeView) {
+                                       const detail::GbtsNodeView& nodeView,
+                                       const std::array<float, 3>& varianceX,
+                                       const std::array<float, 2>& varianceY) {
   initialized = true;
 
   j = 0;
@@ -58,13 +60,13 @@ void detail::GbtsEdgeState::initialize(const detail::GbtsEdge& pS,
   y[1] = (n1.z() - n2.z()) / (n1.r() - n2.r());
 
   cx = {};
-  cx[0][0] = 0.25f;
-  cx[1][1] = 0.001f;
-  cx[2][2] = 0.001f;
+  cx[0][0] = varianceX[0];
+  cx[1][1] = varianceX[1];
+  cx[2][2] = varianceX[2];
 
   cy = {};
-  cy[0][0] = 1.5f;
-  cy[1][1] = 0.001f;
+  cy[0][0] = varianceY[0];
+  cy[1][1] = varianceY[1];
 }
 
 }  // namespace Acts::Experimental::detail
@@ -92,7 +94,8 @@ detail::GbtsEdgeState GbtsTrackingFilter::followTrack(
       state.stateStore[state.globalStateCounter];
   ++state.globalStateCounter;
 
-  pInitState.initialize(pS, nodeView);
+  pInitState.initialize(pS, nodeView, m_cfg.initialVarianceX,
+                        m_cfg.initialVarianceY);
 
   state.stateVec.clear();
 

--- a/Core/src/Seeding/GraphBasedTrackSeeder.cpp
+++ b/Core/src/Seeding/GraphBasedTrackSeeder.cpp
@@ -48,6 +48,11 @@ GraphBasedTrackSeeder::GraphBasedTrackSeeder(
         "GraphBasedTrackSeeder: tauRatioCorr must not be negative");
   }
 
+  if (m_cfg.phiSortBuckets > GbtsNodeStorage::kMaxPhiSortBuckets) {
+    throw std::invalid_argument(
+        "GraphBasedTrackSeeder: phiSortBuckets exceeds the maximum");
+  }
+
   m_tauLut = parseTauLookupTable(m_cfg.lutInputFile);
 }
 
@@ -58,6 +63,9 @@ GbtsNodeStorage GraphBasedTrackSeeder::makeNodeStorage() const {
   config.moduleHalfLengthY = m_cfg.moduleHalfLengthY;
   config.moduleEdgeTolerance = m_cfg.moduleEdgeTolerance;
   config.phiSliceWidth = m_cfg.phiSliceWidth;
+  config.phiIndexMargin = m_cfg.phiIndexMargin;
+  config.phiSortBuckets = m_cfg.phiSortBuckets;
+  config.tauLutBinWidth = m_cfg.tauLutBinWidth;
 
   return GbtsNodeStorage(config, m_geometry, m_tauLut);
 }
@@ -164,26 +172,29 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
   const float cutZMaxU =
       m_cfg.maxZ0 + m_cfg.maxOuterRadius * static_cast<float>(roi.dzdrMax());
 
-  // correction due to limited pT resolution
-  const float tripletPtMin = 0.8f * m_cfg.minPt;
+  const float tripletPtMin = m_cfg.tripletPtFraction * m_cfg.minPt;
 
-  // to re-scale original tunings done for the 900 MeV pT cut
-  const float ptScale = 0.9f / m_cfg.minPt;
+  const float ptScale = m_cfg.tuningPt / m_cfg.minPt;
 
   const float maxCurv = options.ptCoeff / tripletPtMin;
 
-  float maxKappaHighEta =
-      m_cfg.lrtMode ? 1.0f * maxCurv : std::sqrt(0.8f) * maxCurv;
-  float maxKappaLowEta =
-      m_cfg.lrtMode ? 1.0f * maxCurv : std::sqrt(0.6f) * maxCurv;
+  float curvatureCutHighEta =
+      m_cfg.lrtMode
+          ? maxCurv
+          : std::sqrt(m_cfg.oldTuningsCurvatureHighEtaFraction) * maxCurv;
+  float curvatureCutLowEta =
+      m_cfg.lrtMode
+          ? maxCurv
+          : std::sqrt(m_cfg.oldTuningsCurvatureLowEtaFraction) * maxCurv;
 
   // new settings for curvature cuts
   if (!m_cfg.useOldTunings && !m_cfg.lrtMode) {
-    maxKappaHighEta = 4.75e-4f * ptScale;
-    maxKappaLowEta = 3.75e-4f * ptScale;
+    curvatureCutHighEta = m_cfg.maxCurvatureHighEta * ptScale;
+    curvatureCutLowEta = m_cfg.maxCurvatureLowEta * ptScale;
   }
 
-  const float dPhiCoeff = m_cfg.lrtMode ? 1.0f * maxCurv : 0.68f * maxCurv;
+  const float dPhiCoeff =
+      m_cfg.lrtMode ? maxCurv : m_cfg.oldTuningsPhiWindowFraction * maxCurv;
 
   // the loosest tau ratio threshold the triplet matching can apply
   const float maxTauRatioCut =
@@ -223,7 +234,7 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
     std::array<float, 3> point{};
     if (!Acts::detail::calibrateOuterStripSpacePoint(
             direction, nodeStorage.strip(node), point,
-            m_cfg.stripLengthTolerance)) {
+            m_cfg.maxStripLengthFraction)) {
       return false;
     }
     r = fastHypot(point[0], point[1]);
@@ -249,6 +260,13 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
     // (layerId / 10000) == 8 selects: its strip barrel is numbered 13xxx.
     const bool isPixelBarrel1 = isPixel1 && B1.type == GbtsLayerType::Barrel;
 
+    const auto listed = [layerId1](const std::vector<std::uint32_t>& ids) {
+      return std::ranges::find(ids, layerId1) != ids.end();
+    };
+    const bool useZ0Histogram = listed(m_cfg.z0HistogramLayerIds);
+    const bool useMatchBeforeCreate =
+        m_cfg.matchBeforeCreate && listed(m_cfg.matchBeforeCreateLayerIds);
+
     // prepare a sliding window for each non-empty bin2 in the group
 
     phiSlidingWindow.clear();
@@ -270,12 +288,12 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
         const float absDr = std::fabs(rb2 - rb1);
         if (m_cfg.useOldTunings) {
           deltaPhi = m_cfg.minDeltaPhi + dPhiCoeff * absDr;
+        } else if (absDr < m_cfg.phiWindowSplitDeltaRadius) {
+          deltaPhi = m_cfg.phiWindowNearOffset +
+                     m_cfg.phiWindowNearSlope * ptScale * absDr;
         } else {
-          if (absDr < 60.0) {
-            deltaPhi = 0.002f + 4.33e-4f * ptScale * absDr;
-          } else {
-            deltaPhi = 0.015f + 2.2e-4f * ptScale * absDr;
-          }
+          deltaPhi = m_cfg.phiWindowFarOffset +
+                     m_cfg.phiWindowFarSlope * ptScale * absDr;
         }
       }
 
@@ -355,7 +373,7 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
           const std::uint16_t nodeInfo = n2Info.isConnected;
 
           // skip isolated nodes as their incoming edges lead to nowhere
-          if ((layerId1 == 80000) && (nodeInfo == 0)) {
+          if (useZ0Histogram && (nodeInfo == 0)) {
             continue;
           }
 
@@ -437,8 +455,8 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
 
           const float z0 = z1c - r1c * tau;
 
-          if (layerId1 == 80000) {  // check against non-empty z0 histogram
-            if (!checkZ0BitMask(nodeInfo, z0, m_cfg.minZ0, z0HistoCoeff)) {
+          if (useZ0Histogram) {  // check against non-empty z0 histogram
+            if (!checkZ0BitMask(nodeInfo, z0, z0HistoCoeff)) {
               continue;
             }
           }
@@ -458,14 +476,10 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
           const float curv = (phi2 - phi1) / dr;
           const float absCurv = std::abs(curv);
 
-          if (ftau < 4.0f) {  // eta = 2.1
-            if (absCurv > maxKappaLowEta) {
-              continue;
-            }
-          } else {
-            if (absCurv > maxKappaHighEta) {
-              continue;
-            }
+          if (absCurv > (ftau < m_cfg.curvatureSplitAbsTau
+                             ? curvatureCutLowEta
+                             : curvatureCutHighEta)) {
+            continue;
           }
 
           const float hypotTau = fastHypot(1, tau);
@@ -475,10 +489,9 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
           const float invExpEta = hypotTau + tau;
 
           // match edge candidate against edges incoming to n2
-          if (m_cfg.matchBeforeCreate &&
-              (layerId1 == 80000 || layerId1 == 81000)) {
+          if (useMatchBeforeCreate) {
             // we must have enough incoming edges to decide
-            bool isGood = n2NumEdges <= 2;
+            bool isGood = n2NumEdges <= m_cfg.matchBeforeCreateMaxEdges;
 
             if (!isGood) {
               const float uat1 = invExpEta;
@@ -656,8 +669,6 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
 std::int32_t GraphBasedTrackSeeder::runCCA(
     const std::uint32_t nEdges,
     std::vector<detail::GbtsEdge>& edgeStorage) const {
-  constexpr std::uint32_t maxIter = 15;
-
   std::int32_t maxLevel = 0;
 
   std::uint32_t iter = 0;
@@ -679,7 +690,7 @@ std::int32_t GraphBasedTrackSeeder::runCCA(
   vNew.reserve(vOld.size());
 
   // generate proposals
-  for (; iter < maxIter; iter++) {
+  for (; iter < m_cfg.ccaMaxIterations; iter++) {
     vNew.clear();
 
     for (detail::GbtsEdge* pS : vOld) {
@@ -733,13 +744,8 @@ void GraphBasedTrackSeeder::extractSeedsFromTheGraph(
     std::vector<OutputSeedProperties>& vOutputSeeds,
     const GbtsTrackingFilter& filter) const {
   const detail::GbtsNodeView nodeView = nodeStorage.nodeView();
-  // a triplet + 1 confirmation
-  std::uint8_t minLevel = 3;
-
-  if (m_cfg.lrtMode) {
-    // a triplet + no confirmation
-    minLevel = 2;
-  }
+  const auto minLevel = static_cast<std::uint8_t>(
+      m_cfg.lrtMode ? m_cfg.lrtMinSeedLevel : m_cfg.minSeedLevel);
 
   if (maxLevel < minLevel) {
     return;
@@ -759,7 +765,7 @@ void GraphBasedTrackSeeder::extractSeedsFromTheGraph(
     } else {  // eta-dependent cut
       const float edgeAbsEta = std::abs(-std::log(pS->p[0]));
 
-      if (edgeAbsEta > m_cfg.maxAbsEtaAddTripelts) {
+      if (edgeAbsEta > m_cfg.maxAbsEtaAddTriplets) {
         if (pS->level < minLevel) {
           continue;
         }
@@ -815,7 +821,7 @@ void GraphBasedTrackSeeder::extractSeedsFromTheGraph(
         continue;
       }
     } else {
-      if (seedAbsEta > m_cfg.maxAbsEtaAddTripelts) {
+      if (seedAbsEta > m_cfg.maxAbsEtaAddTriplets) {
         if (chainLength < minLevel) {
           continue;
         }
@@ -850,11 +856,12 @@ void GraphBasedTrackSeeder::extractSeedsFromTheGraph(
 
     const float origSeedQuality = -rs.j / origSeedSize;
 
-    std::uint32_t seedSplitFlag = (seedAbsEta < m_cfg.maxSeedSplitEta) &&
-                                          (origSeedSize > 3) &&
-                                          (origSeedSize <= 5)
-                                      ? 1
-                                      : 0;
+    std::uint32_t seedSplitFlag =
+        (seedAbsEta < m_cfg.maxSeedSplitEta) &&
+                (origSeedSize >= m_cfg.minSplitSeedSize) &&
+                (origSeedSize <= m_cfg.maxSplitSeedSize)
+            ? 1
+            : 0;
 
     // split the seed by dropping spacepoints
     if (seedSplitFlag != 0) {
@@ -1022,7 +1029,7 @@ void GraphBasedTrackSeeder::extractSeedsFromTheGraph(
 }
 
 bool GraphBasedTrackSeeder::checkZ0BitMask(const std::uint16_t z0BitMask,
-                                           const float z0, const float minZ0,
+                                           const float z0,
                                            const float z0HistoCoeff) const {
   if (z0BitMask == 0) {
     return true;
@@ -1035,7 +1042,7 @@ bool GraphBasedTrackSeeder::checkZ0BitMask(const std::uint16_t z0BitMask,
            ((z0BitMask >> bin) & 1) != 0;
   };
 
-  const float dz = z0 - minZ0;
+  const float dz = z0 - m_cfg.minZ0;
   const std::int32_t z0BinIndex = static_cast<std::int32_t>(z0HistoCoeff * dz);
 
   if (isSet(z0BinIndex)) {
@@ -1044,9 +1051,7 @@ bool GraphBasedTrackSeeder::checkZ0BitMask(const std::uint16_t z0BitMask,
 
   // check adjacent bins as well
 
-  const float z0Resolution = 2.5;
-
-  const float dzm = dz - z0Resolution;
+  const float dzm = dz - m_cfg.z0Resolution;
 
   std::int32_t nextBin = static_cast<std::int32_t>(z0HistoCoeff * dzm);
 
@@ -1054,7 +1059,7 @@ bool GraphBasedTrackSeeder::checkZ0BitMask(const std::uint16_t z0BitMask,
     return true;
   }
 
-  const float dzp = dz + z0Resolution;
+  const float dzp = dz + m_cfg.z0Resolution;
 
   nextBin = static_cast<std::int32_t>(z0HistoCoeff * dzp);
 

--- a/Core/src/Seeding/GraphBasedTrackSeeder.cpp
+++ b/Core/src/Seeding/GraphBasedTrackSeeder.cpp
@@ -178,23 +178,16 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
 
   const float maxCurv = options.ptCoeff / tripletPtMin;
 
-  float curvatureCutHighEta =
-      m_cfg.lrtMode
-          ? maxCurv
-          : std::sqrt(m_cfg.oldTuningsCurvatureHighEtaFraction) * maxCurv;
-  float curvatureCutLowEta =
-      m_cfg.lrtMode
-          ? maxCurv
-          : std::sqrt(m_cfg.oldTuningsCurvatureLowEtaFraction) * maxCurv;
+  const float curvatureCutHighEta =
+      m_cfg.useOldTuningsCurvature
+          ? std::sqrt(m_cfg.oldTuningsCurvatureHighEtaFraction) * maxCurv
+          : m_cfg.maxCurvatureHighEta * ptScale;
+  const float curvatureCutLowEta =
+      m_cfg.useOldTuningsCurvature
+          ? std::sqrt(m_cfg.oldTuningsCurvatureLowEtaFraction) * maxCurv
+          : m_cfg.maxCurvatureLowEta * ptScale;
 
-  // new settings for curvature cuts
-  if (!m_cfg.useOldTunings && !m_cfg.lrtMode) {
-    curvatureCutHighEta = m_cfg.maxCurvatureHighEta * ptScale;
-    curvatureCutLowEta = m_cfg.maxCurvatureLowEta * ptScale;
-  }
-
-  const float dPhiCoeff =
-      m_cfg.lrtMode ? maxCurv : m_cfg.oldTuningsPhiWindowFraction * maxCurv;
+  const float dPhiCoeff = m_cfg.oldTuningsPhiWindowFraction * maxCurv;
 
   // the loosest tau ratio threshold the triplet matching can apply
   const float maxTauRatioCut =
@@ -286,7 +279,7 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
       // override the default window width
       if (m_cfg.useEtaBinning) {
         const float absDr = std::fabs(rb2 - rb1);
-        if (m_cfg.useOldTunings) {
+        if (m_cfg.useOldTuningsPhiWindow) {
           deltaPhi = m_cfg.minDeltaPhi + dPhiCoeff * absDr;
         } else if (absDr < m_cfg.phiWindowSplitDeltaRadius) {
           deltaPhi = m_cfg.phiWindowNearOffset +
@@ -744,8 +737,7 @@ void GraphBasedTrackSeeder::extractSeedsFromTheGraph(
     std::vector<OutputSeedProperties>& vOutputSeeds,
     const GbtsTrackingFilter& filter) const {
   const detail::GbtsNodeView nodeView = nodeStorage.nodeView();
-  const auto minLevel = static_cast<std::uint8_t>(
-      m_cfg.lrtMode ? m_cfg.lrtMinSeedLevel : m_cfg.minSeedLevel);
+  const auto minLevel = static_cast<std::uint8_t>(m_cfg.minSeedLevel);
 
   if (maxLevel < minLevel) {
     return;
@@ -758,7 +750,7 @@ void GraphBasedTrackSeeder::extractSeedsFromTheGraph(
   for (std::uint32_t edgeIndex = 0; edgeIndex < nEdges; ++edgeIndex) {
     detail::GbtsEdge* pS = &edgeStorage[edgeIndex];
 
-    if (m_cfg.lrtMode || !m_cfg.addTriplets) {
+    if (!m_cfg.addTriplets) {
       if (pS->level < minLevel) {
         continue;
       }
@@ -816,7 +808,7 @@ void GraphBasedTrackSeeder::extractSeedsFromTheGraph(
 
     const std::uint32_t chainLength = static_cast<std::uint32_t>(rs.vs.size());
 
-    if (m_cfg.lrtMode || !m_cfg.addTriplets) {
+    if (!m_cfg.addTriplets) {
       if (chainLength < minLevel) {
         continue;
       }

--- a/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/GraphBasedSeedingAlgorithm.hpp
+++ b/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/GraphBasedSeedingAlgorithm.hpp
@@ -59,6 +59,9 @@ class GraphBasedSeedingAlgorithm final : public IAlgorithm {
     /// be GBTS
     std::string layerMappingFile;
 
+    /// z0 range the eta bin table is built against
+    Acts::Experimental::GbtsZ0Range gbtsZ0Range;
+
     /// holds detector information, used to make the geometry objects used by
     /// GBTS
     std::shared_ptr<const Acts::TrackingGeometry> trackingGeometry;

--- a/Examples/Algorithms/TrackFinding/src/GraphBasedSeedingAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFinding/src/GraphBasedSeedingAlgorithm.cpp
@@ -41,7 +41,7 @@ GraphBasedSeedingAlgorithm::GraphBasedSeedingAlgorithm(
   Acts::Experimental::GbtsLayerConnectionMap layerConnectionMap =
       Acts::Experimental::GbtsLayerConnectionMap::fromFile(
           m_cfg.seedFinderConfig.connectorInputFile,
-          m_cfg.seedFinderConfig.lrtMode);
+          m_cfg.seedFinderConfig.useStripConnections);
 
   // create the TrigInDetSiLayers (Logical Layers),
   // as well as a map that tracks there index in m_layerGeometry
@@ -385,10 +385,11 @@ void GraphBasedSeedingAlgorithm::printConfig() const {
   ACTS_DEBUG("BeamSpotCorrection: " << cfg1.beamSpotCorrection);
   ACTS_DEBUG("connectorInputFile: " << cfg1.connectorInputFile);
   ACTS_DEBUG("lutInputFile: " << cfg1.lutInputFile);
-  ACTS_DEBUG("lrtMode: " << cfg1.lrtMode);
+  ACTS_DEBUG("useStripConnections: " << cfg1.useStripConnections);
   ACTS_DEBUG("useClusterWidthCuts: " << cfg1.useClusterWidthCuts);
   ACTS_DEBUG("matchBeforeCreate: " << cfg1.matchBeforeCreate);
-  ACTS_DEBUG("useOldTunings: " << cfg1.useOldTunings);
+  ACTS_DEBUG("useOldTuningsCurvature: " << cfg1.useOldTuningsCurvature);
+  ACTS_DEBUG("useOldTuningsPhiWindow: " << cfg1.useOldTuningsPhiWindow);
   ACTS_DEBUG("tauRatioCut: " << cfg1.tauRatioCut);
   ACTS_DEBUG("tauRatioPrecut: " << cfg1.tauRatioPrecut);
   ACTS_DEBUG("etaBinWidthOverride: " << cfg1.etaBinWidthOverride);

--- a/Examples/Algorithms/TrackFinding/src/GraphBasedSeedingAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFinding/src/GraphBasedSeedingAlgorithm.cpp
@@ -56,7 +56,7 @@ GraphBasedSeedingAlgorithm::GraphBasedSeedingAlgorithm(
   // initialise the object that holds all the geometry information needed for
   // the algorithm
   auto geometry = std::make_shared<Acts::Experimental::GbtsGeometry>(
-      layerGeometry, layerConnectionMap, this->logger());
+      layerGeometry, layerConnectionMap, m_cfg.gbtsZ0Range, this->logger());
 
   // ROI file:Defines what region in detector we are interested in, currently
   // set to entire detector
@@ -405,7 +405,7 @@ void GraphBasedSeedingAlgorithm::printConfig() const {
   ACTS_DEBUG("useAdaptiveCuts: " << cfg1.useAdaptiveCuts);
   ACTS_DEBUG("addTriplets: " << cfg1.addTriplets);
   ACTS_DEBUG("tauRatioCorr: " << cfg1.tauRatioCorr);
-  ACTS_DEBUG("maxAbsEtaAddTripelts: " << cfg1.maxAbsEtaAddTripelts);
+  ACTS_DEBUG("maxAbsEtaAddTriplets: " << cfg1.maxAbsEtaAddTriplets);
   ACTS_DEBUG("d0Max: " << cfg1.d0Max);
   ACTS_DEBUG("cutDPhiMax: " << cfg1.cutDPhiMax);
   ACTS_DEBUG("cutDCurvMax: " << cfg1.cutDCurvMax);

--- a/docs/groups/pattern_recog/gbts.md
+++ b/docs/groups/pattern_recog/gbts.md
@@ -222,9 +222,11 @@ The main knobs on @ref Acts::Experimental::GraphBasedTrackSeeder "GraphBasedTrac
 | Option | Stage | Effect |
 | --- | --- | --- |
 | `connectorInputFile` | @ref gbts-geometry | layer connection table; defines which layer pairs may form edges |
+| `useStripConnections` | @ref gbts-geometry | take the strip layer connections from the connector file instead of the pixel ones |
 | `etaBinWidthOverride` | @ref gbts-geometry | override the eta bin width from the connector file (default 0.2) |
 | `minPt` | @ref gbts-graph | drives the curvature and @f$\phi@f$-window bounds |
 | `nMaxPhiSlice` | @ref gbts-graph | sets the base @f$\phi@f$ sliding-window width |
+| `useOldTuningsCurvature`, `useOldTuningsPhiWindow` | @ref gbts-graph | bound the curvature and the @f$\phi@f$ window by the pT the triplet has to reach, rather than by the tuned constants |
 | `minDeltaRadius`, `maxAbsTau` | @ref gbts-graph | doublet acceptance |
 | `minZ0`, `maxZ0`, `doubletFilterRZ` | @ref gbts-graph | luminous-region cuts on the doublet |
 | `tauRatioCut`, `cutDPhiMax`, `cutDCurvMax` | @ref gbts-graph | edge-to-edge linking tolerances |
@@ -237,7 +239,10 @@ The main knobs on @ref Acts::Experimental::GraphBasedTrackSeeder "GraphBasedTrac
 | `addTriplets`, `maxAbsEtaAddTriplets` | @ref gbts-extraction | allow shorter chains within an @f$\eta@f$ range |
 | `useClusterWidthCuts`, `lutInputFile` | @ref gbts-ml | cluster-width based @f$\tau@f$ windows |
 | `maxEndcapClusterWidth`, `moduleHalfLengthY`, `moduleEdgeTolerance` | @ref gbts-ml | cluster-width acceptance and module-edge handling |
-| `lrtMode` | all | Large Radius Tracking: strip layers instead of pixel, looser cuts, shorter minimum chain |
+
+There is no large radius tracking mode. LRT is these options set to the values
+it needs: `useStripConnections`, `useOldTuningsCurvature` with both
+`oldTuningsCurvature*Fraction` at 1, and `minSeedLevel = 2`.
 
 @ref Acts::Experimental::GbtsTrackingFilter "GbtsTrackingFilter::Config"
 separately controls the chain-following filter of @ref gbts-extraction "seed extraction":

--- a/docs/groups/pattern_recog/gbts.md
+++ b/docs/groups/pattern_recog/gbts.md
@@ -234,7 +234,7 @@ The main knobs on @ref Acts::Experimental::GraphBasedTrackSeeder "GraphBasedTrac
 | `matchBeforeCreate`, `tauRatioPrecut` | @ref gbts-graph | require a compatible incoming edge before creating one |
 | `hitShareThreshold` | @ref gbts-extraction | fraction of shared hits above which a candidate is a clone |
 | `maxSeedSplitEta`, `maxInvRadDiff` | @ref gbts-extraction | seed splitting |
-| `addTriplets`, `maxAbsEtaAddTripelts` | @ref gbts-extraction | allow shorter chains within an @f$\eta@f$ range |
+| `addTriplets`, `maxAbsEtaAddTriplets` | @ref gbts-extraction | allow shorter chains within an @f$\eta@f$ range |
 | `useClusterWidthCuts`, `lutInputFile` | @ref gbts-ml | cluster-width based @f$\tau@f$ windows |
 | `maxEndcapClusterWidth`, `moduleHalfLengthY`, `moduleEdgeTolerance` | @ref gbts-ml | cluster-width acceptance and module-edge handling |
 | `lrtMode` | all | Large Radius Tracking: strip layers instead of pixel, looser cuts, shorter minimum chain |


### PR DESCRIPTION
Roughly thirty numbers steered GBTS from inside function bodies: the curvature
cuts and the pT they were tuned at, the two-slope phi window model, the eta
split between the curvature cuts, the seed chain length, the CCA iteration cap,
the seed-splitting size window, the z0 histogram's resolution and the layers it
applies to, the phi sort buckets, the tau lookup table's bin width and the
tracking filter's initial covariance. None could be changed without editing
Core. Each becomes a config field defaulting to the literal it replaces.

Two are more than a rename. `GbtsGeometry` built its bin table against a
hardcoded z0 range of +-168 mm while `Config::minZ0`/`maxZ0` defaulted to +-600;
these are two different cuts and the first is now `GbtsZ0Range`. And the tau
lookup table indexes by the reciprocal rather than by the division, which
differ on eight bin edges in [0, 2] mm.

`lrtMode` goes the other way and disappears. It bundled four unrelated things:
strip layer connections instead of pixel, curvature bounds taken from the pT a
triplet has to reach rather than from the tuned constants, a shorter minimum
chain, and triplets switched off. Each is an ordinary option now, so large
radius tracking is a set of values rather than a mode the seeder recognises.
`useOldTunings` gated the curvature bounds and the phi window together while
`lrtMode` wanted only the first, so it splits in two.

`layerId1 == 80000` / `== 81000` become `z0HistogramLayerIds` and
`matchBeforeCreateLayerIds`, the seeder's last absolute layer ids.
`maxAbsEtaAddTripelts` is spelled correctly, and `stripLengthTolerance` becomes
`maxStripLengthFraction` so it no longer collides with the differently scaled
`StripSpacePointBuilder::stripLengthTolerance`.
