### PR TITLE
build(cmake): split ccache out of the common preset

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -2,12 +2,19 @@
     "version": 4,
     "configurePresets": [
         {
+            "name": "ccache",
+            "hidden": true,
+            "description": "Use ccache as the compiler launcher. Kept separate from `common` so that the local presets do not require ccache to be installed. Inherit it alongside another preset to turn it back on.",
+            "cacheVariables": {
+                "CMAKE_CXX_COMPILER_LAUNCHER": "ccache"
+            }
+        },
+        {
             "name": "common",
             "hidden": true,
             "generator": "Ninja",
             "cacheVariables": {
                 "CMAKE_CXX_STANDARD": "20",
-                "CMAKE_CXX_COMPILER_LAUNCHER": "ccache",
                 "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
                 "ACTS_ENABLE_LOG_FAILURE_THRESHOLD": "OFF",
                 "ACTS_BUILD_FATRAS": "ON",
@@ -56,7 +63,10 @@
         {
             "name": "ci-common",
             "hidden": true,
-            "inherits": "common",
+            "inherits": [
+                "common",
+                "ccache"
+            ],
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Release",
                 "CMAKE_COMPILE_WARNING_AS_ERROR": "ON",
@@ -183,7 +193,10 @@
             "displayName": "GitHub-CI Gnn",
             "description": "GNN build for the gnn_build job. Warnings are errors, as everywhere else in CI. Only the Plugins/Gnn unit tests are ever run from this build, so the Core and Examples suites and the integration tests are switched off; Tests/UnitTests/CMakeLists.txt adds Plugins unconditionally, so the GNN ones survive. ODD, DD4hep and ROOT stay on because the `-k gpu` python tests need a detector and read back ROOT output.",
             "generator": "Ninja",
-            "inherits": "common",
+            "inherits": [
+                "common",
+                "ccache"
+            ],
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Release",
                 "CMAKE_COMPILE_WARNING_AS_ERROR": "ON",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -42,7 +42,10 @@
         {
             "name": "devcontainer",
             "displayName": "Devcontainer",
-            "inherits": "dev",
+            "inherits": [
+                "dev",
+                "ccache"
+            ],
             "binaryDir": "build_devcontainer",
             "cacheVariables": {
                 "ACTS_ENABLE_LOG_FAILURE_THRESHOLD": "ON",


### PR DESCRIPTION
Everything inherits from `common`, so setting the compiler launcher there meant ccache had to be installed for local builds too, not just the CI ones. This moves it into its own hidden `ccache` preset and has `ci-common` and `github-ci-gnn` inherit that alongside `common`. Those two were the only presets picking ccache up through `common`; `github-ci-tensorrt` and `python-wheel` set it themselves and I left them as they are.

I resolved the inheritance for every preset before and after to make sure nothing moved that shouldn't. ci-common, github-ci, -clangtidy, -coverage, -cuda-muon, -fpe, -gnn, -lcg, -tensorrt and python-wheel all keep the launcher they had, dev, devcontainer and perf lose it, and no other cache variable changes anywhere. The Detray presets come in through the include but have their own base and never reference `common`, so they aren't affected.

One correction to the issue text. The requirement doesn't bite at configure time. With ccache not installed, `cmake --preset dev` configures fine and it's `cmake --build` that fails with `ccache: command not found`. I checked that on a small project with the same preset shape, since configuring the real dev preset here needs DD4hep, ROOT and Geant4.

Closes #3537
