### PR TITLE
ci: Authenticate github.com fetches and retry truncated data downloads

### DIFF
--- a/CI/dependencies/setup.sh
+++ b/CI/dependencies/setup.sh
@@ -312,6 +312,30 @@ if [ -n "${CI:-}" ]; then
   spack config get mirrors
   end_section
 
+  start_section "Authenticate github.com fetches"
+  # Anonymous git reads leave the runners on a shared egress IP, so GitHub
+  # eventually answers one with a 401. Git turns that into a credential prompt
+  # ("could not read Username for 'https://github.com'"), which is a hard
+  # failure a retry cannot ride out. Authenticating moves us off the per-IP
+  # anonymous quota; the fork-PR GITHUB_TOKEN is enough for reads of a public
+  # repo (unlike GHCR, which needs a `packages: read` fork PRs never get).
+  #
+  # The rewrite is a literal prefix substitution on "https://github.com/" that
+  # carries host and path over untouched, so it only prepends credentials --
+  # every other host, and the ssh form, is left alone. It also reaches git only;
+  # the tarball and OCI fetches elsewhere in the install never consult it.
+  # --replace-all keeps it idempotent: insteadOf is multi-valued, and a cached
+  # spack install can run this more than once.
+  if [ -n "${GITHUB_TOKEN:-}" ]; then
+    git config --global --replace-all \
+      "url.https://x-access-token:${GITHUB_TOKEN}@github.com/.insteadOf" \
+      "https://github.com/"
+    echo "Rewriting https://github.com/ fetches to use GITHUB_TOKEN"
+  else
+    echo "GITHUB_TOKEN not set: github.com fetches stay anonymous"
+  fi
+  end_section
+
   start_section "Add ACTS package repository"
   if ! spack repo list | grep -q "acts"; then
     echo "Adding ACTS package repository from ci-dependencies"

--- a/Detray/data/detray_data_get_files.sh
+++ b/Detray/data/detray_data_get_files.sh
@@ -80,12 +80,15 @@ done
 # Go into the target directory.
 cd "${DETRAY_DATA_DIRECTORY}"
 
-# Download the TGZ and MD5 files.
-"${DETRAY_CURL_EXECUTABLE}" --retry 5 --retry-delay 10 \
-   --output "${DETRAY_DATA_NAME}.tar.gz"               \
+# Download the TGZ and MD5 files. --retry on its own only covers timeouts and
+# 429/5xx responses, so a connection the server drops mid-body ("curl: (18)
+# transfer closed with N bytes remaining to read") is a hard failure.
+# --retry-all-errors covers it.
+"${DETRAY_CURL_EXECUTABLE}" --retry 5 --retry-delay 10 --retry-all-errors \
+   --output "${DETRAY_DATA_NAME}.tar.gz"                                  \
    "${DETRAY_WEB_DIRECTORY}/${DETRAY_DATA_NAME}.tar.gz"
-"${DETRAY_CURL_EXECUTABLE}" --retry 5 --retry-delay 10 \
-   --output "${DETRAY_DATA_NAME}.md5"                  \
+"${DETRAY_CURL_EXECUTABLE}" --retry 5 --retry-delay 10 --retry-all-errors \
+   --output "${DETRAY_DATA_NAME}.md5"                                     \
    "${DETRAY_WEB_DIRECTORY}/${DETRAY_DATA_NAME}.md5"
 
 # Verify that the download succeeded.

--- a/Traccc/data/traccc_data_get_files.sh
+++ b/Traccc/data/traccc_data_get_files.sh
@@ -71,12 +71,15 @@ done
 # Go into the target directory.
 cd "${TRACCC_DATA_DIRECTORY}"
 
-# Download the TGZ and MD5 files.
-"${TRACCC_CURL_EXECUTABLE}" --retry 5 --retry-delay 10 \
-   --output "${TRACCC_DATA_NAME}.tar.gz"               \
+# Download the TGZ and MD5 files. --retry on its own only covers timeouts and
+# 429/5xx responses, so a connection the server drops mid-body ("curl: (18)
+# transfer closed with N bytes remaining to read") is a hard failure -- the
+# common way this ~1.3 GB download breaks. --retry-all-errors covers it.
+"${TRACCC_CURL_EXECUTABLE}" --retry 5 --retry-delay 10 --retry-all-errors \
+   --output "${TRACCC_DATA_NAME}.tar.gz"                                  \
    "${TRACCC_WEB_DIRECTORY}/${TRACCC_DATA_NAME}.tar.gz"
-"${TRACCC_CURL_EXECUTABLE}" --retry 5 --retry-delay 10 \
-   --output "${TRACCC_DATA_NAME}.md5"                  \
+"${TRACCC_CURL_EXECUTABLE}" --retry 5 --retry-delay 10 --retry-all-errors \
+   --output "${TRACCC_DATA_NAME}.md5"                                     \
    "${TRACCC_WEB_DIRECTORY}/${TRACCC_DATA_NAME}.md5"
 
 # Verify that the download succeeded.


### PR DESCRIPTION
Use github tokens for more git clone operations, extend auto-retry patterns.