### PR TITLE
refactor!: Remove the hidden in/out views from the triplet seeding API

### DIFF
--- a/Core/include/Acts/Seeding/DoubletSeedFinder.hpp
+++ b/Core/include/Acts/Seeding/DoubletSeedFinder.hpp
@@ -378,11 +378,7 @@ class DoubletSeedFinder {
   /// @param middleSp Space point candidate to be used as middle SP in a seed
   /// @param middleSpInfo Information about the middle space point
   /// @param candidateSps Subset of space points to be used as candidates for
-  ///   middle SP in a seed. In-out: if the configuration declares the space
-  ///   points sorted by radius, the subset is advanced past the candidates
-  ///   that are out of radius range on return, so that a subsequent call with
-  ///   a larger middle radius does not look at them again. Pass a fresh view
-  ///   to start over.
+  ///   middle SP in a seed
   /// @param compatibleDoublets Output container for compatible doublets
   virtual void createDoublets(
       const ConstSpacePointProxy& middleSp, const MiddleSpInfo& middleSpInfo,
@@ -395,7 +391,7 @@ class DoubletSeedFinder {
   /// @param middleSp Space point candidate to be used as middle SP in a seed
   /// @param middleSpInfo Information about the middle space point
   /// @param candidateSps Range of space points to be used as candidates for
-  ///   middle SP in a seed. In-out, see the subset overload above.
+  ///   middle SP in a seed
   /// @param compatibleDoublets Output container for compatible doublets
   virtual void createDoublets(
       const ConstSpacePointProxy& middleSp, const MiddleSpInfo& middleSpInfo,

--- a/Core/include/Acts/Seeding/DoubletSeedFinder.hpp
+++ b/Core/include/Acts/Seeding/DoubletSeedFinder.hpp
@@ -382,7 +382,7 @@ class DoubletSeedFinder {
   /// @param compatibleDoublets Output container for compatible doublets
   virtual void createDoublets(
       const ConstSpacePointProxy& middleSp, const MiddleSpInfo& middleSpInfo,
-      SpacePointContainer::ConstSubset& candidateSps,
+      SpacePointContainer::ConstSubset candidateSps,
       DoubletsForMiddleSp& compatibleDoublets) const = 0;
 
   /// Creates compatible dublets by applying a series of cuts that can be
@@ -395,7 +395,7 @@ class DoubletSeedFinder {
   /// @param compatibleDoublets Output container for compatible doublets
   virtual void createDoublets(
       const ConstSpacePointProxy& middleSp, const MiddleSpInfo& middleSpInfo,
-      SpacePointContainer::ConstRange& candidateSps,
+      SpacePointContainer::ConstRange candidateSps,
       DoubletsForMiddleSp& compatibleDoublets) const = 0;
 };
 

--- a/Core/include/Acts/Seeding/DoubletSeedFinder.hpp
+++ b/Core/include/Acts/Seeding/DoubletSeedFinder.hpp
@@ -378,7 +378,11 @@ class DoubletSeedFinder {
   /// @param middleSp Space point candidate to be used as middle SP in a seed
   /// @param middleSpInfo Information about the middle space point
   /// @param candidateSps Subset of space points to be used as candidates for
-  ///   middle SP in a seed
+  ///   middle SP in a seed. In-out: if the configuration declares the space
+  ///   points sorted by radius, the subset is advanced past the candidates
+  ///   that are out of radius range on return, so that a subsequent call with
+  ///   a larger middle radius does not look at them again. Pass a fresh view
+  ///   to start over.
   /// @param compatibleDoublets Output container for compatible doublets
   virtual void createDoublets(
       const ConstSpacePointProxy& middleSp, const MiddleSpInfo& middleSpInfo,
@@ -391,7 +395,7 @@ class DoubletSeedFinder {
   /// @param middleSp Space point candidate to be used as middle SP in a seed
   /// @param middleSpInfo Information about the middle space point
   /// @param candidateSps Range of space points to be used as candidates for
-  ///   middle SP in a seed
+  ///   middle SP in a seed. In-out, see the subset overload above.
   /// @param compatibleDoublets Output container for compatible doublets
   virtual void createDoublets(
       const ConstSpacePointProxy& middleSp, const MiddleSpInfo& middleSpInfo,

--- a/Core/include/Acts/Seeding/TripletSeedFinder.hpp
+++ b/Core/include/Acts/Seeding/TripletSeedFinder.hpp
@@ -211,7 +211,12 @@ class TripletSeedFinder {
   /// @param spacePoints Space point container
   /// @param spM Space point candidate to be used as middle SP in a seed
   /// @param bottomDoublet Bottom doublet to be used for triplet creation
-  /// @param topDoublets Top doublets to be used for triplet creation
+  /// @param topDoublets Top doublets to be used for triplet creation. In-out:
+  ///   if the configuration declares the doublets sorted by cotTheta, the view
+  ///   is advanced past the top doublets that can no longer be compatible with
+  ///   any subsequent (larger cotTheta) bottom doublet, so the caller has to
+  ///   pass the doublets of one middle space point in ascending bottom
+  ///   cotTheta order and start over with a fresh view for the next one.
   /// @param tripletTopCandidates Cache for triplet top candidates
   virtual void createTripletTopCandidates(
       const SpacePointContainer& spacePoints, const ConstSpacePointProxy& spM,
@@ -224,7 +229,8 @@ class TripletSeedFinder {
   /// @param spacePoints Space point container
   /// @param spM Space point candidate to be used as middle SP in a seed
   /// @param bottomDoublet Bottom doublet to be used for triplet creation
-  /// @param topDoublets Top doublets to be used for triplet creation
+  /// @param topDoublets Top doublets to be used for triplet creation. In-out,
+  ///   see the range overload above.
   /// @param tripletTopCandidates Cache for triplet top candidates
   virtual void createTripletTopCandidates(
       const SpacePointContainer& spacePoints, const ConstSpacePointProxy& spM,
@@ -237,7 +243,8 @@ class TripletSeedFinder {
   /// @param spacePoints Space point container
   /// @param spM Space point candidate to be used as middle SP in a seed
   /// @param bottomDoublet Bottom doublet to be used for triplet creation
-  /// @param topDoublets Top doublets to be used for triplet creation
+  /// @param topDoublets Top doublets to be used for triplet creation. In-out,
+  ///   see the range overload above.
   /// @param tripletTopCandidates Cache for triplet top candidates
   virtual void createTripletTopCandidates(
       const SpacePointContainer& spacePoints, const ConstSpacePointProxy& spM,

--- a/Core/include/Acts/Seeding/TripletSeedFinder.hpp
+++ b/Core/include/Acts/Seeding/TripletSeedFinder.hpp
@@ -211,12 +211,7 @@ class TripletSeedFinder {
   /// @param spacePoints Space point container
   /// @param spM Space point candidate to be used as middle SP in a seed
   /// @param bottomDoublet Bottom doublet to be used for triplet creation
-  /// @param topDoublets Top doublets to be used for triplet creation. In-out:
-  ///   if the configuration declares the doublets sorted by cotTheta, the view
-  ///   is advanced past the top doublets that can no longer be compatible with
-  ///   any subsequent (larger cotTheta) bottom doublet, so the caller has to
-  ///   pass the doublets of one middle space point in ascending bottom
-  ///   cotTheta order and start over with a fresh view for the next one.
+  /// @param topDoublets Top doublets to be used for triplet creation
   /// @param tripletTopCandidates Cache for triplet top candidates
   virtual void createTripletTopCandidates(
       const SpacePointContainer& spacePoints, const ConstSpacePointProxy& spM,
@@ -229,8 +224,7 @@ class TripletSeedFinder {
   /// @param spacePoints Space point container
   /// @param spM Space point candidate to be used as middle SP in a seed
   /// @param bottomDoublet Bottom doublet to be used for triplet creation
-  /// @param topDoublets Top doublets to be used for triplet creation. In-out,
-  ///   see the range overload above.
+  /// @param topDoublets Top doublets to be used for triplet creation
   /// @param tripletTopCandidates Cache for triplet top candidates
   virtual void createTripletTopCandidates(
       const SpacePointContainer& spacePoints, const ConstSpacePointProxy& spM,
@@ -243,8 +237,7 @@ class TripletSeedFinder {
   /// @param spacePoints Space point container
   /// @param spM Space point candidate to be used as middle SP in a seed
   /// @param bottomDoublet Bottom doublet to be used for triplet creation
-  /// @param topDoublets Top doublets to be used for triplet creation. In-out,
-  ///   see the range overload above.
+  /// @param topDoublets Top doublets to be used for triplet creation
   /// @param tripletTopCandidates Cache for triplet top candidates
   virtual void createTripletTopCandidates(
       const SpacePointContainer& spacePoints, const ConstSpacePointProxy& spM,

--- a/Core/include/Acts/Seeding/TripletSeedFinder.hpp
+++ b/Core/include/Acts/Seeding/TripletSeedFinder.hpp
@@ -208,15 +208,24 @@ class TripletSeedFinder {
 
   /// Create triplets from the bottom, middle, and top space points.
   ///
+  /// @note If the configuration declares the doublets sorted by cotTheta, the
+  ///   returned view is the input advanced past the top doublets that can no
+  ///   longer be compatible with any bottom doublet of a larger cotTheta. A
+  ///   caller sweeping the bottom doublets in ascending cotTheta has to feed
+  ///   the returned view to the next call, and start over from the full
+  ///   collection for the next middle space point.
+  ///
   /// @param spacePoints Space point container
   /// @param spM Space point candidate to be used as middle SP in a seed
   /// @param bottomDoublet Bottom doublet to be used for triplet creation
   /// @param topDoublets Top doublets to be used for triplet creation
   /// @param tripletTopCandidates Cache for triplet top candidates
-  virtual void createTripletTopCandidates(
+  /// @return The top doublets that can still be compatible with a subsequent
+  ///   bottom doublet, see the note above
+  [[nodiscard]] virtual DoubletsForMiddleSp::Range createTripletTopCandidates(
       const SpacePointContainer& spacePoints, const ConstSpacePointProxy& spM,
       const DoubletsForMiddleSp::Proxy& bottomDoublet,
-      DoubletsForMiddleSp::Range& topDoublets,
+      DoubletsForMiddleSp::Range topDoublets,
       TripletTopCandidates& tripletTopCandidates) const = 0;
 
   /// Create triplets from the bottom, middle, and top space points.
@@ -226,10 +235,12 @@ class TripletSeedFinder {
   /// @param bottomDoublet Bottom doublet to be used for triplet creation
   /// @param topDoublets Top doublets to be used for triplet creation
   /// @param tripletTopCandidates Cache for triplet top candidates
-  virtual void createTripletTopCandidates(
+  /// @return The top doublets that can still be compatible with a subsequent
+  ///   bottom doublet, see the note above
+  [[nodiscard]] virtual DoubletsForMiddleSp::Subset createTripletTopCandidates(
       const SpacePointContainer& spacePoints, const ConstSpacePointProxy& spM,
       const DoubletsForMiddleSp::Proxy& bottomDoublet,
-      DoubletsForMiddleSp::Subset& topDoublets,
+      DoubletsForMiddleSp::Subset topDoublets,
       TripletTopCandidates& tripletTopCandidates) const = 0;
 
   /// Create triplets from the bottom, middle, and top space points.
@@ -239,10 +250,12 @@ class TripletSeedFinder {
   /// @param bottomDoublet Bottom doublet to be used for triplet creation
   /// @param topDoublets Top doublets to be used for triplet creation
   /// @param tripletTopCandidates Cache for triplet top candidates
-  virtual void createTripletTopCandidates(
+  /// @return The top doublets that can still be compatible with a subsequent
+  ///   bottom doublet, see the note above
+  [[nodiscard]] virtual DoubletsForMiddleSp::Subset2 createTripletTopCandidates(
       const SpacePointContainer& spacePoints, const ConstSpacePointProxy& spM,
       const DoubletsForMiddleSp::Proxy& bottomDoublet,
-      DoubletsForMiddleSp::Subset2& topDoublets,
+      DoubletsForMiddleSp::Subset2 topDoublets,
       TripletTopCandidates& tripletTopCandidates) const = 0;
 };
 

--- a/Core/include/Acts/Seeding/TripletSeeder.hpp
+++ b/Core/include/Acts/Seeding/TripletSeeder.hpp
@@ -63,9 +63,9 @@ class TripletSeeder {
                             const TripletSeedFinder& tripletFinder,
                             const ITripletSeedFilter& filter,
                             const SpacePointContainer& spacePoints,
-                            SpacePointContainer::ConstSubset bottomSps,
+                            SpacePointContainer::ConstSubset& bottomSps,
                             const ConstSpacePointProxy& middleSp,
-                            SpacePointContainer::ConstSubset topSps,
+                            SpacePointContainer::ConstSubset& topSps,
                             SeedContainer& outputSeeds) const;
 
   /// Create all possible seeds from bottom, middle, and top space points.

--- a/Core/include/Acts/Seeding/TripletSeeder.hpp
+++ b/Core/include/Acts/Seeding/TripletSeeder.hpp
@@ -38,6 +38,12 @@ class TripletSeeder {
 
     /// Cache for triplet top candidates during seed formation
     TripletTopCandidates tripletTopCandidates;
+
+    /// Cursors into the bottom and top space point groups of the current
+    /// call. Copied from the caller's groups by `createSeedsFromGroups` and
+    /// advanced as the middle space points are swept in ascending radius.
+    std::vector<SpacePointContainer::ConstRange> bottomSpGroups;
+    std::vector<SpacePointContainer::ConstRange> topSpGroups;
   };
 
   /// Construct a TripletSeeder with optional logger.
@@ -63,9 +69,9 @@ class TripletSeeder {
                             const TripletSeedFinder& tripletFinder,
                             const ITripletSeedFilter& filter,
                             const SpacePointContainer& spacePoints,
-                            SpacePointContainer::ConstSubset& bottomSps,
+                            SpacePointContainer::ConstSubset bottomSps,
                             const ConstSpacePointProxy& middleSp,
-                            SpacePointContainer::ConstSubset& topSps,
+                            SpacePointContainer::ConstSubset topSps,
                             SeedContainer& outputSeeds) const;
 
   /// Create all possible seeds from bottom, middle, and top space points.
@@ -86,9 +92,9 @@ class TripletSeeder {
       const DoubletSeedFinder& topFinder,
       const TripletSeedFinder& tripletFinder, const ITripletSeedFilter& filter,
       const SpacePointContainer& spacePoints,
-      const std::span<SpacePointContainer::ConstRange>& bottomSpGroups,
+      std::span<const SpacePointContainer::ConstRange> bottomSpGroups,
       const SpacePointContainer::ConstRange& middleSpGroup,
-      const std::span<SpacePointContainer::ConstRange>& topSpGroups,
+      std::span<const SpacePointContainer::ConstRange> topSpGroups,
       const std::pair<float, float>& radiusRangeForMiddle,
       SeedContainer& outputSeeds) const;
 

--- a/Core/include/Acts/Seeding/TripletSeeder.hpp
+++ b/Core/include/Acts/Seeding/TripletSeeder.hpp
@@ -63,9 +63,9 @@ class TripletSeeder {
                             const TripletSeedFinder& tripletFinder,
                             const ITripletSeedFilter& filter,
                             const SpacePointContainer& spacePoints,
-                            SpacePointContainer::ConstSubset& bottomSps,
+                            SpacePointContainer::ConstSubset bottomSps,
                             const ConstSpacePointProxy& middleSp,
-                            SpacePointContainer::ConstSubset& topSps,
+                            SpacePointContainer::ConstSubset topSps,
                             SeedContainer& outputSeeds) const;
 
   /// Create all possible seeds from bottom, middle, and top space points.

--- a/Core/src/Seeding/DoubletSeedFinder.cpp
+++ b/Core/src/Seeding/DoubletSeedFinder.cpp
@@ -35,13 +35,12 @@ class Impl final : public DoubletSeedFinder {
   /// @param middleSp Space point candidate to be used as middle SP in a seed
   /// @param middleSpInfo Information about the middle space point
   /// @param candidateSps Range or subet of space points to be used as candidates
-  ///   for middle SP in a seed. In case of `sortedByR` - an offset will be
-  ///   applied based on the middle SP radius.
+  ///   for middle SP in a seed
   /// @param compatibleDoublets Output container for compatible doublets
   template <typename CandidateSps>
   void createDoubletsImpl(const ConstSpacePointProxy& middleSp,
                           const MiddleSpInfo& middleSpInfo,
-                          CandidateSps& candidateSps,
+                          CandidateSps candidateSps,
                           DoubletsForMiddleSp& compatibleDoublets) const {
     const float impactMax =
         isBottomCandidate ? -m_cfg.impactMax : m_cfg.impactMax;
@@ -69,28 +68,6 @@ class Impl final : public DoubletSeedFinder {
       return iDeltaR2 * ((varianceZM + varianceZO) +
                          (cotTheta * cotTheta) * (varianceRM + varianceRO));
     };
-
-    if constexpr (sortedByR) {
-      // find the first SP inside the radius region of interest and update
-      // the iterator so we don't need to look at the other SPs again
-      std::uint32_t offset = 0;
-      for (ConstSpacePointProxy otherSp : candidateSps) {
-        if constexpr (isBottomCandidate) {
-          // if r-distance is too big, try next SP in bin
-          if (rM - otherSp.zr()[1] <= m_cfg.deltaRMax) {
-            break;
-          }
-        } else {
-          // if r-distance is too small, try next SP in bin
-          if (otherSp.zr()[1] - rM >= m_cfg.deltaRMin) {
-            break;
-          }
-        }
-
-        ++offset;
-      }
-      candidateSps = candidateSps.subrange(offset);
-    }
 
     const SpacePointContainer& container = candidateSps.container();
     for (auto [indexO, xyO, zrO, varianceZO, varianceRO] : candidateSps.zip(
@@ -274,7 +251,7 @@ class Impl final : public DoubletSeedFinder {
 
   void createDoublets(const ConstSpacePointProxy& middleSp,
                       const MiddleSpInfo& middleSpInfo,
-                      SpacePointContainer::ConstSubset& candidateSps,
+                      SpacePointContainer::ConstSubset candidateSps,
                       DoubletsForMiddleSp& compatibleDoublets) const override {
     createDoubletsImpl(middleSp, middleSpInfo, candidateSps,
                        compatibleDoublets);
@@ -282,7 +259,7 @@ class Impl final : public DoubletSeedFinder {
 
   void createDoublets(const ConstSpacePointProxy& middleSp,
                       const MiddleSpInfo& middleSpInfo,
-                      SpacePointContainer::ConstRange& candidateSps,
+                      SpacePointContainer::ConstRange candidateSps,
                       DoubletsForMiddleSp& compatibleDoublets) const override {
     createDoubletsImpl(middleSp, middleSpInfo, candidateSps,
                        compatibleDoublets);

--- a/Core/src/Seeding/TripletSeedFinder.cpp
+++ b/Core/src/Seeding/TripletSeedFinder.cpp
@@ -32,9 +32,9 @@ class Impl final : public TripletSeedFinder {
   const DerivedConfig& config() const override { return m_cfg; }
 
   template <typename TopDoublets>
-  void createPixelTripletTopCandidates(
+  TopDoublets createPixelTripletTopCandidates(
       const ConstSpacePointProxy& spM,
-      const DoubletsForMiddleSp::Proxy& bottomDoublet, TopDoublets& topDoublets,
+      const DoubletsForMiddleSp::Proxy& bottomDoublet, TopDoublets topDoublets,
       TripletTopCandidates& tripletTopCandidates) const {
     const float rM = spM.zr()[1];
     const float varianceZM = spM.varianceZ();
@@ -159,12 +159,13 @@ class Impl final : public TripletSeedFinder {
       // remove the top doublets that were skipped due to cotTheta sorting
       topDoublets = topDoublets.subrange(topDoubletOffset);
     }
+    return topDoublets;
   }
 
   template <typename TopDoublets>
-  void createStripTripletTopCandidates(
+  TopDoublets createStripTripletTopCandidates(
       const SpacePointContainer& spacePoints, const ConstSpacePointProxy& spM,
-      const DoubletsForMiddleSp::Proxy& bottomDoublet, TopDoublets& topDoublets,
+      const DoubletsForMiddleSp::Proxy& bottomDoublet, TopDoublets topDoublets,
       TripletTopCandidates& tripletTopCandidates) const {
     const float rM = spM.zr()[1];
     const float cosPhiM = spM.xy()[0] / rM;
@@ -403,47 +404,48 @@ class Impl final : public TripletSeedFinder {
       // subsequent bottom doublet (which has a larger approximate cotTheta)
       topDoublets = topDoublets.subrange(topDoubletOffset);
     }
+    return topDoublets;
   }
 
-  void createTripletTopCandidates(
+  DoubletsForMiddleSp::Range createTripletTopCandidates(
       const SpacePointContainer& spacePoints, const ConstSpacePointProxy& spM,
       const DoubletsForMiddleSp::Proxy& bottomDoublet,
-      DoubletsForMiddleSp::Range& topDoublets,
+      DoubletsForMiddleSp::Range topDoublets,
       TripletTopCandidates& tripletTopCandidates) const override {
     if constexpr (useStripInfo) {
-      createStripTripletTopCandidates(spacePoints, spM, bottomDoublet,
-                                      topDoublets, tripletTopCandidates);
+      return createStripTripletTopCandidates(spacePoints, spM, bottomDoublet,
+                                             topDoublets, tripletTopCandidates);
     } else {
-      createPixelTripletTopCandidates(spM, bottomDoublet, topDoublets,
-                                      tripletTopCandidates);
+      return createPixelTripletTopCandidates(spM, bottomDoublet, topDoublets,
+                                             tripletTopCandidates);
     }
   }
 
-  void createTripletTopCandidates(
+  DoubletsForMiddleSp::Subset createTripletTopCandidates(
       const SpacePointContainer& spacePoints, const ConstSpacePointProxy& spM,
       const DoubletsForMiddleSp::Proxy& bottomDoublet,
-      DoubletsForMiddleSp::Subset& topDoublets,
+      DoubletsForMiddleSp::Subset topDoublets,
       TripletTopCandidates& tripletTopCandidates) const override {
     if constexpr (useStripInfo) {
-      createStripTripletTopCandidates(spacePoints, spM, bottomDoublet,
-                                      topDoublets, tripletTopCandidates);
+      return createStripTripletTopCandidates(spacePoints, spM, bottomDoublet,
+                                             topDoublets, tripletTopCandidates);
     } else {
-      createPixelTripletTopCandidates(spM, bottomDoublet, topDoublets,
-                                      tripletTopCandidates);
+      return createPixelTripletTopCandidates(spM, bottomDoublet, topDoublets,
+                                             tripletTopCandidates);
     }
   }
 
-  void createTripletTopCandidates(
+  DoubletsForMiddleSp::Subset2 createTripletTopCandidates(
       const SpacePointContainer& spacePoints, const ConstSpacePointProxy& spM,
       const DoubletsForMiddleSp::Proxy& bottomDoublet,
-      DoubletsForMiddleSp::Subset2& topDoublets,
+      DoubletsForMiddleSp::Subset2 topDoublets,
       TripletTopCandidates& tripletTopCandidates) const override {
     if constexpr (useStripInfo) {
-      createStripTripletTopCandidates(spacePoints, spM, bottomDoublet,
-                                      topDoublets, tripletTopCandidates);
+      return createStripTripletTopCandidates(spacePoints, spM, bottomDoublet,
+                                             topDoublets, tripletTopCandidates);
     } else {
-      createPixelTripletTopCandidates(spM, bottomDoublet, topDoublets,
-                                      tripletTopCandidates);
+      return createPixelTripletTopCandidates(spM, bottomDoublet, topDoublets,
+                                             tripletTopCandidates);
     }
   }
 

--- a/Core/src/Seeding/TripletSeeder.cpp
+++ b/Core/src/Seeding/TripletSeeder.cpp
@@ -119,10 +119,9 @@ void TripletSeeder::createSeedsFromGroup(
     Cache& cache, const DoubletSeedFinder& bottomFinder,
     const DoubletSeedFinder& topFinder, const TripletSeedFinder& tripletFinder,
     const ITripletSeedFilter& filter, const SpacePointContainer& spacePoints,
-    SpacePointContainer::ConstSubset& bottomSps,
+    SpacePointContainer::ConstSubset bottomSps,
     const ConstSpacePointProxy& middleSp,
-    SpacePointContainer::ConstSubset& topSps,
-    SeedContainer& outputSeeds) const {
+    SpacePointContainer::ConstSubset topSps, SeedContainer& outputSeeds) const {
   assert((bottomFinder.config().spacePointsSortedByRadius ==
           topFinder.config().spacePointsSortedByRadius) &&
          "Inconsistent space point sorting");

--- a/Core/src/Seeding/TripletSeeder.cpp
+++ b/Core/src/Seeding/TripletSeeder.cpp
@@ -119,9 +119,10 @@ void TripletSeeder::createSeedsFromGroup(
     Cache& cache, const DoubletSeedFinder& bottomFinder,
     const DoubletSeedFinder& topFinder, const TripletSeedFinder& tripletFinder,
     const ITripletSeedFilter& filter, const SpacePointContainer& spacePoints,
-    SpacePointContainer::ConstSubset bottomSps,
+    SpacePointContainer::ConstSubset& bottomSps,
     const ConstSpacePointProxy& middleSp,
-    SpacePointContainer::ConstSubset topSps, SeedContainer& outputSeeds) const {
+    SpacePointContainer::ConstSubset& topSps,
+    SeedContainer& outputSeeds) const {
   assert((bottomFinder.config().spacePointsSortedByRadius ==
           topFinder.config().spacePointsSortedByRadius) &&
          "Inconsistent space point sorting");

--- a/Core/src/Seeding/TripletSeeder.cpp
+++ b/Core/src/Seeding/TripletSeeder.cpp
@@ -18,6 +18,26 @@ namespace Acts {
 
 namespace {
 
+/// Advance a space point group past the candidates that can no longer pair
+/// with the middle space point, or with any of the ones after it. Groups are
+/// sorted by radius and the middle space points are swept in ascending radius,
+/// so the cut point only ever moves forward and the group is never rewound.
+///
+/// This is the incremental form of the binary search that primes the groups in
+/// `createSeedsFromGroups`; `isInRange` has to spell the radius cut exactly the
+/// way `DoubletSeedFinder` does, so that the two agree bit for bit.
+template <typename SpacePointGroup, typename Predicate>
+void advanceGroup(SpacePointGroup& group, Predicate isInRange) {
+  std::uint32_t offset = 0;
+  for (ConstSpacePointProxy candidateSp : group) {
+    if (isInRange(candidateSp)) {
+      break;
+    }
+    ++offset;
+  }
+  group = group.subrange(offset);
+}
+
 template <typename DoubletCollections>
 void createAndFilterTriplets(TripletSeeder::Cache& cache,
                              const TripletSeedFinder& tripletFinder,
@@ -32,9 +52,9 @@ void createAndFilterTriplets(TripletSeeder::Cache& cache,
     }
 
     cache.tripletTopCandidates.clear();
-    tripletFinder.createTripletTopCandidates(spacePoints, spM, bottomDoublet,
-                                             topDoublets,
-                                             cache.tripletTopCandidates);
+    topDoublets = tripletFinder.createTripletTopCandidates(
+        spacePoints, spM, bottomDoublet, topDoublets,
+        cache.tripletTopCandidates);
 
     filter.filterTripletTopCandidates(spacePoints, spM, bottomDoublet,
                                       cache.tripletTopCandidates);
@@ -48,12 +68,20 @@ void createSeedsFromGroupsImpl(
     const TripletSeedFinder& tripletFinder, const ITripletSeedFilter& filter,
     const SpacePointContainer& spacePoints,
     SpacePointCollections& bottomSpGroups, const ConstSpacePointProxy& middleSp,
-    SpacePointCollections& topSpGroups, SeedContainer& outputSeeds) {
+    SpacePointCollections& topSpGroups, bool spacePointsSortedByRadius,
+    float bottomDeltaRMax, float topDeltaRMin, SeedContainer& outputSeeds) {
   MiddleSpInfo middleSpInfo = DoubletSeedFinder::computeMiddleSpInfo(middleSp);
+  const float rM = middleSp.zr()[1];
 
   // create middle-top doublets
   cache.topDoublets.clear();
   for (auto& topSpGroup : topSpGroups) {
+    if (spacePointsSortedByRadius) {
+      // if r-distance is too small, try next SP in bin
+      advanceGroup(topSpGroup, [&](const ConstSpacePointProxy& candidateSp) {
+        return candidateSp.zr()[1] - rM >= topDeltaRMin;
+      });
+    }
     topFinder.createDoublets(middleSp, middleSpInfo, topSpGroup,
                              cache.topDoublets);
   }
@@ -71,6 +99,12 @@ void createSeedsFromGroupsImpl(
   // create middle-bottom doublets
   cache.bottomDoublets.clear();
   for (auto& bottomSpGroup : bottomSpGroups) {
+    if (spacePointsSortedByRadius) {
+      // if r-distance is too big, try next SP in bin
+      advanceGroup(bottomSpGroup, [&](const ConstSpacePointProxy& candidateSp) {
+        return rM - candidateSp.zr()[1] <= bottomDeltaRMax;
+      });
+    }
     bottomFinder.createDoublets(middleSp, middleSpInfo, bottomSpGroup,
                                 cache.bottomDoublets);
   }
@@ -119,29 +153,33 @@ void TripletSeeder::createSeedsFromGroup(
     Cache& cache, const DoubletSeedFinder& bottomFinder,
     const DoubletSeedFinder& topFinder, const TripletSeedFinder& tripletFinder,
     const ITripletSeedFilter& filter, const SpacePointContainer& spacePoints,
-    SpacePointContainer::ConstSubset& bottomSps,
+    SpacePointContainer::ConstSubset bottomSps,
     const ConstSpacePointProxy& middleSp,
-    SpacePointContainer::ConstSubset& topSps,
-    SeedContainer& outputSeeds) const {
+    SpacePointContainer::ConstSubset topSps, SeedContainer& outputSeeds) const {
   assert((bottomFinder.config().spacePointsSortedByRadius ==
           topFinder.config().spacePointsSortedByRadius) &&
          "Inconsistent space point sorting");
 
+  // the cursors live and die with this call, so every middle space point
+  // starts its sweep at the front of the subset again
   std::array<SpacePointContainer::ConstSubset, 1> bottomSpGroups{bottomSps};
   std::array<SpacePointContainer::ConstSubset, 1> topSpGroups{topSps};
 
   createSeedsFromGroupsImpl(*m_logger, cache, bottomFinder, topFinder,
                             tripletFinder, filter, spacePoints, bottomSpGroups,
-                            middleSp, topSpGroups, outputSeeds);
+                            middleSp, topSpGroups,
+                            bottomFinder.config().spacePointsSortedByRadius,
+                            bottomFinder.config().deltaRMax,
+                            topFinder.config().deltaRMin, outputSeeds);
 }
 
 void TripletSeeder::createSeedsFromGroups(
     Cache& cache, const DoubletSeedFinder& bottomFinder,
     const DoubletSeedFinder& topFinder, const TripletSeedFinder& tripletFinder,
     const ITripletSeedFilter& filter, const SpacePointContainer& spacePoints,
-    const std::span<SpacePointContainer::ConstRange>& bottomSpGroups,
+    std::span<const SpacePointContainer::ConstRange> bottomSpGroups,
     const SpacePointContainer::ConstRange& middleSpGroup,
-    const std::span<SpacePointContainer::ConstRange>& topSpGroups,
+    std::span<const SpacePointContainer::ConstRange> topSpGroups,
     const std::pair<float, float>& radiusRangeForMiddle,
     SeedContainer& outputSeeds) const {
   assert((bottomFinder.config().spacePointsSortedByRadius ==
@@ -149,10 +187,17 @@ void TripletSeeder::createSeedsFromGroups(
          "Inconsistent space point sorting");
   const bool spacePointsSortedByRadius =
       bottomFinder.config().spacePointsSortedByRadius;
+  const float bottomDeltaRMax = bottomFinder.config().deltaRMax;
+  const float topDeltaRMin = topFinder.config().deltaRMin;
 
   if (middleSpGroup.empty()) {
     return;
   }
+
+  // the cursors are ours, so the caller's groups stay untouched and can be
+  // handed to another call unchanged
+  cache.bottomSpGroups.assign(bottomSpGroups.begin(), bottomSpGroups.end());
+  cache.topSpGroups.assign(topSpGroups.begin(), topSpGroups.end());
 
   if (spacePointsSortedByRadius) {
     // Initialize initial offsets for bottom and top space points with binary
@@ -161,20 +206,20 @@ void TripletSeeder::createSeedsFromGroups(
     const ConstSpacePointProxy firstMiddleSp = middleSpGroup.front();
     const float firstMiddleSpR = firstMiddleSp.zr()[1];
 
-    for (auto& bottomSpGroup : bottomSpGroups) {
+    for (auto& bottomSpGroup : cache.bottomSpGroups) {
       // Find the first bottom space point that is within the deltaRMax of the
       // first middle space point.
       const auto low = std::ranges::lower_bound(
-          bottomSpGroup, firstMiddleSpR - bottomFinder.config().deltaRMax, {},
+          bottomSpGroup, firstMiddleSpR - bottomDeltaRMax, {},
           [&](const ConstSpacePointProxy& sp) { return sp.zr()[1]; });
       bottomSpGroup = bottomSpGroup.subrange(low - bottomSpGroup.begin());
     }
 
-    for (auto& topSpGroup : topSpGroups) {
+    for (auto& topSpGroup : cache.topSpGroups) {
       // Find the first top space point that is within the deltaRMin of the
       // first middle space point.
       const auto low = std::ranges::lower_bound(
-          topSpGroup, firstMiddleSpR + topFinder.config().deltaRMin, {},
+          topSpGroup, firstMiddleSpR + topDeltaRMin, {},
           [&](const ConstSpacePointProxy& sp) { return sp.zr()[1]; });
       topSpGroup = topSpGroup.subrange(low - topSpGroup.begin());
     }
@@ -194,9 +239,10 @@ void TripletSeeder::createSeedsFromGroups(
       }
     }
 
-    createSeedsFromGroupsImpl(*m_logger, cache, bottomFinder, topFinder,
-                              tripletFinder, filter, spacePoints,
-                              bottomSpGroups, spM, topSpGroups, outputSeeds);
+    createSeedsFromGroupsImpl(
+        *m_logger, cache, bottomFinder, topFinder, tripletFinder, filter,
+        spacePoints, cache.bottomSpGroups, spM, cache.topSpGroups,
+        spacePointsSortedByRadius, bottomDeltaRMax, topDeltaRMin, outputSeeds);
   }
 }
 

--- a/Examples/Algorithms/TrackFinding/src/OrthogonalTripletSeedingAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFinding/src/OrthogonalTripletSeedingAlgorithm.cpp
@@ -285,19 +285,17 @@ ProcessCode OrthogonalTripletSeedingAlgorithm::execute(
     candidates.clear();
     kdTree.validTuples(lhOptions, hlOptions, spM, nTopSeedConf, candidates);
 
-    Acts::SpacePointContainer::ConstSubset bottomSps =
-        coreSpacePoints.subset(candidates.bottom_lh_v).asConst();
-    Acts::SpacePointContainer::ConstSubset topSps =
-        coreSpacePoints.subset(candidates.top_lh_v).asConst();
     m_seedFinder->createSeedsFromGroup(
         cache, *bottomDoubletFinder, *topDoubletFinder, *tripletFinder,
-        seedFilter, coreSpacePoints, bottomSps, spM, topSps, seeds);
+        seedFilter, coreSpacePoints,
+        coreSpacePoints.subset(candidates.bottom_lh_v).asConst(), spM,
+        coreSpacePoints.subset(candidates.top_lh_v).asConst(), seeds);
 
-    bottomSps = coreSpacePoints.subset(candidates.bottom_hl_v).asConst();
-    topSps = coreSpacePoints.subset(candidates.top_hl_v).asConst();
     m_seedFinder->createSeedsFromGroup(
         cache, *bottomDoubletFinder, *topDoubletFinder, *tripletFinder,
-        seedFilter, coreSpacePoints, bottomSps, spM, topSps, seeds);
+        seedFilter, coreSpacePoints,
+        coreSpacePoints.subset(candidates.bottom_hl_v).asConst(), spM,
+        coreSpacePoints.subset(candidates.top_hl_v).asConst(), seeds);
   }
 
   ACTS_DEBUG("Created " << seeds.size() << " track seeds from "

--- a/Examples/Algorithms/TrackFinding/src/OrthogonalTripletSeedingAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFinding/src/OrthogonalTripletSeedingAlgorithm.cpp
@@ -285,17 +285,19 @@ ProcessCode OrthogonalTripletSeedingAlgorithm::execute(
     candidates.clear();
     kdTree.validTuples(lhOptions, hlOptions, spM, nTopSeedConf, candidates);
 
+    Acts::SpacePointContainer::ConstSubset bottomSps =
+        coreSpacePoints.subset(candidates.bottom_lh_v).asConst();
+    Acts::SpacePointContainer::ConstSubset topSps =
+        coreSpacePoints.subset(candidates.top_lh_v).asConst();
     m_seedFinder->createSeedsFromGroup(
         cache, *bottomDoubletFinder, *topDoubletFinder, *tripletFinder,
-        seedFilter, coreSpacePoints,
-        coreSpacePoints.subset(candidates.bottom_lh_v).asConst(), spM,
-        coreSpacePoints.subset(candidates.top_lh_v).asConst(), seeds);
+        seedFilter, coreSpacePoints, bottomSps, spM, topSps, seeds);
 
+    bottomSps = coreSpacePoints.subset(candidates.bottom_hl_v).asConst();
+    topSps = coreSpacePoints.subset(candidates.top_hl_v).asConst();
     m_seedFinder->createSeedsFromGroup(
         cache, *bottomDoubletFinder, *topDoubletFinder, *tripletFinder,
-        seedFilter, coreSpacePoints,
-        coreSpacePoints.subset(candidates.bottom_hl_v).asConst(), spM,
-        coreSpacePoints.subset(candidates.top_hl_v).asConst(), seeds);
+        seedFilter, coreSpacePoints, bottomSps, spM, topSps, seeds);
   }
 
   ACTS_DEBUG("Created " << seeds.size() << " track seeds from "


### PR DESCRIPTION
Three functions in the triplet seeding chain took a view by mutable reference
and quietly wrote a shortened one back, so that the next call would not walk
over candidates that can no longer match. The mechanism is right, and the
sweeps depend on it, but nothing in the interfaces said so and one of them was
even spelled `const&`.

`DoubletSeedFinder::createDoublets` loses its cursor entirely. The seeder
already computes the same bound with a binary search when it primes the groups,
reading `deltaRMax` and `deltaRMin` off the very same configs, so the finder's
linear rescan was the incremental form of a cut that lives one level up. It
moves next to that priming loop, spelled exactly the way the finder spelled it
so the two still agree bit for bit, and the finder becomes a pure function of
the middle space point and a candidate view.

`TripletSeedFinder::createTripletTopCandidates` keeps its cursor, because the
offset falls out of the compatibility test inside the loop and hoisting it
would cost a second pass, but it returns the advanced view instead of writing
through a reference. It is `[[nodiscard]]`, so dropping the thread is now a
compile error rather than a silent quadratic sweep.

`TripletSeeder::createSeedsFromGroups` took `const std::span<ConstRange>&` and
overwrote the span's elements, i.e. it rewrote the caller's vector through a
signature that reads as read only. The cursors move into `Cache`, next to the
other per-call scratch, and the parameter becomes
`std::span<const ConstRange>`. `createSeedsFromGroup` never wrote its subsets
back at all and now takes them by value.

Seeding output is unchanged, bit for bit: all nine root hashes of the five
seeding example tests are identical before and after.