### PR TITLE
ci: apply `-DACTS_USE_SYSTEM_LIBS=ON` for eic-shell build

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1321,6 +1321,7 @@ jobs:
               -DACTS_BUILD_EXAMPLES=ON \
               -DACTS_BUILD_FATRAS=ON \
               -DACTS_BUILD_PLUGIN_DD4HEP=ON \
+              -DACTS_USE_SYSTEM_LIBS=ON \
               -DACTS_USE_SYSTEM_NLOHMANN_JSON=ON
             echo "::endgroup::"
             echo "::group::Acts build phase"


### PR DESCRIPTION
This is how downstream does it
https://github.com/spack/spack-packages/blob/fbdc07d9e7cfe61cb4c1328d2ab3e8158fa033f6/repos/spack_repo/builtin/packages/acts/package.py#L358