### PR TITLE
refactor: Take the last file handles out of the GBTS core

### DIFF
--- a/Core/include/Acts/Seeding/GbtsLayerConnectionTool.hpp
+++ b/Core/include/Acts/Seeding/GbtsLayerConnectionTool.hpp
@@ -14,7 +14,6 @@
 #include <memory>
 #include <optional>
 #include <span>
-#include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -112,10 +111,8 @@ class GbtsLayerConnectionTool {
   void addTrack(std::span<const HitCoordinates> track);
 
   /// Creates the connection table
-  /// @param outputFileLocation the location for the layer connection table
   /// @return layer pairs
-  GbtsLayerConnectionTool::LayerIdPairs createConnectionTable(
-      const std::string& outputFileLocation) const;
+  GbtsLayerConnectionTool::LayerIdPairs createConnectionTable() const;
 
  private:
   /// returns the Acts logger

--- a/Core/include/Acts/Seeding/GraphBasedTrackSeeder.hpp
+++ b/Core/include/Acts/Seeding/GraphBasedTrackSeeder.hpp
@@ -183,15 +183,15 @@ class GraphBasedTrackSeeder {
     float maxInvRadDiff = 0.7e-2 / UnitConstants::m;
     // GbtsNodeStorage options
     /// Maximum endcap cluster width.
-    float maxEndcapClusterWidth = 0.35 * Acts::UnitConstants::mm;
+    float maxEndcapClusterWidth = 0.35f * Acts::UnitConstants::mm;
     /// Half-length in local y of a pixel module, against which the distance of
     /// a cluster to the module edge is measured.
-    float moduleHalfLengthY = 10.0 * Acts::UnitConstants::mm;
+    float moduleHalfLengthY = 10.0f * Acts::UnitConstants::mm;
     /// Distance to the module edge below which a cluster may be shortened,
     /// which switches to the tau lookup table's near-edge bounds.
-    float moduleEdgeTolerance = 0.3 * Acts::UnitConstants::mm;
+    float moduleEdgeTolerance = 0.3f * Acts::UnitConstants::mm;
     /// Cluster width covered by one bin of the tau lookup table.
-    float tauLutBinWidth = 0.05 * Acts::UnitConstants::mm;
+    float tauLutBinWidth = 0.05f * Acts::UnitConstants::mm;
     /// Multiples of the phi slice width duplicated either side of the
     /// wrap-around, so a sliding window never has to wrap.
     float phiIndexMargin = 1.5f;

--- a/Core/include/Acts/Seeding/GraphBasedTrackSeeder.hpp
+++ b/Core/include/Acts/Seeding/GraphBasedTrackSeeder.hpp
@@ -23,7 +23,6 @@
 #include <cstdint>
 #include <limits>
 #include <memory>
-#include <string>
 #include <utility>
 #include <vector>
 
@@ -37,8 +36,9 @@ class GraphBasedTrackSeeder {
     /// Enable beam spot correction.
     bool beamSpotCorrection = false;
 
-    /// Look-up table input file path.
-    std::string lutInputFile;
+    /// Accepted tau range per cluster width bin, needed by the cluster width
+    /// cuts and ignored without them.
+    detail::GbtsTauLookupTable tauLookupTable;
 
     /// Take the strip-to-strip layer connections from the connector file
     /// instead of the pixel-to-pixel ones. Read where the file is loaded, not
@@ -329,18 +329,10 @@ class GraphBasedTrackSeeder {
 
   std::shared_ptr<const GbtsGeometry> m_geometry;
 
-  detail::GbtsTauLookupTable m_tauLut;
-
   std::unique_ptr<const Acts::Logger> m_logger =
       Acts::getDefaultLogger("Finder", Acts::Logging::Level::INFO);
 
   const Acts::Logger& logger() const { return *m_logger; }
-
-  /// Parse the tau lookup table from file.
-  /// @param lutInputFile Path to the lookup table input file
-  /// @return Parsed tau lookup table
-  detail::GbtsTauLookupTable parseTauLookupTable(
-      const std::string& lutInputFile) const;
 
   /// Build doublet graph from nodes.
   /// @param roi Region of interest descriptor

--- a/Core/src/Seeding/GbtsLayerConnectionTool.cpp
+++ b/Core/src/Seeding/GbtsLayerConnectionTool.cpp
@@ -9,10 +9,7 @@
 #include "Acts/Seeding/GbtsLayerConnectionTool.hpp"
 
 #include <cmath>
-#include <fstream>
-#include <iostream>
 #include <stdexcept>
-#include <string>
 
 namespace Acts::Experimental {
 
@@ -92,15 +89,11 @@ void GbtsLayerConnectionTool::addTrack(std::span<const HitCoordinates> track) {
 }
 
 GbtsLayerConnectionTool::LayerIdPairs
-GbtsLayerConnectionTool::createConnectionTable(
-    const std::string& outputFileLocation) const {
+GbtsLayerConnectionTool::createConnectionTable() const {
   if (m_totalTracks == 0) {
     throw std::runtime_error(
         "Warning: no tracks were added when creating connection table");
   }
-
-  // define output text file
-  std::ofstream outputFile(outputFileLocation);
 
   // obtain total incoming transitions for each src layer (used as denominator
   // of probability)

--- a/Core/src/Seeding/GraphBasedTrackSeeder.cpp
+++ b/Core/src/Seeding/GraphBasedTrackSeeder.cpp
@@ -174,7 +174,7 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
 
   // scale factor to get indexes of binned beamspot
   const float z0HistoCoeff =
-      detail::kGbtsZ0HistogramBins / (m_cfg.maxZ0 - m_cfg.minZ0 + 1e-6);
+      detail::kGbtsZ0HistogramBins / (m_cfg.maxZ0 - m_cfg.minZ0 + 1e-6f);
 
   const detail::GbtsNodeView nodeView = nodeStorage.nodeView();
   const std::span<const detail::GbtsNodeParams> params =
@@ -417,10 +417,9 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
 
           const float z0 = z1c - r1c * tau;
 
-          if (useZ0Histogram) {  // check against non-empty z0 histogram
-            if (!checkZ0BitMask(nodeInfo, z0, z0HistoCoeff)) {
-              continue;
-            }
+          // check against a non-empty z0 histogram
+          if (useZ0Histogram && !checkZ0BitMask(nodeInfo, z0, z0HistoCoeff)) {
+            continue;
           }
 
           if (m_cfg.doubletFilterRZ) {
@@ -436,11 +435,10 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
           }
 
           const float curv = (phi2 - phi1) / dr;
-          const float absCurv = std::abs(curv);
 
-          if (absCurv > (ftau < m_cfg.curvatureSplitAbsTau
-                             ? curvatureCutLowEta
-                             : curvatureCutHighEta)) {
+          if (std::abs(curv) > (ftau < m_cfg.curvatureSplitAbsTau
+                                    ? curvatureCutLowEta
+                                    : curvatureCutHighEta)) {
             continue;
           }
 
@@ -563,16 +561,14 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
               }
 
               // final check: cuts on pT and d0
-              if (m_cfg.validateTriplets) {
-                if (isPixelBarrel1 && isPixelBarrel2 && isPixelBarrel3) {
-                  const std::array<SpacePointIndex, 3> candidateTriplet = {
-                      n1Idx, n2Idx, pS->n2};
+              if (m_cfg.validateTriplets && isPixelBarrel1 && isPixelBarrel2 &&
+                  isPixelBarrel3) {
+                const std::array<SpacePointIndex, 3> candidateTriplet = {
+                    n1Idx, n2Idx, pS->n2};
 
-                  if (!validateTriplet(nodeView, candidateTriplet, tripletPtMin,
-                                       absTauRatio, m_cfg.tauRatioCut,
-                                       options)) {
-                    continue;
-                  }
+                if (!validateTriplet(nodeView, candidateTriplet, tripletPtMin,
+                                     absTauRatio, m_cfg.tauRatioCut, options)) {
+                  continue;
                 }
               }
 
@@ -583,10 +579,9 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
 
               // edge confirmed - update z0 histogram. Only doubletFilterRZ
               // holds z0 to the histogram range, and it is optional.
-              const auto z0BinIndex =
-                  static_cast<std::int32_t>(z0HistoCoeff * (z0 - m_cfg.minZ0));
-
-              if (z0BinIndex >= 0 &&
+              if (const auto z0BinIndex = static_cast<std::int32_t>(
+                      z0HistoCoeff * (z0 - m_cfg.minZ0));
+                  z0BinIndex >= 0 &&
                   z0BinIndex < detail::kGbtsZ0HistogramBins) {
                 ++z0Histo[z0BinIndex];
               }

--- a/Core/src/Seeding/GraphBasedTrackSeeder.cpp
+++ b/Core/src/Seeding/GraphBasedTrackSeeder.cpp
@@ -16,7 +16,6 @@
 #include <array>
 #include <cmath>
 #include <cstdint>
-#include <fstream>
 #include <memory>
 #include <numbers>
 #include <stdexcept>
@@ -53,7 +52,11 @@ GraphBasedTrackSeeder::GraphBasedTrackSeeder(
         "GraphBasedTrackSeeder: phiSortBuckets exceeds the maximum");
   }
 
-  m_tauLut = parseTauLookupTable(m_cfg.lutInputFile);
+  if (m_cfg.useClusterWidthCuts && m_cfg.tauLookupTable.empty()) {
+    throw std::invalid_argument(
+        "GraphBasedTrackSeeder: the cluster width cuts need a tau lookup "
+        "table");
+  }
 }
 
 GbtsNodeStorage GraphBasedTrackSeeder::makeNodeStorage() const {
@@ -67,7 +70,7 @@ GbtsNodeStorage GraphBasedTrackSeeder::makeNodeStorage() const {
   config.phiSortBuckets = m_cfg.phiSortBuckets;
   config.tauLutBinWidth = m_cfg.tauLutBinWidth;
 
-  return GbtsNodeStorage(config, m_geometry, m_tauLut);
+  return GbtsNodeStorage(config, m_geometry, m_cfg.tauLookupTable);
 }
 
 void GraphBasedTrackSeeder::createSeeds(const SpacePointContainer& spacePoints,
@@ -127,40 +130,6 @@ void GraphBasedTrackSeeder::createSeeds(GbtsNodeStorage& nodeStorage,
     newSeed.assignSpacePointIndices(seed.spacePoints);
     newSeed.quality() = seed.seedQuality;
   }
-}
-
-detail::GbtsTauLookupTable GraphBasedTrackSeeder::parseTauLookupTable(
-    const std::string& lutInputFile) const {
-  if (!m_cfg.useClusterWidthCuts) {
-    return {};
-  }
-  if (lutInputFile.empty()) {
-    throw std::runtime_error("Cannot find tau lookup table file");
-  }
-
-  std::ifstream ifs(std::string(lutInputFile).c_str());
-  if (!ifs.is_open()) {
-    throw std::runtime_error("Failed to open tau lookup table file");
-  }
-
-  detail::GbtsTauLookupTable tauLut;
-  tauLut.reserve(100);
-
-  // per line: cluster width, bulk tau bounds, near-edge tau bounds. The width
-  // is dropped - rows are located by index, never searched.
-  float clusterWidth{};
-  detail::GbtsTauBounds bounds;
-  while (ifs >> clusterWidth >> bounds.minTau >> bounds.maxTau >>
-         bounds.minTauNearEdge >> bounds.maxTauNearEdge) {
-    tauLut.push_back(bounds);
-  }
-
-  if (!ifs.eof()) {
-    // ended if parse error present, not clean EOF
-    throw std::runtime_error("Stopped reading LUT file due to parse error");
-  }
-
-  return tauLut;
 }
 
 std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(

--- a/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/GraphBasedSeedingAlgorithm.hpp
+++ b/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/GraphBasedSeedingAlgorithm.hpp
@@ -21,6 +21,7 @@
 #include "ActsExamples/Framework/DataHandle.hpp"
 #include "ActsExamples/Framework/IAlgorithm.hpp"
 
+#include <filesystem>
 #include <memory>
 #include <string>
 #include <vector>
@@ -64,7 +65,7 @@ class GraphBasedSeedingAlgorithm final : public IAlgorithm {
 
     /// the ATLAS lookup table of tau bounds per cluster width, needed by the
     /// cluster width cuts
-    std::string lutInputFile;
+    std::filesystem::path lutInputFile;
 
     /// Eta bin width the layers are split into (0 takes the value the
     /// connector file carries, 0.2 in ATLAS' createLinkingScheme.py)

--- a/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/GraphBasedSeedingAlgorithm.hpp
+++ b/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/GraphBasedSeedingAlgorithm.hpp
@@ -62,6 +62,10 @@ class GraphBasedSeedingAlgorithm final : public IAlgorithm {
     /// the ATLAS connector file listing which layers may be connected
     std::string connectorInputFile;
 
+    /// the ATLAS lookup table of tau bounds per cluster width, needed by the
+    /// cluster width cuts
+    std::string lutInputFile;
+
     /// Eta bin width the layers are split into (0 takes the value the
     /// connector file carries, 0.2 in ATLAS' createLinkingScheme.py)
     float etaBinWidthOverride = 0.0f;

--- a/Examples/Algorithms/TrackFinding/src/GraphBasedSeedingAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFinding/src/GraphBasedSeedingAlgorithm.cpp
@@ -14,6 +14,7 @@
 #include "Acts/Seeding/GbtsGeometry.hpp"
 #include "Acts/Seeding/GbtsLayerConnection.hpp"
 #include "Acts/Seeding/GbtsTrackingFilter.hpp"
+#include "Acts/Seeding/detail/GbtsGraphTypes.hpp"
 #include "ActsExamples/EventData/IndexSourceLink.hpp"
 
 #include <algorithm>
@@ -107,6 +108,36 @@ ConnectorTable readConnectorTable(const std::string &path,
   return table;
 }
 
+/// Read an ATLAS GBTS tau lookup table: per line a cluster width, the bulk tau
+/// bounds and the near-edge ones. The width is dropped - a row is located by
+/// index, one row per `tauLutBinWidth` of cluster width, never searched.
+///
+/// @param path Path to the lookup table file
+Acts::Experimental::detail::GbtsTauLookupTable readTauLookupTable(
+    const std::string &path) {
+  std::ifstream inStream(path);
+  if (!inStream) {
+    throw std::runtime_error("Cannot open GBTS tau lookup table '" + path +
+                             "'");
+  }
+
+  Acts::Experimental::detail::GbtsTauLookupTable tauLut;
+
+  float clusterWidth{};
+  Acts::Experimental::detail::GbtsTauBounds bounds;
+  while (inStream >> clusterWidth >> bounds.minTau >> bounds.maxTau >>
+         bounds.minTauNearEdge >> bounds.maxTauNearEdge) {
+    tauLut.push_back(bounds);
+  }
+
+  if (!inStream.eof()) {
+    // ended on a parse error, not on a clean EOF
+    throw std::runtime_error("Malformed GBTS tau lookup table '" + path + "'");
+  }
+
+  return tauLut;
+}
+
 }  // namespace
 
 GraphBasedSeedingAlgorithm::GraphBasedSeedingAlgorithm(
@@ -123,6 +154,12 @@ GraphBasedSeedingAlgorithm::GraphBasedSeedingAlgorithm(
   // read which layers may be connected
   const ConnectorTable connectorTable = readConnectorTable(
       m_cfg.connectorInputFile, m_cfg.seedFinderConfig.useStripConnections);
+
+  // the cluster width cuts are the only user of the tau lookup table
+  if (m_cfg.seedFinderConfig.useClusterWidthCuts) {
+    m_cfg.seedFinderConfig.tauLookupTable =
+        readTauLookupTable(m_cfg.lutInputFile);
+  }
 
   // create the TrigInDetSiLayers (Logical Layers),
   // as well as a map that tracks there index in m_layerGeometry
@@ -465,11 +502,11 @@ void GraphBasedSeedingAlgorithm::printConfig() const {
   ACTS_DEBUG("===== GraphBasedSeedingAlgorithm =====");
   ACTS_DEBUG("layerMappingFile: " << m_cfg.layerMappingFile);
   ACTS_DEBUG("connectorInputFile: " << m_cfg.connectorInputFile);
+  ACTS_DEBUG("lutInputFile: " << m_cfg.lutInputFile);
   ACTS_DEBUG("etaBinWidthOverride: " << m_cfg.etaBinWidthOverride);
   ACTS_DEBUG("===== GraphBasedTrackSeeder =====");
   const auto &cfg1 = m_cfg.seedFinderConfig;
   ACTS_DEBUG("BeamSpotCorrection: " << cfg1.beamSpotCorrection);
-  ACTS_DEBUG("lutInputFile: " << cfg1.lutInputFile);
   ACTS_DEBUG("useStripConnections: " << cfg1.useStripConnections);
   ACTS_DEBUG("useClusterWidthCuts: " << cfg1.useClusterWidthCuts);
   ACTS_DEBUG("matchBeforeCreate: " << cfg1.matchBeforeCreate);

--- a/Examples/Algorithms/TrackFinding/src/GraphBasedSeedingAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFinding/src/GraphBasedSeedingAlgorithm.cpp
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <map>
@@ -114,11 +115,11 @@ ConnectorTable readConnectorTable(const std::string &path,
 ///
 /// @param path Path to the lookup table file
 Acts::Experimental::detail::GbtsTauLookupTable readTauLookupTable(
-    const std::string &path) {
+    const std::filesystem::path &path) {
   std::ifstream inStream(path);
   if (!inStream) {
-    throw std::runtime_error("Cannot open GBTS tau lookup table '" + path +
-                             "'");
+    throw std::runtime_error("Cannot open GBTS tau lookup table '" +
+                             path.string() + "'");
   }
 
   Acts::Experimental::detail::GbtsTauLookupTable tauLut;
@@ -132,7 +133,8 @@ Acts::Experimental::detail::GbtsTauLookupTable readTauLookupTable(
 
   if (!inStream.eof()) {
     // ended on a parse error, not on a clean EOF
-    throw std::runtime_error("Malformed GBTS tau lookup table '" + path + "'");
+    throw std::runtime_error("Malformed GBTS tau lookup table '" +
+                             path.string() + "'");
   }
 
   return tauLut;

--- a/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/GbtsTrainingAlgorithm.cpp
+++ b/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/GbtsTrainingAlgorithm.cpp
@@ -110,8 +110,7 @@ GbtsTrainingAlgorithm::GbtsTrainingAlgorithm(
 }
 
 ProcessCode GbtsTrainingAlgorithm::finalize() {
-  const auto layerTable =
-      m_layerConnectionTool->createConnectionTable(m_cfg.outputFileDir);
+  const auto layerTable = m_layerConnectionTool->createConnectionTable();
 
   // define output text file
   std::ofstream outputFile(m_cfg.outputFileDir);

--- a/Python/Examples/python/reconstruction.py
+++ b/Python/Examples/python/reconstruction.py
@@ -1435,7 +1435,6 @@ def addGbtsSeeding(
     seedFinderConfig = acts.examples.GraphBasedSeedingConfig(
         **acts.examples.defaultKWArgs(
             minPt=seedFinderConfigArg.minPt,
-            lutInputFile=lutInputConfigFileStr,
         ),
     )
 
@@ -1446,6 +1445,7 @@ def addGbtsSeeding(
         seedFinderConfig=seedFinderConfig,
         layerMappingFile=layerMappingFile,
         connectorInputFile=connectorInputFileStr,
+        lutInputFile=lutInputConfigFileStr,
         trackingGeometry=trackingGeometry,
         fillModuleCsv=False,
         inputClusters="clusters",

--- a/Python/Examples/src/TrackFinding.cpp
+++ b/Python/Examples/src/TrackFinding.cpp
@@ -84,14 +84,15 @@ void addTrackFinding(py::module& mex) {
     using Config = Acts::Experimental::GraphBasedTrackSeeder::Config;
     auto c =
         py::class_<Config>(mex, "GraphBasedSeedingConfig").def(py::init<>());
-    ACTS_PYTHON_STRUCT(c, minPt, nMaxPhiSlice, lutInputFile);
+    ACTS_PYTHON_STRUCT(c, minPt, nMaxPhiSlice);
     patchKwargsConstructor(c);
   }
 
-  ACTS_PYTHON_DECLARE_ALGORITHM(
-      GraphBasedSeedingAlgorithm, mex, "GraphBasedSeedingAlgorithm",
-      inputSpacePoints, outputSeeds, seedFinderConfig, layerMappingFile,
-      connectorInputFile, trackingGeometry, fillModuleCsv, inputClusters);
+  ACTS_PYTHON_DECLARE_ALGORITHM(GraphBasedSeedingAlgorithm, mex,
+                                "GraphBasedSeedingAlgorithm", inputSpacePoints,
+                                outputSeeds, seedFinderConfig, layerMappingFile,
+                                connectorInputFile, lutInputFile,
+                                trackingGeometry, fillModuleCsv, inputClusters);
 
   ACTS_PYTHON_DECLARE_ALGORITHM(
       HoughTransformSeeder, mex, "HoughTransformSeeder", inputSpacePoints,

--- a/Python/Examples/src/TrackFinding.cpp
+++ b/Python/Examples/src/TrackFinding.cpp
@@ -27,6 +27,7 @@
 #include <pybind11/functional.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+#include <pybind11/stl/filesystem.h>
 
 namespace py = pybind11;
 

--- a/docs/groups/pattern_recog/gbts.md
+++ b/docs/groups/pattern_recog/gbts.md
@@ -211,10 +211,12 @@ the angle. Wide clusters in the pixel endcap are dropped entirely
 (`maxEndcapClusterWidth`).
 
 > [!note]
-> The lookup table is only consulted for pixel barrel layers, and the ACTS
-> examples framework does not currently provide cluster widths or local
-> positions, so this path is exercised only by experiment-side integrations that
-> supply them through `insert`.
+> The seeder takes the table itself as `tauLookupTable`, not a path to it;
+> `ActsExamples::GraphBasedSeedingAlgorithm` parses it from ATLAS' text format.
+> It is only consulted for pixel barrel layers, and the ACTS examples framework
+> does not currently provide cluster widths or local positions, so this path is
+> exercised only by experiment-side integrations that supply them through
+> `insert`.
 
 ## Configuration {#gbts-configuration}
 
@@ -236,7 +238,7 @@ The main knobs on @ref Acts::Experimental::GraphBasedTrackSeeder "GraphBasedTrac
 | `hitShareThreshold` | @ref gbts-extraction | fraction of shared hits above which a candidate is a clone |
 | `maxSeedSplitEta`, `maxInvRadDiff` | @ref gbts-extraction | seed splitting |
 | `addTriplets`, `maxAbsEtaAddTriplets` | @ref gbts-extraction | allow shorter chains within an @f$\eta@f$ range |
-| `useClusterWidthCuts`, `lutInputFile` | @ref gbts-ml | cluster-width based @f$\tau@f$ windows |
+| `useClusterWidthCuts`, `tauLookupTable` | @ref gbts-ml | cluster-width based @f$\tau@f$ windows |
 | `maxEndcapClusterWidth`, `moduleHalfLengthY`, `moduleEdgeTolerance` | @ref gbts-ml | cluster-width acceptance and module-edge handling |
 
 There is no large radius tracking mode. LRT is these options set to the values


### PR DESCRIPTION
`GraphBasedTrackSeeder` opened and parsed a second ATLAS text file, the tau
lookup table its cluster width cuts read, for the same reason the connector
file was opened before #5994: because that is where the path was configured.
The seeder does not need the path, it needs the table, so `Config` now carries
`tauLookupTable` and the examples algorithm parses the file next to the
connector table it already reads. A run with the cuts on and no table is still
an error, now raised where the rest of the configuration is validated instead
of at the failing `ifstream`.

`GbtsLayerConnectionTool::createConnectionTable` also took a path, opened an
`ofstream` on it and wrote nothing: the training algorithm writes the table
itself, from the pairs the tool returns, into a stream it opens on that same
path. The argument goes.

Nothing under `Core/src/Seeding` includes `<fstream>` any more.

