### PR TITLE
refactor!: Clean up triplet seeding config structs and grid API

### DIFF
--- a/Core/include/Acts/Seeding/BroadTripletSeedFilter.hpp
+++ b/Core/include/Acts/Seeding/BroadTripletSeedFilter.hpp
@@ -17,6 +17,7 @@
 #include "Acts/Seeding/detail/CandidatesForMiddleSp.hpp"
 #include "Acts/Utilities/Logger.hpp"
 
+#include <cstdint>
 #include <memory>
 #include <unordered_map>
 #include <vector>
@@ -86,11 +87,11 @@ class BroadTripletSeedFilter final : public ITripletSeedFilter {
     /// Maximum number (minus one) of accepted seeds per middle space-point
     /// In dense environments many seeds may be found per middle space-point
     /// Only seeds with the highest weight will be kept if this limit is reached
-    unsigned int maxSeedsPerSpM = 5;
+    std::uint32_t maxSeedsPerSpM = 5;
     /// Maximum limit to number of compatible space-point used in score
     /// calculation. We increase by c1 the weight calculation for each
     /// compatible space-point until we reach compatSeedLimit
-    std::size_t compatSeedLimit = 2;
+    std::uint32_t compatSeedLimit = 2;
 
     /// Increment in seed weight if the number of compatible seeds is larger
     /// than numSeedIncrement, this is used in case of high occupancy scenarios

--- a/Core/include/Acts/Seeding/CartesianSpacePointGrid.hpp
+++ b/Core/include/Acts/Seeding/CartesianSpacePointGrid.hpp
@@ -17,6 +17,7 @@
 #include "Acts/Utilities/Logger.hpp"
 #include "Acts/Utilities/RangeXD.hpp"
 
+#include <cstdint>
 #include <functional>
 #include <vector>
 
@@ -46,30 +47,32 @@ class CartesianSpacePointGrid
   /// Configuration parameters for the cartesian space point grid.
   struct Config {
     /// number of bins in the x-coordinate
-    int nXbins = 10;
+    std::uint32_t nXbins = 10;
     /// minimum x-coordinate of space points used in the seeding
     float xMin = -600 * UnitConstants::mm;
     /// maximum x-coordinate of space points used in the seeding
     float xMax = 600 * UnitConstants::mm;
     /// number of bins in the y-coordinate
-    int nYbins = 6;
+    std::uint32_t nYbins = 6;
     /// minimum y-coordinate of space points used in the seeding
     float yMin = -600 * UnitConstants::mm;
     /// maximum y-coordinate of space points used in the seeding
     float yMax = 600 * UnitConstants::mm;
     /// number of bins in the z-coordinate
-    int nZbins = 10;
+    std::uint32_t nZbins = 10;
     /// minimum z coordinate ofspace points used in the seeding
     float zMin = -2700 * UnitConstants::mm;
     /// maximum z coordinate ofspace points used in the seeding
     float zMax = 2700 * UnitConstants::mm;
 
-    /// bin finder for bottom space points
-    std::optional<GridBinFinder<3ul>> bottomBinFinder;
-    /// bin finder for top space points
-    std::optional<GridBinFinder<3ul>> topBinFinder;
+    /// bin finder for bottom space points. Defaults to the neighbouring bins
+    /// on all three axes.
+    GridBinFinder<GridType::DIM> bottomBinFinder{1, 1, 1};
+    /// bin finder for top space points. Defaults to the neighbouring bins on
+    /// all three axes.
+    GridBinFinder<GridType::DIM> topBinFinder{1, 1, 1};
     /// navigation structure for the grid
-    std::array<std::vector<std::size_t>, 3ul> navigation;
+    std::array<std::vector<std::size_t>, GridType::DIM> navigation;
 
     /// coordinate to sort the space points by
     Acts::CoordinateIndices sortingCoord = Acts::CoordinateIndices::eY;
@@ -123,11 +126,13 @@ class CartesianSpacePointGrid
   /// @param spacePoints The space point container to sort the bins by the configured coordinate
   void sortBinsByCoord(const SpacePointContainer& spacePoints);
 
-  /// Compute the range of the sorting coordinates in the grid. This requires
-  /// the grid to be filled with space points and sorted by coordinate. The
-  /// sorting can be done with the `sortBinsByCoord` method.
+  /// Compute the range of the sort keys in the grid. The key is the sorting
+  /// coordinate multiplied by `sortingDirection`, so for a negative sorting
+  /// direction the range is the negated coordinate range. This requires the
+  /// grid to be filled with space points and sorted by coordinate. The sorting
+  /// can be done with the `sortBinsByCoord` method.
   /// @param spacePoints The space point container to compute the coordinate range
-  /// @return The range of sorting-coordinate values in the grid
+  /// @return The range of sort keys in the grid
   Range1D<float> computeCoordRange(
       const SpacePointContainer& spacePoints) const;
 

--- a/Core/include/Acts/Seeding/CylindricalSpacePointGrid.hpp
+++ b/Core/include/Acts/Seeding/CylindricalSpacePointGrid.hpp
@@ -15,6 +15,7 @@
 #include "Acts/Utilities/Logger.hpp"
 #include "Acts/Utilities/RangeXD.hpp"
 
+#include <cstdint>
 #include <numbers>
 #include <vector>
 
@@ -78,9 +79,9 @@ class CylindricalSpacePointGrid
     /// numPhiNeighbors (in the configuration of the BinFinders) is configured
     /// to return 1 neighbor on either side of the current phi-bin (and you want
     /// to cover the full phi-range of minPT), leave this at 1.
-    int phiBinDeflectionCoverage = 1;
+    std::uint32_t phiBinDeflectionCoverage = 1;
     /// maximum number of phi bins
-    int maxPhiBins = 10000;
+    std::uint32_t maxPhiBins = 10000;
     /// enable non equidistant binning in z
     std::vector<float> zBinEdges{};
     /// enable non equidistant binning in r
@@ -89,12 +90,14 @@ class CylindricalSpacePointGrid
     /// magnetic field
     float bFieldInZ = 0 * UnitConstants::T;
 
-    /// bin finder for bottom space points
-    std::optional<GridBinFinder<3ul>> bottomBinFinder;
-    /// bin finder for top space points
-    std::optional<GridBinFinder<3ul>> topBinFinder;
+    /// bin finder for bottom space points. Defaults to the neighbouring bins
+    /// in phi and z, and the same bin in r.
+    GridBinFinder<GridType::DIM> bottomBinFinder{1, 1, 0};
+    /// bin finder for top space points. Defaults to the neighbouring bins in
+    /// phi and z, and the same bin in r.
+    GridBinFinder<GridType::DIM> topBinFinder{1, 1, 0};
     /// navigation structure for the grid
-    std::array<std::vector<std::size_t>, 3ul> navigation;
+    std::array<std::vector<std::size_t>, GridType::DIM> navigation;
   };
 
   /// Construct a cylindrical space point grid with the given configuration and

--- a/Core/include/Acts/Seeding/SphericalSpacePointGrid.hpp
+++ b/Core/include/Acts/Seeding/SphericalSpacePointGrid.hpp
@@ -15,6 +15,7 @@
 #include "Acts/Utilities/Logger.hpp"
 #include "Acts/Utilities/RangeXD.hpp"
 
+#include <cstdint>
 #include <numbers>
 #include <vector>
 
@@ -79,11 +80,11 @@ class SphericalSpacePointGrid
     /// numPhiNeighbors (in the configuration of the BinFinders) is configured
     /// to return 1 neighbor on either side of the current phi-bin (and you want
     /// to cover the full phi-range of minPT), leave this at 1.
-    int phiBinDeflectionCoverage = 1;
+    std::uint32_t phiBinDeflectionCoverage = 1;
     /// maximum number of phi bins
-    int maxPhiBins = 10000;
+    std::uint32_t maxPhiBins = 10000;
     /// width of the equidistant eta bins used when `etaBinEdges` is empty
-    float deltaEtaMax = 0.8;
+    float etaBinSize = 0.8;
     /// enable non equidistant binning in eta (edges given in pseudorapidity;
     /// mapped to cot(theta) = sinh(eta) internally)
     std::vector<float> etaBinEdges{};
@@ -93,12 +94,14 @@ class SphericalSpacePointGrid
     /// magnetic field
     float bFieldInZ = 0 * UnitConstants::T;
 
-    /// bin finder for bottom space points
-    std::optional<GridBinFinder<3ul>> bottomBinFinder;
-    /// bin finder for top space points
-    std::optional<GridBinFinder<3ul>> topBinFinder;
+    /// bin finder for bottom space points. Defaults to the neighbouring bins
+    /// in phi and eta, and the same bin in r.
+    GridBinFinder<GridType::DIM> bottomBinFinder{1, 1, 0};
+    /// bin finder for top space points. Defaults to the neighbouring bins in
+    /// phi and eta, and the same bin in r.
+    GridBinFinder<GridType::DIM> topBinFinder{1, 1, 0};
     /// navigation structure for the grid
-    std::array<std::vector<std::size_t>, 3ul> navigation;
+    std::array<std::vector<std::size_t>, GridType::DIM> navigation;
   };
 
   /// Construct a spherical space point grid with the given configuration and

--- a/Core/include/Acts/Seeding/TripletSeedFinder.hpp
+++ b/Core/include/Acts/Seeding/TripletSeedFinder.hpp
@@ -134,10 +134,11 @@ class TripletSeedFinder {
   /// includes triplet cuts, steering switches, and assumptions about the space
   /// points.
   struct Config {
-    /// Delegates for accessors to detailed information on double strip
-    /// measurement that produced the space point. This is mainly referring to
-    /// space points produced when combining measurement from strips on
-    /// back-to-back modules. Enables setting of the following delegates.
+    /// Whether the space points carry detailed information on the double
+    /// strip measurement that produced them. This is mainly referring to space
+    /// points produced when combining measurements from strips on back-to-back
+    /// modules. If enabled, the triplet is formed from the strip coordinates
+    /// instead of the space point centers.
     bool useStripInfo = false;
 
     /// Whether the input doublets are sorted by cotTheta
@@ -169,8 +170,8 @@ class TripletSeedFinder {
 
     /// Maximum allowed difference in cot(theta) between the bottom and top
     /// doublets, applied as a pre-filter before the expensive strip
-    /// coordinate transformation. Only active when useStripInfo is true.
-    /// Set to infinity (default) to disable.
+    /// coordinate transformation. Only active when both `useStripInfo` and
+    /// `sortedByCotTheta` are true. Set to infinity (default) to disable.
     float cotThetaDiffMax = std::numeric_limits<float>::infinity();
   };
 

--- a/Core/include/Acts/Seeding/detail/SpacePointGridBase.hpp
+++ b/Core/include/Acts/Seeding/detail/SpacePointGridBase.hpp
@@ -134,6 +134,15 @@ class SpacePointGridBase {
 
   ~SpacePointGridBase() = default;
 
+  /// The binned group points at the bin finders owned by the derived class's
+  /// configuration, and `m_grid` points into the binned group. Copying or
+  /// moving would leave those pointers referring to the source object, so
+  /// neither is allowed.
+  SpacePointGridBase(const SpacePointGridBase&) = delete;
+  SpacePointGridBase(SpacePointGridBase&&) = delete;
+  SpacePointGridBase& operator=(const SpacePointGridBase&) = delete;
+  SpacePointGridBase& operator=(SpacePointGridBase&&) = delete;
+
   /// Take ownership of the fully constructed grid and set up the binned
   /// group. Has to be called exactly once by the derived constructor.
   /// @param grid The grid to take ownership of

--- a/Core/include/Acts/Seeding/detail/SpacePointGridPhiBinning.hpp
+++ b/Core/include/Acts/Seeding/detail/SpacePointGridPhiBinning.hpp
@@ -10,6 +10,8 @@
 
 #include "Acts/Utilities/Logger.hpp"
 
+#include <cstdint>
+
 namespace Acts::detail {
 
 /// Parameters to derive the number of phi bins of a space point grid from the
@@ -33,9 +35,9 @@ struct SpacePointGridPhiBinningConfig {
   /// numPhiNeighbors (in the configuration of the BinFinders) is configured
   /// to return 1 neighbor on either side of the current phi-bin (and you want
   /// to cover the full phi-range of minPT), leave this at 1.
-  int phiBinDeflectionCoverage = 1;
+  std::uint32_t phiBinDeflectionCoverage = 1;
   /// maximum number of phi bins
-  int maxPhiBins = 10000;
+  std::uint32_t maxPhiBins = 10000;
 };
 
 /// Compute the number of phi bins of a space point grid such that each bin
@@ -45,7 +47,8 @@ struct SpacePointGridPhiBinningConfig {
 /// @param config Parameters the phi bin count is derived from
 /// @param logger Logger instance for debugging output
 /// @return The number of phi bins, capped at `config.maxPhiBins`
-int computeSpacePointGridPhiBins(const SpacePointGridPhiBinningConfig& config,
-                                 const Logger& logger = getDummyLogger());
+std::uint32_t computeSpacePointGridPhiBins(
+    const SpacePointGridPhiBinningConfig& config,
+    const Logger& logger = getDummyLogger());
 
 }  // namespace Acts::detail

--- a/Core/src/Seeding/CartesianSpacePointGrid.cpp
+++ b/Core/src/Seeding/CartesianSpacePointGrid.cpp
@@ -44,8 +44,8 @@ CartesianSpacePointGrid::CartesianSpacePointGrid(
 
   GridType grid(
       std::make_tuple(std::move(xAxis), std::move(yAxis), std::move(zAxis)));
-  initializeGrid(std::move(grid), m_cfg.bottomBinFinder.value(),
-                 m_cfg.topBinFinder.value(), m_cfg.navigation);
+  initializeGrid(std::move(grid), m_cfg.bottomBinFinder, m_cfg.topBinFinder,
+                 m_cfg.navigation);
   m_sortCoordGetter = [c = m_cfg.sortingCoord, d = m_cfg.sortingDirection](
                           const ConstSpacePointProxy& p) {
     return d * p.xyz()[c];

--- a/Core/src/Seeding/CylindricalSpacePointGrid.cpp
+++ b/Core/src/Seeding/CylindricalSpacePointGrid.cpp
@@ -17,26 +17,26 @@ CylindricalSpacePointGrid::CylindricalSpacePointGrid(
     : GridBase(std::move(_logger)), m_cfg(config) {
   if (m_cfg.phiMin < -std::numbers::pi_v<float> ||
       m_cfg.phiMax > std::numbers::pi_v<float>) {
-    throw std::runtime_error(
+    throw std::invalid_argument(
         "CylindricalSpacePointGrid: phiMin (" + std::to_string(m_cfg.phiMin) +
         ") and/or phiMax (" + std::to_string(m_cfg.phiMax) +
         ") are outside the allowed phi range, defined as "
         "[-std::numbers::pi_v<float>, std::numbers::pi_v<float>]");
   }
   if (m_cfg.phiMin > m_cfg.phiMax) {
-    throw std::runtime_error(
+    throw std::invalid_argument(
         "CylindricalSpacePointGrid: phiMin is bigger then phiMax");
   }
   if (m_cfg.rMin > m_cfg.rMax) {
-    throw std::runtime_error(
+    throw std::invalid_argument(
         "CylindricalSpacePointGrid: rMin is bigger then rMax");
   }
   if (m_cfg.zMin > m_cfg.zMax) {
-    throw std::runtime_error(
+    throw std::invalid_argument(
         "CylindricalSpacePointGrid: zMin is bigger than zMax");
   }
 
-  const int phiBins = detail::computeSpacePointGridPhiBins(
+  const std::uint32_t phiBins = detail::computeSpacePointGridPhiBins(
       {.minPt = m_cfg.minPt,
        .bFieldInZ = m_cfg.bFieldInZ,
        .rMax = m_cfg.rMax,
@@ -94,8 +94,8 @@ CylindricalSpacePointGrid::CylindricalSpacePointGrid(
 
   GridType grid(
       std::make_tuple(std::move(phiAxis), std::move(zAxis), std::move(rAxis)));
-  initializeGrid(std::move(grid), m_cfg.bottomBinFinder.value(),
-                 m_cfg.topBinFinder.value(), m_cfg.navigation);
+  initializeGrid(std::move(grid), m_cfg.bottomBinFinder, m_cfg.topBinFinder,
+                 m_cfg.navigation);
 }
 
 void CylindricalSpacePointGrid::sortBinsByR(

--- a/Core/src/Seeding/SphericalSpacePointGrid.cpp
+++ b/Core/src/Seeding/SphericalSpacePointGrid.cpp
@@ -19,26 +19,26 @@ SphericalSpacePointGrid::SphericalSpacePointGrid(
     : GridBase(std::move(_logger)), m_cfg(config) {
   if (m_cfg.phiMin < -std::numbers::pi_v<float> ||
       m_cfg.phiMax > std::numbers::pi_v<float>) {
-    throw std::runtime_error(
+    throw std::invalid_argument(
         "SphericalSpacePointGrid: phiMin (" + std::to_string(m_cfg.phiMin) +
         ") and/or phiMax (" + std::to_string(m_cfg.phiMax) +
         ") are outside the allowed phi range, defined as "
         "[-std::numbers::pi_v<float>, std::numbers::pi_v<float>]");
   }
   if (m_cfg.phiMin > m_cfg.phiMax) {
-    throw std::runtime_error(
+    throw std::invalid_argument(
         "SphericalSpacePointGrid: phiMin is bigger then phiMax");
   }
   if (m_cfg.rMin > m_cfg.rMax) {
-    throw std::runtime_error(
+    throw std::invalid_argument(
         "SphericalSpacePointGrid: rMin is bigger then rMax");
   }
   if (m_cfg.etaMin > m_cfg.etaMax) {
-    throw std::runtime_error(
+    throw std::invalid_argument(
         "SphericalSpacePointGrid: etaMin is bigger than etaMax");
   }
 
-  const int phiBins = Acts::detail::computeSpacePointGridPhiBins(
+  const std::uint32_t phiBins = Acts::detail::computeSpacePointGridPhiBins(
       {.minPt = m_cfg.minPt,
        .bFieldInZ = m_cfg.bFieldInZ,
        .rMax = m_cfg.rMax,
@@ -57,7 +57,7 @@ SphericalSpacePointGrid::SphericalSpacePointGrid(
 
   // If etaBinEdges is not defined, calculate equidistant eta edges.
   if (m_cfg.etaBinEdges.empty()) {
-    const float etaBinSize = m_cfg.deltaEtaMax;
+    const float etaBinSize = m_cfg.etaBinSize;
     const float etaBins =
         std::max(1.f, std::floor((m_cfg.etaMax - m_cfg.etaMin) / etaBinSize));
 
@@ -94,8 +94,8 @@ SphericalSpacePointGrid::SphericalSpacePointGrid(
 
   GridType grid(std::make_tuple(std::move(phiAxis), std::move(cotThetaAxis),
                                 std::move(rAxis)));
-  initializeGrid(std::move(grid), m_cfg.bottomBinFinder.value(),
-                 m_cfg.topBinFinder.value(), m_cfg.navigation);
+  initializeGrid(std::move(grid), m_cfg.bottomBinFinder, m_cfg.topBinFinder,
+                 m_cfg.navigation);
 }
 
 void SphericalSpacePointGrid::sortBinsByR(

--- a/Core/src/Seeding/detail/SpacePointGridPhiBinning.cpp
+++ b/Core/src/Seeding/detail/SpacePointGridPhiBinning.cpp
@@ -17,8 +17,8 @@
 
 namespace Acts::detail {
 
-int computeSpacePointGridPhiBins(const SpacePointGridPhiBinningConfig& config,
-                                 const Logger& logger) {
+std::uint32_t computeSpacePointGridPhiBins(
+    const SpacePointGridPhiBinningConfig& config, const Logger& logger) {
   if (config.bFieldInZ == 0) {
     // for no magnetic field, use the maximum number of phi bins
     ACTS_VERBOSE(
@@ -87,8 +87,8 @@ int computeSpacePointGridPhiBins(const SpacePointGridPhiBinningConfig& config,
 
   // divide 2pi by angle delta to get number of phi-bins
   // size is always 2pi even for regions of interest
-  const int phiBins =
-      static_cast<int>(std::ceil(2 * std::numbers::pi / deltaPhi));
+  const auto phiBins =
+      static_cast<std::uint32_t>(std::ceil(2 * std::numbers::pi / deltaPhi));
 
   // set protection for large number of bins, by default it is large
   return std::min(phiBins, config.maxPhiBins);

--- a/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/GridTripletSeedingAlgorithm.hpp
+++ b/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/GridTripletSeedingAlgorithm.hpp
@@ -12,7 +12,6 @@
 #include "Acts/Seeding/CylindricalSpacePointGrid.hpp"
 #include "Acts/Seeding/SeedConfirmationRangeConfig.hpp"
 #include "Acts/Seeding/TripletSeeder.hpp"
-#include "Acts/Utilities/GridBinFinder.hpp"
 #include "Acts/Utilities/Logger.hpp"
 #include "ActsExamples/EventData/Seed.hpp"
 #include "ActsExamples/EventData/SpacePoint.hpp"
@@ -21,6 +20,7 @@
 #include "ActsExamples/Framework/IAlgorithm.hpp"
 #include "ActsExamples/Framework/ProcessCode.hpp"
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <utility>
@@ -90,9 +90,9 @@ class GridTripletSeedingAlgorithm final : public IAlgorithm {
     /// numPhiNeighbors (in the configuration of the BinFinders) is configured
     /// to return 1 neighbor on either side of the current phi-bin (and you want
     /// to cover the full phi-range of minPT), leave this at 1.
-    int phiBinDeflectionCoverage = 1;
+    std::uint32_t phiBinDeflectionCoverage = 1;
     /// maximum number of phi bins
-    int maxPhiBins = 10000;
+    std::uint32_t maxPhiBins = 10000;
 
     /// vector containing the map of z bins in the top and bottom layers
     std::vector<std::pair<int, int>> zBinNeighborsTop;
@@ -184,11 +184,11 @@ class GridTripletSeedingAlgorithm final : public IAlgorithm {
     /// Maximum number (minus one) of accepted seeds per middle space-point
     /// In dense environments many seeds may be found per middle space-point
     /// Only seeds with the highest weight will be kept if this limit is reached
-    unsigned int maxSeedsPerSpM = 5;
+    std::uint32_t maxSeedsPerSpM = 5;
     /// Maximum limit to number of compatible space-point used in score
     /// calculation. We increase by c1 the weight calculation for each
     /// compatible space-point until we reach compatSeedLimit
-    std::size_t compatSeedLimit = 2;
+    std::uint32_t compatSeedLimit = 2;
 
     /// Increment in seed weight if the number of compatible seeds is larger
     /// than numSeedIncrement, this is used in case of high occupancy scenarios
@@ -263,11 +263,9 @@ class GridTripletSeedingAlgorithm final : public IAlgorithm {
   Config m_cfg;
   Acts::CylindricalSpacePointGrid::Config m_gridConfig;
 
-  std::unique_ptr<const Acts::GridBinFinder<3ul>> m_bottomBinFinder{nullptr};
-  std::unique_ptr<const Acts::GridBinFinder<3ul>> m_topBinFinder{nullptr};
   Acts::BroadTripletSeedFilter::Config m_filterConfig;
   std::unique_ptr<const Acts::Logger> m_filterLogger;
-  std::optional<Acts::TripletSeeder> m_seedFinder;
+  Acts::TripletSeeder m_seedFinder;
 
   Acts::Delegate<bool(const ConstSpacePointProxy&)> m_spacePointSelector;
 

--- a/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/HashingPrototypeSeedingAlgorithm.hpp
+++ b/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/HashingPrototypeSeedingAlgorithm.hpp
@@ -17,6 +17,7 @@
 #include "ActsExamples/Framework/IAlgorithm.hpp"
 #include "ActsExamples/Framework/ProcessCode.hpp"
 
+#include <cstdint>
 #include <memory>
 #include <string>
 
@@ -120,11 +121,11 @@ class HashingPrototypeSeedingAlgorithm final : public IAlgorithm {
     /// Maximum number (minus one) of accepted seeds per middle space-point
     /// In dense environments many seeds may be found per middle space-point
     /// Only seeds with the highest weight will be kept if this limit is reached
-    unsigned int maxSeedsPerSpM = 5;
+    std::uint32_t maxSeedsPerSpM = 5;
     /// Maximum limit to number of compatible space-point used in score
     /// calculation. We increase by c1 the weight calculation for each
     /// compatible space-point until we reach compatSeedLimit
-    std::size_t compatSeedLimit = 2;
+    std::uint32_t compatSeedLimit = 2;
 
     /// Increment in seed weight if the number of compatible seeds is larger
     /// than numSeedIncrement, this is used in case of high occupancy scenarios

--- a/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/OrthogonalTripletSeedingAlgorithm.hpp
+++ b/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/OrthogonalTripletSeedingAlgorithm.hpp
@@ -18,6 +18,7 @@
 #include "ActsExamples/Framework/IAlgorithm.hpp"
 #include "ActsExamples/Framework/ProcessCode.hpp"
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
@@ -167,11 +168,11 @@ class OrthogonalTripletSeedingAlgorithm final : public IAlgorithm {
     /// Maximum number (minus one) of accepted seeds per middle space-point
     /// In dense environments many seeds may be found per middle space-point
     /// Only seeds with the highest weight will be kept if this limit is reached
-    unsigned int maxSeedsPerSpM = 5;
+    std::uint32_t maxSeedsPerSpM = 5;
     /// Maximum limit to number of compatible space-point used in score
     /// calculation. We increase by c1 the weight calculation for each
     /// compatible space-point until we reach compatSeedLimit
-    std::size_t compatSeedLimit = 2;
+    std::uint32_t compatSeedLimit = 2;
 
     /// Increment in seed weight if the number of compatible seeds is larger
     /// than numSeedIncrement, this is used in case of high occupancy scenarios

--- a/Examples/Algorithms/TrackFinding/src/GridTripletSeedingAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFinding/src/GridTripletSeedingAlgorithm.cpp
@@ -145,10 +145,10 @@ GridTripletSeedingAlgorithm::GridTripletSeedingAlgorithm(
   m_gridConfig.rBinEdges = {};
   m_gridConfig.zBinEdges = m_cfg.zBinEdges;
   m_gridConfig.bFieldInZ = m_cfg.bFieldInZ;
-  m_gridConfig.bottomBinFinder.emplace(m_cfg.numPhiNeighbors,
-                                       m_cfg.zBinNeighborsBottom, 0);
-  m_gridConfig.topBinFinder.emplace(m_cfg.numPhiNeighbors,
-                                    m_cfg.zBinNeighborsTop, 0);
+  m_gridConfig.bottomBinFinder = Acts::GridBinFinder<3ul>(
+      m_cfg.numPhiNeighbors, m_cfg.zBinNeighborsBottom, 0);
+  m_gridConfig.topBinFinder = Acts::GridBinFinder<3ul>(
+      m_cfg.numPhiNeighbors, m_cfg.zBinNeighborsTop, 0);
   m_gridConfig.navigation[0ul] = {};
   m_gridConfig.navigation[1ul] = m_cfg.zBinsCustomLooping;
   m_gridConfig.navigation[2ul] = {};
@@ -373,7 +373,7 @@ ProcessCode GridTripletSeedingAlgorithm::execute(
                  << radiusRangeForMiddle.first << ", "
                  << radiusRangeForMiddle.second << "]");
 
-    m_seedFinder->createSeedsFromGroups(
+    m_seedFinder.createSeedsFromGroups(
         cache, *bottomDoubletFinder, *topDoubletFinder, *tripletFinder,
         seedFilter, coreSpacePoints, bottomSpRanges, *middleSpRange,
         topSpRanges, radiusRangeForMiddle, seeds);

--- a/Plugins/Json/include/ActsPlugins/Json/SeedingConfigJsonConverter.hpp
+++ b/Plugins/Json/include/ActsPlugins/Json/SeedingConfigJsonConverter.hpp
@@ -31,14 +31,6 @@ void to_json(nlohmann::json& j, const SeedConfirmationRangeConfig& config);
 /// @param config Destination SeedConfirmationRangeConfig to populate
 void from_json(const nlohmann::json& j, SeedConfirmationRangeConfig& config);
 
-/// @}
-}  // namespace Acts
-
-namespace Acts::Experimental {
-
-/// @ingroup json_plugin
-/// @{
-
 /// Convert DoubletSeedFinder::Config to JSON
 /// @param j Destination JSON object
 /// @param config Source DoubletSeedFinder::Config to convert
@@ -95,4 +87,4 @@ void from_json(const nlohmann::json& j,
 
 /// @}
 
-}  // namespace Acts::Experimental
+}  // namespace Acts

--- a/Plugins/Json/src/SeedingConfigJsonConverter.cpp
+++ b/Plugins/Json/src/SeedingConfigJsonConverter.cpp
@@ -89,8 +89,8 @@ void Acts::from_json(const nlohmann::json& j,
   j["minImpactSeedConf"].get_to(config.minImpactSeedConf);
 }
 
-void Acts::Experimental::to_json(nlohmann::json& j,
-                                 const DoubletSeedFinder::Config& config) {
+void Acts::to_json(nlohmann::json& j, const DoubletSeedFinder::Config& config) {
+  j["spacePointsSortedByRadius"] = config.spacePointsSortedByRadius;
   j["candidateDirection"] = config.candidateDirection;
   j["deltaRMin"] = config.deltaRMin;
   j["deltaRMax"] = config.deltaRMax;
@@ -106,27 +106,27 @@ void Acts::Experimental::to_json(nlohmann::json& j,
   // experiment cuts cannot be serialized directly, so we skip it
 }
 
-void Acts::Experimental::to_json(
-    nlohmann::json& j, const DoubletSeedFinder::DerivedConfig& config) {
+void Acts::to_json(nlohmann::json& j,
+                   const DoubletSeedFinder::DerivedConfig& config) {
   to_json(j, static_cast<const DoubletSeedFinder::Config&>(config));
   j["bFieldInZ"] = config.bFieldInZ;
   j["minHelixDiameter2"] = config.minHelixDiameter2;
 }
 
-void Acts::Experimental::to_json(nlohmann::json& j,
-                                 const TripletSeedFinder::Config& config) {
+void Acts::to_json(nlohmann::json& j, const TripletSeedFinder::Config& config) {
   j["minPt"] = config.minPt;
   j["sigmaScattering"] = config.sigmaScattering;
   j["radLengthPerSeed"] = config.radLengthPerSeed;
   j["impactMax"] = config.impactMax;
   j["helixCutTolerance"] = config.helixCutTolerance;
   j["toleranceParam"] = config.toleranceParam;
+  j["cotThetaDiffMax"] = config.cotThetaDiffMax;
   j["useStripInfo"] = config.useStripInfo;
   j["sortedByCotTheta"] = config.sortedByCotTheta;
 }
 
-void Acts::Experimental::to_json(
-    nlohmann::json& j, const TripletSeedFinder::DerivedConfig& config) {
+void Acts::to_json(nlohmann::json& j,
+                   const TripletSeedFinder::DerivedConfig& config) {
   to_json(j, static_cast<const TripletSeedFinder::Config&>(config));
   j["bFieldInZ"] = config.bFieldInZ;
   j["highland"] = config.highland;
@@ -136,8 +136,8 @@ void Acts::Experimental::to_json(
   j["multipleScattering2"] = config.multipleScattering2;
 }
 
-void Acts::Experimental::to_json(nlohmann::json& j,
-                                 const BroadTripletSeedFilter::Config& config) {
+void Acts::to_json(nlohmann::json& j,
+                   const BroadTripletSeedFilter::Config& config) {
   j["deltaInvHelixDiameter"] = config.deltaInvHelixDiameter;
   j["deltaRMin"] = config.deltaRMin;
   j["compatSeedWeight"] = config.compatSeedWeight;
@@ -147,6 +147,8 @@ void Acts::Experimental::to_json(nlohmann::json& j,
   j["compatSeedLimit"] = config.compatSeedLimit;
   j["seedWeightIncrement"] = config.seedWeightIncrement;
   j["numSeedIncrement"] = config.numSeedIncrement;
+  j["absDeltaEtaWeightFactor"] = config.absDeltaEtaWeightFactor;
+  j["absDeltaEtaMinImpact"] = config.absDeltaEtaMinImpact;
   j["seedConfirmation"] = config.seedConfirmation;
   j["centralSeedConfirmationRange"] = config.centralSeedConfirmationRange;
   j["forwardSeedConfirmationRange"] = config.forwardSeedConfirmationRange;
@@ -156,8 +158,8 @@ void Acts::Experimental::to_json(nlohmann::json& j,
   // experiment cuts cannot be serialized directly, so we skip it
 }
 
-void Acts::Experimental::to_json(
-    nlohmann::json& j, const CylindricalSpacePointGrid::Config& config) {
+void Acts::to_json(nlohmann::json& j,
+                   const CylindricalSpacePointGrid::Config& config) {
   j["minPt"] = config.minPt;
   j["rMin"] = config.rMin;
   j["rMax"] = config.rMax;
@@ -173,17 +175,14 @@ void Acts::Experimental::to_json(
   j["zBinEdges"] = config.zBinEdges;
   j["rBinEdges"] = config.rBinEdges;
   j["bFieldInZ"] = config.bFieldInZ;
-  if (config.bottomBinFinder.has_value()) {
-    ::to_json(j["bottomBinFinder"], config.bottomBinFinder.value());
-  }
-  if (config.topBinFinder.has_value()) {
-    ::to_json(j["topBinFinder"], config.topBinFinder.value());
-  }
+  ::to_json(j["bottomBinFinder"], config.bottomBinFinder);
+  ::to_json(j["topBinFinder"], config.topBinFinder);
   j["navigation"] = config.navigation;
 }
 
-void Acts::Experimental::from_json(const nlohmann::json& j,
-                                   DoubletSeedFinder::Config& config) {
+void Acts::from_json(const nlohmann::json& j,
+                     DoubletSeedFinder::Config& config) {
+  j["spacePointsSortedByRadius"].get_to(config.spacePointsSortedByRadius);
   j["candidateDirection"].get_to(config.candidateDirection);
   j["deltaRMin"].get_to(config.deltaRMin);
   j["deltaRMax"].get_to(config.deltaRMax);
@@ -199,27 +198,28 @@ void Acts::Experimental::from_json(const nlohmann::json& j,
   // experiment cuts cannot be serialized directly, so we skip it
 }
 
-void Acts::Experimental::from_json(const nlohmann::json& j,
-                                   DoubletSeedFinder::DerivedConfig& config) {
+void Acts::from_json(const nlohmann::json& j,
+                     DoubletSeedFinder::DerivedConfig& config) {
   from_json(j, static_cast<DoubletSeedFinder::Config&>(config));
   j["bFieldInZ"].get_to(config.bFieldInZ);
   j["minHelixDiameter2"].get_to(config.minHelixDiameter2);
 }
 
-void Acts::Experimental::from_json(const nlohmann::json& j,
-                                   TripletSeedFinder::Config& config) {
+void Acts::from_json(const nlohmann::json& j,
+                     TripletSeedFinder::Config& config) {
   j["minPt"].get_to(config.minPt);
   j["sigmaScattering"].get_to(config.sigmaScattering);
   j["radLengthPerSeed"].get_to(config.radLengthPerSeed);
   j["impactMax"].get_to(config.impactMax);
   j["helixCutTolerance"].get_to(config.helixCutTolerance);
   j["toleranceParam"].get_to(config.toleranceParam);
+  j["cotThetaDiffMax"].get_to(config.cotThetaDiffMax);
   j["useStripInfo"].get_to(config.useStripInfo);
   j["sortedByCotTheta"].get_to(config.sortedByCotTheta);
 }
 
-void Acts::Experimental::from_json(const nlohmann::json& j,
-                                   TripletSeedFinder::DerivedConfig& config) {
+void Acts::from_json(const nlohmann::json& j,
+                     TripletSeedFinder::DerivedConfig& config) {
   from_json(j, static_cast<TripletSeedFinder::Config&>(config));
   j["bFieldInZ"].get_to(config.bFieldInZ);
   j["highland"].get_to(config.highland);
@@ -229,8 +229,8 @@ void Acts::Experimental::from_json(const nlohmann::json& j,
   j["multipleScattering2"].get_to(config.multipleScattering2);
 }
 
-void Acts::Experimental::from_json(const nlohmann::json& j,
-                                   BroadTripletSeedFilter::Config& config) {
+void Acts::from_json(const nlohmann::json& j,
+                     BroadTripletSeedFilter::Config& config) {
   j["deltaInvHelixDiameter"].get_to(config.deltaInvHelixDiameter);
   j["deltaRMin"].get_to(config.deltaRMin);
   j["compatSeedWeight"].get_to(config.compatSeedWeight);
@@ -240,6 +240,8 @@ void Acts::Experimental::from_json(const nlohmann::json& j,
   j["compatSeedLimit"].get_to(config.compatSeedLimit);
   j["seedWeightIncrement"].get_to(config.seedWeightIncrement);
   j["numSeedIncrement"].get_to(config.numSeedIncrement);
+  j["absDeltaEtaWeightFactor"].get_to(config.absDeltaEtaWeightFactor);
+  j["absDeltaEtaMinImpact"].get_to(config.absDeltaEtaMinImpact);
   j["seedConfirmation"].get_to(config.seedConfirmation);
   j["centralSeedConfirmationRange"].get_to(config.centralSeedConfirmationRange);
   j["forwardSeedConfirmationRange"].get_to(config.forwardSeedConfirmationRange);
@@ -249,8 +251,8 @@ void Acts::Experimental::from_json(const nlohmann::json& j,
   // experiment cuts cannot be serialized directly, so we skip it
 }
 
-void Acts::Experimental::from_json(const nlohmann::json& j,
-                                   CylindricalSpacePointGrid::Config& config) {
+void Acts::from_json(const nlohmann::json& j,
+                     CylindricalSpacePointGrid::Config& config) {
   j["minPt"].get_to(config.minPt);
   j["rMin"].get_to(config.rMin);
   j["rMax"].get_to(config.rMax);
@@ -266,11 +268,7 @@ void Acts::Experimental::from_json(const nlohmann::json& j,
   j["zBinEdges"].get_to(config.zBinEdges);
   j["rBinEdges"].get_to(config.rBinEdges);
   j["bFieldInZ"].get_to(config.bFieldInZ);
-  if (j.contains("bottomBinFinder")) {
-    config.bottomBinFinder = ::from_json<3ul>(j["bottomBinFinder"]);
-  }
-  if (j.contains("topBinFinder")) {
-    config.topBinFinder = ::from_json<3ul>(j["topBinFinder"]);
-  }
+  config.bottomBinFinder = ::from_json<3ul>(j["bottomBinFinder"]);
+  config.topBinFinder = ::from_json<3ul>(j["topBinFinder"]);
   j["navigation"].get_to(config.navigation);
 }

--- a/Tests/UnitTests/Core/Seeding/SpacePointGridPhiBinningTests.cpp
+++ b/Tests/UnitTests/Core/Seeding/SpacePointGridPhiBinningTests.cpp
@@ -11,6 +11,7 @@
 #include "Acts/Definitions/Units.hpp"
 #include "Acts/Seeding/detail/SpacePointGridPhiBinning.hpp"
 
+#include <cstdint>
 #include <stdexcept>
 
 using namespace Acts::UnitLiterals;
@@ -41,19 +42,19 @@ BOOST_AUTO_TEST_CASE(ZeroFieldUsesMaxPhiBins) {
   auto config = makeConfig();
   config.bFieldInZ = 0;
   config.maxPhiBins = 42;
-  BOOST_CHECK_EQUAL(detail::computeSpacePointGridPhiBins(config), 42);
+  BOOST_CHECK_EQUAL(detail::computeSpacePointGridPhiBins(config), 42u);
 }
 
 BOOST_AUTO_TEST_CASE(BaselineGivesFinitePositiveBinCount) {
   const auto config = makeConfig();
-  const int phiBins = detail::computeSpacePointGridPhiBins(config);
-  BOOST_CHECK_GT(phiBins, 1);
+  const std::uint32_t phiBins = detail::computeSpacePointGridPhiBins(config);
+  BOOST_CHECK_GT(phiBins, 1u);
   BOOST_CHECK_LE(phiBins, config.maxPhiBins);
 }
 
 BOOST_AUTO_TEST_CASE(MaxPhiBinsCapsResult) {
   auto config = makeConfig();
-  const int uncapped = detail::computeSpacePointGridPhiBins(config);
+  const std::uint32_t uncapped = detail::computeSpacePointGridPhiBins(config);
   config.maxPhiBins = uncapped - 1;
   BOOST_CHECK_EQUAL(detail::computeSpacePointGridPhiBins(config),
                     config.maxPhiBins);
@@ -61,9 +62,11 @@ BOOST_AUTO_TEST_CASE(MaxPhiBinsCapsResult) {
 
 BOOST_AUTO_TEST_CASE(DeflectionCoverageIncreasesBinCount) {
   auto config = makeConfig();
-  const int singleCoverage = detail::computeSpacePointGridPhiBins(config);
+  const std::uint32_t singleCoverage =
+      detail::computeSpacePointGridPhiBins(config);
   config.phiBinDeflectionCoverage = 2;
-  const int doubleCoverage = detail::computeSpacePointGridPhiBins(config);
+  const std::uint32_t doubleCoverage =
+      detail::computeSpacePointGridPhiBins(config);
   BOOST_CHECK_GT(doubleCoverage, singleCoverage);
 }
 
@@ -73,8 +76,8 @@ BOOST_AUTO_TEST_CASE(DeflectionCoverageIncreasesBinCount) {
 BOOST_AUTO_TEST_CASE(LargeImpactParameterStaysFinite) {
   auto config = makeConfig();
   config.impactMax = config.rMax;
-  const int phiBins = detail::computeSpacePointGridPhiBins(config);
-  BOOST_CHECK_GT(phiBins, 0);
+  const std::uint32_t phiBins = detail::computeSpacePointGridPhiBins(config);
+  BOOST_CHECK_GT(phiBins, 0u);
   BOOST_CHECK_LE(phiBins, config.maxPhiBins);
 }
 

--- a/Tests/UnitTests/Core/Seeding/SphericalSpacePointGridTests.cpp
+++ b/Tests/UnitTests/Core/Seeding/SphericalSpacePointGridTests.cpp
@@ -34,8 +34,6 @@ Acts::Experimental::SphericalSpacePointGrid::Config makeConfig() {
   cfg.etaMax = 3.f;
   cfg.etaBinEdges = {-3.f, -1.f, 0.f, 1.f, 3.f};
   cfg.rBinEdges = {0.f, 100.f, 200.f};
-  cfg.bottomBinFinder.emplace(1, 1, 0);
-  cfg.topBinFinder.emplace(1, 1, 0);
   return cfg;
 }
 
@@ -90,12 +88,12 @@ BOOST_AUTO_TEST_CASE(OutOfAcceptanceHasNoBin) {
 }
 
 // When etaBinEdges is empty the grid builds equidistant eta bins from
-// etaMin/etaMax with deltaEtaMax width (the default production path). It must
+// etaMin/etaMax with etaBinSize width (the default production path). It must
 // still bin in eta.
 BOOST_AUTO_TEST_CASE(UniformEtaFallback) {
   auto cfg = makeConfig();
   cfg.etaBinEdges.clear();
-  cfg.deltaEtaMax = 0.5f;  // etaMin=-3 .. etaMax=3 -> 12 bins
+  cfg.etaBinSize = 0.5f;  // etaMin=-3 .. etaMax=3 -> 12 bins
   Acts::Experimental::SphericalSpacePointGrid grid(cfg);
 
   BOOST_CHECK_GT(grid.numberOfBins(), 0u);


### PR DESCRIPTION
A pass over the configuration surface of the triplet seeder and the space
point grids. Seeding output is unchanged.

The three space point grid configs held the bottom and top bin finder in a
`std::optional`, although neither is optional: every constructor calls
`.value()` unconditionally, so forgetting one surfaced as an unmessaged
`std::bad_optional_access`. They are plain members now, with a default member
initializer giving one neighbour on either side per axis, which is what every
call site already set.

The grids are no longer copyable or movable. `BinnedGroup` keeps pointers to
the bin finders, which live in the grid's own copy of the config, and the base
class keeps a pointer into the binned group, so a move left both referring to
the source object.

`spacePointsSortedByRadius`, `cotThetaDiffMax`, `absDeltaEtaWeightFactor` and
`absDeltaEtaMinImpact` were missing from the seeding JSON converters and reset
to their defaults on a round trip. The converters themselves moved from
`Acts::Experimental` to `Acts`, where the types they convert live, so that ADL
can find them at all.

The rest is consistency. Config validation in the cylindrical and spherical
grids throws `std::invalid_argument` like the cartesian one and `BinnedGroup`.
The seeding configs use fixed width integers, and the grid dimension comes from
the grid type instead of a hard coded `3ul`. `deltaEtaMax` is a bin width, so
it is `etaBinSize`. The doc comments for `useStripInfo`, `cotThetaDiffMax` and
`computeCoordRange` describe what the code does, and two dead members of
`GridTripletSeedingAlgorithm` are gone.