### PR TITLE
fix: geo_id handling in materialPlotHelper for newer geometry maps

### DIFF
--- a/Examples/Scripts/MaterialMapping/materialPlotHelper.cpp
+++ b/Examples/Scripts/MaterialMapping/materialPlotHelper.cpp
@@ -59,7 +59,7 @@ std::unordered_map<std::uint64_t, json> load_geometry_file(
     // Handle both old (uint64_t) and new (object with component fields) formats
     std::uint64_t gid;
     if (entry["value"]["geo_id"].is_number()) {
-      // Specification: geo_id is a simple uint64_t (
+      // Specification: geo_id is a simple uint64_t
       gid = entry["value"]["geo_id"].get<std::uint64_t>();
     } else if (entry["value"]["geo_id"].is_object()) {
       // Specification: geo_id is an object with component fields

--- a/Examples/Scripts/MaterialMapping/materialPlotHelper.cpp
+++ b/Examples/Scripts/MaterialMapping/materialPlotHelper.cpp
@@ -56,7 +56,44 @@ std::unordered_map<std::uint64_t, json> load_geometry_file(
   std::unordered_map<std::uint64_t, json> surface_bounds;
   const auto& entries = geom["Surfaces"]["entries"];
   for (const auto& entry : entries) {
-    std::uint64_t gid = entry["value"]["geo_id"].get<std::uint64_t>();
+    // Handle both old (uint64_t) and new (object with component fields) formats
+    std::uint64_t gid;
+    if (entry["value"]["geo_id"].is_number()) {
+      // Specification: geo_id is a simple uint64_t (
+      gid = entry["value"]["geo_id"].get<std::uint64_t>();
+    } else if (entry["value"]["geo_id"].is_object()) {
+      // Specification: geo_id is an object with component fields
+      // Reconstruct the uint64_t from individual components
+      // Layout: volume (bits 56-63), boundary (bits 48-55), layer (bits 36-47),
+      //         approach (bits 28-35), sensitive (bits 0-27)
+      std::uint64_t gid_value = 0;
+      const auto& geo_id_obj = entry["value"]["geo_id"];
+
+      if (geo_id_obj.contains("volume") && !geo_id_obj["volume"].is_null()) {
+        uint32_t volume = static_cast<uint32_t>(geo_id_obj["volume"].get<double>());
+        gid_value |= (static_cast<std::uint64_t>(volume) & 0xFF) << 56;
+      }
+      if (geo_id_obj.contains("boundary") && !geo_id_obj["boundary"].is_null()) {
+        uint32_t boundary = static_cast<uint32_t>(geo_id_obj["boundary"].get<double>());
+        gid_value |= (static_cast<std::uint64_t>(boundary) & 0xFF) << 48;
+      }
+      if (geo_id_obj.contains("layer") && !geo_id_obj["layer"].is_null()) {
+        uint32_t layer = static_cast<uint32_t>(geo_id_obj["layer"].get<double>());
+        gid_value |= (static_cast<std::uint64_t>(layer) & 0xFFF) << 36;
+      }
+      if (geo_id_obj.contains("approach") && !geo_id_obj["approach"].is_null()) {
+        uint32_t approach = static_cast<uint32_t>(geo_id_obj["approach"].get<double>());
+        gid_value |= (static_cast<std::uint64_t>(approach) & 0xFF) << 28;
+      }
+      if (geo_id_obj.contains("sensitive") && !geo_id_obj["sensitive"].is_null()) {
+        uint32_t sensitive = static_cast<uint32_t>(geo_id_obj["sensitive"].get<double>());
+        gid_value |= (static_cast<std::uint64_t>(sensitive) & 0x0FFFFFFF);
+      }
+      gid = gid_value;
+    } else {
+      std::cerr << "WARNING: Unknown geo_id format in geometry file." << std::endl;
+      continue;
+    }
     surface_bounds[gid] = entry["value"]["bounds"];
   }
   return surface_bounds;

--- a/Examples/Scripts/MaterialMapping/materialPlotHelper.cpp
+++ b/Examples/Scripts/MaterialMapping/materialPlotHelper.cpp
@@ -95,7 +95,11 @@ std::unordered_map<std::uint64_t, json> load_geometry_file(
           !geo_id_obj["sensitive"].is_null()) {
         std::uint32_t sensitive = static_cast<std::uint32_t>(
             geo_id_obj["sensitive"].get<std::uint32_t>());
-        gid_value |= (static_cast<std::uint64_t>(sensitive) & 0x0FFFFFFF);
+        gid_value |= (static_cast<std::uint64_t>(sensitive) & 0xFFFFF) << 8;
+      }
+      if (geo_id_obj.contains("extra") && !geo_id_obj["extra"].is_null()) {
+        std::uint64_t extra = geo_id_obj["extra"].get<std::uint64_t>();
+        gid_value |= (extra & 0xFF);
       }
       gid = gid_value;
     } else {

--- a/Examples/Scripts/MaterialMapping/materialPlotHelper.cpp
+++ b/Examples/Scripts/MaterialMapping/materialPlotHelper.cpp
@@ -70,28 +70,37 @@ std::unordered_map<std::uint64_t, json> load_geometry_file(
       const auto& geo_id_obj = entry["value"]["geo_id"];
 
       if (geo_id_obj.contains("volume") && !geo_id_obj["volume"].is_null()) {
-        uint32_t volume = static_cast<uint32_t>(geo_id_obj["volume"].get<double>());
+        std::uint32_t volume = static_cast<std::uint32_t>(
+            geo_id_obj["volume"].get<std::uint32_t>());
         gid_value |= (static_cast<std::uint64_t>(volume) & 0xFF) << 56;
       }
-      if (geo_id_obj.contains("boundary") && !geo_id_obj["boundary"].is_null()) {
-        uint32_t boundary = static_cast<uint32_t>(geo_id_obj["boundary"].get<double>());
+      if (geo_id_obj.contains("boundary") &&
+          !geo_id_obj["boundary"].is_null()) {
+        std::uint32_t boundary = static_cast<std::uint32_t>(
+            geo_id_obj["boundary"].get<std::uint32_t>());
         gid_value |= (static_cast<std::uint64_t>(boundary) & 0xFF) << 48;
       }
       if (geo_id_obj.contains("layer") && !geo_id_obj["layer"].is_null()) {
-        uint32_t layer = static_cast<uint32_t>(geo_id_obj["layer"].get<double>());
+        std::uint32_t layer = static_cast<std::uint32_t>(
+            geo_id_obj["layer"].get<std::uint32_t>());
         gid_value |= (static_cast<std::uint64_t>(layer) & 0xFFF) << 36;
       }
-      if (geo_id_obj.contains("approach") && !geo_id_obj["approach"].is_null()) {
-        uint32_t approach = static_cast<uint32_t>(geo_id_obj["approach"].get<double>());
+      if (geo_id_obj.contains("approach") &&
+          !geo_id_obj["approach"].is_null()) {
+        std::uint32_t approach = static_cast<std::uint32_t>(
+            geo_id_obj["approach"].get<std::uint32_t>());
         gid_value |= (static_cast<std::uint64_t>(approach) & 0xFF) << 28;
       }
-      if (geo_id_obj.contains("sensitive") && !geo_id_obj["sensitive"].is_null()) {
-        uint32_t sensitive = static_cast<uint32_t>(geo_id_obj["sensitive"].get<double>());
+      if (geo_id_obj.contains("sensitive") &&
+          !geo_id_obj["sensitive"].is_null()) {
+        std::uint32_t sensitive = static_cast<std::uint32_t>(
+            geo_id_obj["sensitive"].get<std::uint32_t>());
         gid_value |= (static_cast<std::uint64_t>(sensitive) & 0x0FFFFFFF);
       }
       gid = gid_value;
     } else {
-      std::cerr << "WARNING: Unknown geo_id format in geometry file." << std::endl;
+      std::cerr << "WARNING: Unknown geo_id format in geometry file."
+                << std::endl;
       continue;
     }
     surface_bounds[gid] = entry["value"]["bounds"];

--- a/Examples/Scripts/MaterialMapping/materialPlotHelper.cpp
+++ b/Examples/Scripts/MaterialMapping/materialPlotHelper.cpp
@@ -56,14 +56,15 @@ std::unordered_map<std::uint64_t, json> load_geometry_file(
   std::unordered_map<std::uint64_t, json> surface_bounds;
   const auto& entries = geom["Surfaces"]["entries"];
   for (const auto& entry : entries) {
-    // Handle both old (uint64_t) and new (object with component fields) formats
+    // Handle both old (std::uint64_t) and new (object with component fields)
+    // formats
     std::uint64_t gid;
     if (entry["value"]["geo_id"].is_number()) {
-      // Specification: geo_id is a simple uint64_t
+      // Specification: geo_id is a simple std::uint64_t
       gid = entry["value"]["geo_id"].get<std::uint64_t>();
     } else if (entry["value"]["geo_id"].is_object()) {
       // Specification: geo_id is an object with component fields
-      // Reconstruct the uint64_t from individual components
+      // Reconstruct the std::uint64_t from individual components
       // Layout: volume (bits 56-63), boundary (bits 48-55), layer (bits 36-47),
       //         approach (bits 28-35), sensitive (bits 0-27)
       std::uint64_t gid_value = 0;


### PR DESCRIPTION
In recent geometry json writing (`geometry.py`) the `geo_id` field appears to now be an object instead of an `uint64_t`. This PR allows for reading both old and new format.

New format:
```
"geo_id": {
    "layer": 2,
    "sensitive": 10030,
    "volume": 47
  }
```

Old format (not same surface):
```
  "geo_id": 2377901015568723712,
```

I think this may have changed in https://github.com/acts-project/acts/commit/3da1e39c8dd68156cf87dfd14b1d6ace1b320658 (46.2.0) but I am not 100% sure.

Assisted-by: Claude Haiku 4.5
