### PR TITLE
fix(cmake): add cmake_minimum_required to ActsConfig.cmake.in

### DIFF
--- a/cmake/ActsConfig.cmake.in
+++ b/cmake/ActsConfig.cmake.in
@@ -11,6 +11,13 @@
 #   - Acts_COMMIT_HASH
 #   - Acts_COMMIT_HASH_SHORT
 
+# This file uses `if(... IN_LIST ...)`, which needs policy CMP0057 set to NEW.
+# find_package gives this file its own policy scope, inherited from the calling
+# project, so a client with an older cmake_minimum_required would otherwise fail
+# here. The upper bound keeps the policy version at the CMake that generated the
+# config, matching the Acts*Targets.cmake files included below.
+cmake_minimum_required(VERSION 3.10...@CMAKE_VERSION@)
+
 @PACKAGE_INIT@
 
 set(Acts_COMPONENTS @_components@)


### PR DESCRIPTION
ActsConfig.cmake.in uses `if(... IN_LIST ...)` in a dozen places, which needs CMP0057 set to NEW. find_package gives the config its own policy scope, but that scope takes its policy version from whoever calls it, so a project with an older cmake_minimum_required gets "Unknown arguments specified" from inside a file it doesn't own. That's the LCG_97 failure from #2186.

The flat `VERSION 3.3` suggested in the issue doesn't work any more, CMake 4.x rejects anything below 3.5 outright, so I used a range. 3.10 is the lowest min that doesn't warn on CMake 4, which keeps the floor low for client code. The upper bound is what actually sets the policy version, and a fixed one lowers it for modern consumers (with 3.19, CMP0144 flips from NEW to unset inside the config and the find_dependency calls stop picking up BOOST_ROOT), so I substituted CMAKE_VERSION there. That matches what CMake itself writes into the Acts*Targets.cmake files this config includes.

Checked with the generated ActsConfig.cmake: on CMake 3.25 with a consumer declaring cmake_minimum_required(VERSION 3.0), find_package(Acts) fails before this change and succeeds after, and on CMake 4.4 with a modern consumer nothing changes either way. One side effect worth flagging is that cmake_minimum_required in a config file leaks CMAKE_MINIMUM_REQUIRED_VERSION into the caller (3.0 becomes 3.10 in that test), policies don't leak. I can use cmake_policy(VERSION ...) instead if you'd rather avoid that.

Closes #2216
