### PR TITLE
fix(traccc): Repair the HIP spacepoint formation build, and gate Traccc on the merge queue

### DIFF
--- a/.github/workflows/traccc.yml
+++ b/.github/workflows/traccc.yml
@@ -8,8 +8,10 @@ name: Traccc
 
 on:
   push:
-    # The release branches (keep in sync with release.yml) and the merge
-    # queue's temp ref carry a tree that has already been built.
+    # The release branches (keep in sync with release.yml) carry a tree the
+    # merge queue has already built. The queue's own temp ref triggers
+    # merge_group below; a push run there shares its concurrency group and
+    # evicts the PR from the queue.
     branches-ignore:
       - 'releases'
       - 'release/**'
@@ -25,10 +27,19 @@ on:
       - "Traccc/**"
       - "Detray/**"
       - ".github/workflows/traccc.yml"
+  # merge_group does not support path filters, so this runs on every queue
+  # entry targeting main, not just ones touching Traccc/ or Detray/. Only
+  # required via merge-sentinel's "Traccc / *" pattern, which is itself
+  # path-gated, so a non-Traccc entry running this wastes compute but doesn't
+  # block merging.
+  merge_group:
+    types: [checks_requested]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  # Never cancel a merge_group run: it's a required check for a queue entry,
+  # and a cancellation reads as a failure to the queue, ejecting the PR.
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 jobs:
   containers:

--- a/.merge-sentinel.yml
+++ b/.merge-sentinel.yml
@@ -44,3 +44,18 @@ rules:
      - ".github/workflows/detray.yml"
     required_pattern:
      - "Detray / *"
+
+  # Without this the Traccc jobs run on a queue entry but do not gate it:
+  # pending only blocks when required, and they take ~25 minutes, so the
+  # aggregate would go green long before they report. A Detray-only change
+  # still runs them (traccc.yml triggers on Detray/** too) and a *failure*
+  # fails the gate whether required or not -- only the wait is missing there.
+  - branch_filter:
+     - "main"
+     - "develop/*"
+    paths:
+     - "Traccc/*"
+     - "Traccc/**/*"
+     - ".github/workflows/traccc.yml"
+    required_pattern:
+     - "Traccc / *"

--- a/Traccc/device/hip/include/traccc/hip/seeding/silicon_pixel_spacepoint_formation_algorithm.hpp
+++ b/Traccc/device/hip/include/traccc/hip/seeding/silicon_pixel_spacepoint_formation_algorithm.hpp
@@ -42,6 +42,20 @@ class silicon_pixel_spacepoint_formation_algorithm
   /// @c traccc::device::silicon_pixel_spacepoint_formation_algorithm
   /// @{
 
+  /// Launch the spacepoint counting kernel
+  ///
+  /// @param payload The payload for the kernel
+  ///
+  void count_spacepoints_kernel(
+      const count_spacepoints_kernel_payload& payload) const override;
+
+  /// Turn the spacepoint flags into a prefix sum, in place
+  ///
+  /// @param spacepoint_flags The flags to scan
+  ///
+  void scan_spacepoint_flags(
+      vecmem::data::vector_view<unsigned int>& spacepoint_flags) const override;
+
   /// Launch the spacepoint formation kernel
   ///
   /// @param payload The payload for the kernel

--- a/Traccc/device/hip/src/seeding/silicon_pixel_spacepoint_formation_algorithm.hip
+++ b/Traccc/device/hip/src/seeding/silicon_pixel_spacepoint_formation_algorithm.hip
@@ -13,21 +13,40 @@
 
 // Project include(s).
 #include "traccc/geometry/detector.hpp"
+#include "traccc/seeding/device/count_spacepoints.hpp"
 #include "traccc/seeding/device/form_spacepoints.hpp"
+
+// (Roc)Thrust include(s).
+#include <thrust/execution_policy.h>
+#include <thrust/scan.h>
+
+// System include(s).
+#include <cassert>
+#include <memory_resource>
 
 namespace traccc::hip {
 namespace kernels {
 
+/// Kernel wrapping @c device::count_spacepoints
+__global__ void __launch_bounds__(1024, 1) count_spacepoints(
+    edm::measurement_collection::const_view measurements,
+    vecmem::data::vector_view<unsigned int> spacepoint_flags) {
+  device::count_spacepoints(details::global_index1(), measurements,
+                            spacepoint_flags);
+}
+
 /// Kernel wrapping @c device::form_spacepoints
 template <typename detector_t>
-__global__ void __launch_bounds__(1024, 1)
-    form_spacepoints(typename detector_t::view detector,
-                     edm::measurement_collection::const_view measurements,
-                     edm::spacepoint_collection::view spacepoints)
+__global__ void __launch_bounds__(1024, 1) form_spacepoints(
+    typename detector_t::view detector,
+    edm::measurement_collection::const_view measurements,
+    vecmem::data::vector_view<const unsigned int> spacepoint_index,
+    edm::spacepoint_collection::view spacepoints)
   requires(traccc::is_detector_traits<detector_t>)
 {
   device::form_spacepoints<detector_t>(details::global_index1(), detector,
-                                       measurements, spacepoints);
+                                       measurements, spacepoint_index,
+                                       spacepoints);
 }
 
 }  // namespace kernels
@@ -40,6 +59,40 @@ silicon_pixel_spacepoint_formation_algorithm::
                                                            std::move(logger)),
       hip::algorithm_base(str) {}
 
+void silicon_pixel_spacepoint_formation_algorithm::count_spacepoints_kernel(
+    const count_spacepoints_kernel_payload& payload) const {
+  const unsigned int n_threads = warp_size() * 8;
+  const unsigned int n_blocks =
+      (payload.n_measurements + n_threads - 1) / n_threads;
+  hipLaunchKernelGGL(kernels::count_spacepoints, n_blocks, n_threads, 0,
+                     details::get_stream(stream()), payload.measurements,
+                     payload.spacepoint_flags);
+  TRACCC_HIP_ERROR_CHECK(hipGetLastError());
+}
+
+void silicon_pixel_spacepoint_formation_algorithm::scan_spacepoint_flags(
+    vecmem::data::vector_view<unsigned int>& spacepoint_flags) const {
+  assert(spacepoint_flags.size_ptr() == nullptr);
+
+// Set up the Thrust execution policy. Unfortunately this has to be done in
+// a backend specific way. :-(
+#if defined(__HIP_PLATFORM_AMD__)
+  auto policy =
+      thrust::hip::par_nosync(std::pmr::polymorphic_allocator(&(mr().main)))
+          .on(details::get_stream(stream()));
+#elif defined(__HIP_PLATFORM_NVIDIA__)
+  auto policy =
+      thrust::cuda::par_nosync(std::pmr::polymorphic_allocator(&(mr().main)))
+          .on(details::get_stream(stream()));
+#else
+#error "Unrecognised HIP platform."
+#endif
+
+  thrust::inclusive_scan(policy, spacepoint_flags.ptr(),
+                         spacepoint_flags.ptr() + spacepoint_flags.capacity(),
+                         spacepoint_flags.ptr());
+}
+
 void silicon_pixel_spacepoint_formation_algorithm::form_spacepoints_kernel(
     const form_spacepoints_kernel_payload& payload) const {
   const unsigned int n_threads = warp_size() * 8;
@@ -48,12 +101,15 @@ void silicon_pixel_spacepoint_formation_algorithm::form_spacepoints_kernel(
   detector_buffer_visitor<detector_type_list>(
       payload.detector, [&]<typename detector_traits_t>(
                             const typename detector_traits_t::view& det) {
-        hipLaunchKernelGGL(kernels::form_spacepoints<detector_traits_t>,
-                           n_blocks, n_threads, 0,
-                           details::get_stream(stream()), det,
-                           payload.measurements, payload.spacepoints);
+        hipLaunchKernelGGL(
+            kernels::form_spacepoints<detector_traits_t>, n_blocks, n_threads,
+            0, details::get_stream(stream()), det, payload.measurements,
+            payload.spacepoint_index, payload.spacepoints);
       });
   TRACCC_HIP_ERROR_CHECK(hipGetLastError());
+  // The base class destroys the prefix sum buffer right after this call, so
+  // the kernel must finish before returning.
+  stream().synchronize();
 }
 
 }  // namespace traccc::hip


### PR DESCRIPTION
`main` does not build with HIP. `Traccc / ALPAKA_HIP-RelWithDebInfo` has been red since [run 33422649947](https://github.com/acts-project/acts/actions/runs/33422649947) on `83e52311ec`:

```
Traccc/device/hip/src/seeding/silicon_pixel_spacepoint_formation_algorithm.hip:29:3:
  error: no matching function for call to 'form_spacepoints'
```

It has gone unnoticed because `traccc.yml` is path-filtered on `Traccc/**` / `Detray/**` and nothing merged since has touched either, so the workflow has not run on `main` again.

## The build fix

A semantic conflict between two PRs that merged in the same queue batch (identical `mergedAt`, both branched from `fa09a1b049`):

| PR | Change | `.hip` file present in its tree? |
|---|---|---|
| #5938 "Make spacepoint formation deterministic" | gave `device::form_spacepoints` a `spacepoint_index` parameter and split the algorithm base into `count_spacepoints_kernel` / `scan_spacepoint_flags` / `form_spacepoints_kernel`, updating CUDA and Alpaka | no |
| #5941 "HIP Seed Finding" | added the HIP backend, calling the *old* `form_spacepoints` | added it |

Each was legitimately green: #5938's branch had no HIP caller to compile, and #5941 compiled against the `form_spacepoints` still on `main`. Only the union is broken.

The HIP backend is brought in line with CUDA — it was missing two of the three virtuals entirely, not just the changed signature:

- `count_spacepoints_kernel` plus the kernel it launches
- `scan_spacepoint_flags`, an in-place inclusive rocThrust scan, with the same `__HIP_PLATFORM_AMD__` / `__HIP_PLATFORM_NVIDIA__` policy split `kalman_fitting_algorithm_prepare_track_fit_order.hip` already uses
- `form_spacepoints_kernel` now passes the prefix sum, and synchronises before returning, because the base class frees that buffer right after the call

## Why the merge queue did not catch it

That is precisely what a queue is for, and both PRs went through it. But `traccc.yml` has **no `merge_group:` trigger** (`detray.yml`, `builds.yml`, `analysis.yml` and `checks.yml` all do) and its `push` trigger ignores `gh-readonly-queue/**`. So the combined tree was never built by this workflow, and the breakage first appeared on the post-merge push to `main` — after the merge was irreversible.

The second commit adds the trigger, mirroring `detray.yml`, including the `cancel-in-progress: ${{ github.event_name != 'merge_group' }}` guard — cancelling a `merge_group` run reads as a failure and ejects the entry from the queue.

**The trigger alone would not gate.** Per sentinel's rule-matching docs, *"pending only blocks when required"*, and these jobs take ~25 minutes — the aggregate would go green long before they report, and the entry would merge regardless. Hence the matching `Traccc / *` rule in `.merge-sentinel.yml`.

Two notes on that rule:

- It is path-gated on `Traccc/**` and the workflow file, deliberately not `Detray/**`. A failing check fails the gate whether required or not, so Detray-only entries — which `traccc.yml` also runs on — stay covered against *failures*; only the wait is missing. Widening it would put ~25 min on the critical path of every Detray PR.
- sentinel reads `.merge-sentinel.yml` from the **default branch**, so the rule does not apply to this PR itself, and takes up to `PROJECTION_CONFIG_CACHE_SECONDS` (300s) to take effect after merge.

The two commits are independent: the first is the build fix, the second the CI gap. Drop the second if the added queue latency isn't wanted.

## Checks

The HIP path can't be compiled locally (no ROCm), so the code change is verified by construction against the CUDA and Alpaka backends rather than by a local build — `Traccc / ALPAKA_HIP-RelWithDebInfo` on this PR is the real test. `clang-format` and `zizmor` pass.
