### PR TITLE
fix: restore cbor output map format support in material mapping

### DIFF
--- a/Examples/Scripts/Python/material_mapping.py
+++ b/Examples/Scripts/Python/material_mapping.py
@@ -98,7 +98,7 @@ def runMaterialMapping(
         elif "cbor" in outputMapFormats:
             writeFormat = JsonFormat.Cbor
         else:
-            throw RuntimeError("Unknown output map format: " + str(outputMapFormats))
+            raise RuntimeError("Unknown output map format: " + str(outputMapFormats))
         materialMapWriters.append(
             JsonMaterialWriter(
                 level=loglevel,

--- a/Examples/Scripts/Python/material_mapping.py
+++ b/Examples/Scripts/Python/material_mapping.py
@@ -84,7 +84,7 @@ def runMaterialMapping(
     # Add the map writer(s)
     materialMapWriters = []
     # json map writer
-    if "json" in outputMapFormats:
+    if "json" in outputMapFormats or "cbor" in outputMapFormats:
         jmConverterCfg = MaterialMapJsonConverter.Config(
             processSensitives=True,
             processApproaches=True,
@@ -93,12 +93,18 @@ def runMaterialMapping(
             processVolumes=False,
         )
         # Suffix for the map file is added in the writer depending on the format
+        if "json" in outputMapFormats:
+            writeFormat = JsonFormat.Json
+        elif "cbor" in outputMapFormats:
+            writeFormat = JsonFormat.Cbor
+        else:
+            throw RuntimeError("Unknown output map format: " + str(outputMapFormats))
         materialMapWriters.append(
             JsonMaterialWriter(
                 level=loglevel,
                 converterCfg=jmConverterCfg,
                 fileName=outputFileBase + "_map",
-                writeFormat=JsonFormat.Json,
+                writeFormat=writeFormat,
             )
         )
     if "root" in outputMapFormats:

--- a/Examples/Scripts/Python/material_mapping.py
+++ b/Examples/Scripts/Python/material_mapping.py
@@ -84,7 +84,11 @@ def runMaterialMapping(
     # Add the map writer(s)
     materialMapWriters = []
     # json map writer
-    if "json" in outputMapFormats or "cbor" in outputMapFormats:
+    jsonOutputMapFormatsDict = {"json": JsonFormat.Json, "cbor": JsonFormat.Cbor}
+    jsonOutputMapFormats = [
+        jsonOutputMapFormatsDict[f] for f in outputMapFormats if f in jsonOutputMapFormatsDict
+    ]
+    if jsonOutputMapFormats:
         jmConverterCfg = MaterialMapJsonConverter.Config(
             processSensitives=True,
             processApproaches=True,
@@ -93,20 +97,15 @@ def runMaterialMapping(
             processVolumes=False,
         )
         # Suffix for the map file is added in the writer depending on the format
-        if "json" in outputMapFormats:
-            writeFormat = JsonFormat.Json
-        elif "cbor" in outputMapFormats:
-            writeFormat = JsonFormat.Cbor
-        else:
-            raise RuntimeError("Unknown output map format: " + str(outputMapFormats))
-        materialMapWriters.append(
-            JsonMaterialWriter(
-                level=loglevel,
-                converterCfg=jmConverterCfg,
-                fileName=outputFileBase + "_map",
-                writeFormat=writeFormat,
+        for writeFormat in jsonOutputMapFormats:
+            materialMapWriters.append(
+                JsonMaterialWriter(
+                    level=loglevel,
+                    converterCfg=jmConverterCfg,
+                    fileName=outputFileBase + "_map",
+                    writeFormat=writeFormat,
+                )
             )
-        )
     if "root" in outputMapFormats:
         materialMapWriters.append(
             RootMaterialWriter(

--- a/Examples/Scripts/Python/material_mapping.py
+++ b/Examples/Scripts/Python/material_mapping.py
@@ -86,7 +86,9 @@ def runMaterialMapping(
     # json map writer
     jsonOutputMapFormatsDict = {"json": JsonFormat.Json, "cbor": JsonFormat.Cbor}
     jsonOutputMapFormats = [
-        jsonOutputMapFormatsDict[f] for f in outputMapFormats if f in jsonOutputMapFormatsDict
+        jsonOutputMapFormatsDict[f]
+        for f in outputMapFormats
+        if f in jsonOutputMapFormatsDict
     ]
     if jsonOutputMapFormats:
         jmConverterCfg = MaterialMapJsonConverter.Config(


### PR DESCRIPTION
This PR restores the ability to output `cbor` material maps (instead of only `json` and `root`). Only options at the point of the if/elif/else are `json` and `cbor`, so the throw is not ever expected to happen but here for safety reasons.

I think this may have changed in 3da1e39 (46.2.0) but I am not 100% sure. (See #6010.)
