### PR TITLE
fix: Build surface array axes in the representative surface frame

### DIFF
--- a/Core/src/Geometry/SurfaceArrayCreator.cpp
+++ b/Core/src/Geometry/SurfaceArrayCreator.cpp
@@ -29,6 +29,28 @@ namespace Acts {
 using VectorHelpers::perp;
 using VectorHelpers::phi;
 
+namespace {
+
+/// Bin edges are derived from the surfaces but consumed as local coordinates of
+/// the representative surface. Subtracting its translation puts them in the
+/// same frame. Phi is rotated by @c createEquidistantAxis instead, and R is
+/// invariant under the translations applied here.
+double axisFrameOffset(AxisDirection aDir, const Transform3& transform) {
+  using enum AxisDirection;
+  switch (aDir) {
+    case AxisX:
+      return transform.translation().x();
+    case AxisY:
+      return transform.translation().y();
+    case AxisZ:
+      return transform.translation().z();
+    default:
+      return 0.;
+  }
+}
+
+}  // namespace
+
 SurfaceArray SurfaceArrayCreator::surfaceArrayOnCylinder(
     const GeometryContext& gctx,
     std::vector<std::shared_ptr<const Surface>> surfaces, std::size_t binsPhi,
@@ -305,11 +327,13 @@ SurfaceArray SurfaceArrayCreator::surfaceArrayOnPlane(
       const auto pAxis2 =
           createEquidistantAxis(gctx, surfacesRaw, AxisBoundaryType::Bound,
                                 AxisZ, protoLayer, fullTransform, bins2);
+      const Vector3 shift = fullTransform.translation();
       auto surface = Surface::makeShared<PlaneSurface>(
-          fullTransform,
-          std::make_shared<RectangleBounds>(
-              Vector2(protoLayer.min(AxisY), protoLayer.min(AxisZ)),
-              Vector2(protoLayer.max(AxisY), protoLayer.max(AxisZ))));
+          fullTransform, std::make_shared<RectangleBounds>(
+                             Vector2(protoLayer.min(AxisY) - shift.y(),
+                                     protoLayer.min(AxisZ) - shift.z()),
+                             Vector2(protoLayer.max(AxisY) - shift.y(),
+                                     protoLayer.max(AxisZ) - shift.z())));
       return SurfaceArray(gctx, std::move(surfaces), std::move(surface),
                           layerTolerance, {*pAxis1, *pAxis2},
                           maxNeighborDistance);
@@ -321,11 +345,13 @@ SurfaceArray SurfaceArrayCreator::surfaceArrayOnPlane(
       const auto pAxis2 =
           createEquidistantAxis(gctx, surfacesRaw, AxisBoundaryType::Bound,
                                 AxisZ, protoLayer, fullTransform, bins2);
+      const Vector3 shift = fullTransform.translation();
       auto surface = Surface::makeShared<PlaneSurface>(
-          fullTransform,
-          std::make_shared<RectangleBounds>(
-              Vector2(protoLayer.min(AxisX), protoLayer.min(AxisY)),
-              Vector2(protoLayer.max(AxisX), protoLayer.max(AxisY))));
+          fullTransform, std::make_shared<RectangleBounds>(
+                             Vector2(protoLayer.min(AxisX) - shift.x(),
+                                     protoLayer.min(AxisZ) - shift.z()),
+                             Vector2(protoLayer.max(AxisX) - shift.x(),
+                                     protoLayer.max(AxisZ) - shift.z())));
       return SurfaceArray(gctx, std::move(surfaces), std::move(surface),
                           layerTolerance, {*pAxis1, *pAxis2},
                           maxNeighborDistance);
@@ -337,11 +363,13 @@ SurfaceArray SurfaceArrayCreator::surfaceArrayOnPlane(
       const auto pAxis2 =
           createEquidistantAxis(gctx, surfacesRaw, AxisBoundaryType::Bound,
                                 AxisY, protoLayer, fullTransform, bins2);
+      const Vector3 shift = fullTransform.translation();
       auto surface = Surface::makeShared<PlaneSurface>(
-          fullTransform,
-          std::make_shared<RectangleBounds>(
-              Vector2(protoLayer.min(AxisX), protoLayer.min(AxisY)),
-              Vector2(protoLayer.max(AxisX), protoLayer.max(AxisY))));
+          fullTransform, std::make_shared<RectangleBounds>(
+                             Vector2(protoLayer.min(AxisX) - shift.x(),
+                                     protoLayer.min(AxisY) - shift.y()),
+                             Vector2(protoLayer.max(AxisX) - shift.x(),
+                                     protoLayer.max(AxisY) - shift.y())));
       return SurfaceArray(gctx, std::move(surfaces), std::move(surface),
                           layerTolerance, {*pAxis1, *pAxis2},
                           maxNeighborDistance);
@@ -469,8 +497,10 @@ std::unique_ptr<const IAxis> SurfaceArrayCreator::createVariableAxis(
       return s->referencePosition(gctx, AxisZ).z();
     });
 
-    binEdges.push_back(protoLayer.min(AxisZ));
-    binEdges.push_back(protoLayer.max(AxisZ));
+    const double frameOffset = axisFrameOffset(AxisZ, transform);
+
+    binEdges.push_back(protoLayer.min(AxisZ) - frameOffset);
+    binEdges.push_back(protoLayer.max(AxisZ) - frameOffset);
 
     // the z-center position of the previous surface
     double previous = keys.front()->referencePosition(gctx, AxisZ).z();
@@ -480,7 +510,8 @@ std::unique_ptr<const IAxis> SurfaceArrayCreator::createVariableAxis(
       // positions in the binning direction of the current and previous
       // surface
       binEdges.push_back(
-          0.5 * (previous + (*surface)->referencePosition(gctx, AxisZ).z()));
+          0.5 * (previous + (*surface)->referencePosition(gctx, AxisZ).z()) -
+          frameOffset);
       previous = (*surface)->referencePosition(gctx, AxisZ).z();
     }
   } else {  // AxisR
@@ -527,8 +558,9 @@ std::unique_ptr<const IAxis> SurfaceArrayCreator::createEquidistantAxis(
   }
   // check the binning type first
 
-  double minimum = protoLayer.min(aDir, false);
-  double maximum = protoLayer.max(aDir, false);
+  const double frameOffset = axisFrameOffset(aDir, transform);
+  double minimum = protoLayer.min(aDir, false) - frameOffset;
+  double maximum = protoLayer.max(aDir, false) - frameOffset;
 
   std::size_t binNumber = 0;
   if (nBins == 0) {

--- a/Tests/UnitTests/Core/Geometry/SurfaceArrayCreatorTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/SurfaceArrayCreatorTests.cpp
@@ -10,6 +10,8 @@
 
 #include "Acts/Definitions/Algebra.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
+#include "Acts/Geometry/Layer.hpp"
+#include "Acts/Geometry/LayerCreator.hpp"
 #include "Acts/Geometry/ProtoLayer.hpp"
 #include "Acts/Geometry/SurfaceArrayCreator.hpp"
 #include "Acts/Surfaces/CylinderSurface.hpp"
@@ -495,6 +497,62 @@ BOOST_FIXTURE_TEST_CASE(SurfaceArrayCreator_createEquidistantAxis_Z,
   CHECK_CLOSE_ABS(axis->getMax(), 30.9749, 1e-3);
   CHECK_CLOSE_ABS(axis->getMin(), -0.974873, 1e-3);
   BOOST_CHECK_EQUAL(axis->getType(), AxisType::Equidistant);
+}
+
+// Axis values are derived from the surfaces but looked up as local coordinates
+// of the representative surface, which `LayerCreator` places at the layer
+// centre. For a barrel off z = 0 the two frames differ by the layer z position.
+BOOST_FIXTURE_TEST_CASE(SurfaceArrayCreator_zAxisInRepresentativeFrame,
+                        SurfaceArrayCreatorFixture) {
+  constexpr double layerZ = 500.;
+  constexpr std::size_t nPhi = 20;
+  constexpr std::size_t nZ = 5;
+
+  SrfVec surfaces;
+  for (std::size_t iz = 0; iz < nZ; ++iz) {
+    // modules tile in z: fullPhiTestSurfacesBRL has a half length of 1.5
+    const double z = layerZ + (static_cast<double>(iz) - 2.) * 3.;
+    SrfVec ring = fullPhiTestSurfacesBRL(nPhi, 0., z);
+    surfaces.insert(surfaces.end(), ring.begin(), ring.end());
+  }
+  auto surfacesRaw = unpackSmartPointers(surfaces);
+  ProtoLayer pl(tgContext, surfacesRaw);
+
+  LayerCreator::Config lcCfg;
+  lcCfg.surfaceArrayCreator = std::make_shared<const SurfaceArrayCreator>(
+      SurfaceArrayCreator::Config(),
+      getDefaultLogger("SurfaceArrayCreator", Logging::INFO));
+  LayerCreator layerCreator(lcCfg,
+                            getDefaultLogger("LayerCreator", Logging::INFO));
+
+  // identity transform, so LayerCreator shifts the layer to its own centre
+  auto layer = layerCreator.cylinderLayer(tgContext, surfaces, nPhi, nZ, pl);
+  const SurfaceArray* sa = layer->surfaceArray();
+  BOOST_REQUIRE(sa != nullptr);
+
+  const auto axes = sa->getAxes();
+  BOOST_CHECK_EQUAL(axes.at(1)->getNBins(), nZ);
+  // centred on the representative surface, not on z = 0
+  CHECK_CLOSE_ABS(0.5 * (axes.at(1)->getMin() + axes.at(1)->getMax()), 0.,
+                  1e-6);
+
+  // every module lands in its own z bin; a global-frame axis clamps them all
+  // into the edge bin
+  std::set<std::size_t> occupiedZBins;
+  for (const Surface* surface : surfacesRaw) {
+    const Vector3 centre = surface->center(tgContext);
+    // the representative cylinder's normal
+    const Vector3 radial = Vector3(centre.x(), centre.y(), 0.).normalized();
+    const auto content = sa->at(tgContext, centre, radial);
+    BOOST_CHECK(std::ranges::find(content, surface) != content.end());
+
+    const Vector3 local = sa->surfaceRepresentation()
+                              ->localToGlobalTransform(tgContext)
+                              .inverse() *
+                          centre;
+    occupiedZBins.insert(axes.at(1)->getBin(local.z()));
+  }
+  BOOST_CHECK_EQUAL(occupiedZBins.size(), nZ);
 }
 
 BOOST_FIXTURE_TEST_CASE(SurfaceArrayCreator_createEquidistantAxis_R,


### PR DESCRIPTION
The axis edges are derived from the surfaces but read as local coordinates of
the representative surface, which `LayerCreator` places at the layer centre.
The two frames then differ by the layer position, and `AxisBoundaryType::Bound`
clamps the whole layer into a single column instead of losing hits.

Subtract the representative surface's translation in `createEquidistantAxis`,
in `createVariableAxis` and from the plane bounds, which were additionally
built from the x/y extent while binning in x/z.
