### PR TITLE
feat: Write measurement indices in the arrow track converter

### DIFF
--- a/Examples/Io/Arrow/include/ActsExamples/Io/Arrow/ArrowTrackOutputConverter.hpp
+++ b/Examples/Io/Arrow/include/ActsExamples/Io/Arrow/ArrowTrackOutputConverter.hpp
@@ -27,8 +27,8 @@ namespace ActsExamples {
 ///
 /// The output table has one row per event with list-valued columns for the
 /// perigee parameters (d0, z0, phi, theta, qop), the majority truth particle
-/// id, the per-track measurement (hit) indices, and a running track index.
-/// The @c ParquetWriter stamps the @c event_id column.
+/// id, the per-track measurement indices, the per-track sim-hit indices, and
+/// a running track index. The @c ParquetWriter stamps the @c event_id column.
 class ACTS_ARROW_EXPORT ArrowTrackOutputConverter final
     : public ArrowOutputConverter {
  public:
@@ -44,10 +44,10 @@ class ACTS_ARROW_EXPORT ArrowTrackOutputConverter final
     /// it empty disables index resolution and forces the unmatched sentinel.
     std::string inputParticles;
     /// Optional measurement → sim-hit map. When set, each track-state's
-    /// measurement index is translated to one or more sim-hit indices (the
-    /// row indices of the corresponding hits parquet table); without it,
-    /// @c hit_ids is left empty so consumers don't mistake measurement
-    /// indices for sim-hit indices.
+    /// measurement index is additionally translated to one or more sim-hit
+    /// indices (the row indices of the corresponding hits parquet table) in
+    /// the @c hit_ids column; without it that column is null. The
+    /// @c measurement_ids column is written either way.
     std::string inputMeasurementSimHitsMap;
     /// Output whiteboard key for the resulting @c arrow::Table.
     std::string outputTable = "tracks";

--- a/Examples/Io/Arrow/include/ActsExamples/Io/Arrow/ArrowTrackOutputConverter.hpp
+++ b/Examples/Io/Arrow/include/ActsExamples/Io/Arrow/ArrowTrackOutputConverter.hpp
@@ -43,11 +43,9 @@ class ACTS_ARROW_EXPORT ArrowTrackOutputConverter final
     /// the @c ArrowParticleOutputConverter consumes for that table — leaving
     /// it empty disables index resolution and forces the unmatched sentinel.
     std::string inputParticles;
-    /// Optional measurement → sim-hit map. When set, each track-state's
-    /// measurement index is additionally translated to one or more sim-hit
-    /// indices (the row indices of the corresponding hits parquet table) in
-    /// the @c hit_ids column; without it that column is null. The
-    /// @c measurement_ids column is written either way.
+    /// Optional measurement → sim-hit map. When set, @c hit_ids holds the
+    /// row indices of the hits parquet table; without it that column is null.
+    /// @c measurement_ids is written either way.
     std::string inputMeasurementSimHitsMap;
     /// Output whiteboard key for the resulting @c arrow::Table.
     std::string outputTable = "tracks";

--- a/Examples/Io/Arrow/src/ArrowTrackOutputConverter.cpp
+++ b/Examples/Io/Arrow/src/ArrowTrackOutputConverter.cpp
@@ -12,6 +12,7 @@
 #include "ActsExamples/EventData/IndexSourceLink.hpp"
 #include "ActsPlugins/Arrow/ArrowUtil.hpp"
 
+#include <algorithm>
 #include <cmath>
 #include <cstdint>
 #include <limits>
@@ -81,6 +82,9 @@ ProcessCode ArrowTrackOutputConverter::execute(
   arrow::ListBuilder tList(pool, std::make_shared<arrow::FloatBuilder>(pool));
   arrow::ListBuilder majIdList(pool,
                                std::make_shared<arrow::UInt64Builder>(pool));
+  arrow::ListBuilder measIdsList(
+      pool, std::make_shared<arrow::ListBuilder>(
+                pool, std::make_shared<arrow::UInt32Builder>(pool)));
   arrow::ListBuilder hitIdsList(
       pool, std::make_shared<arrow::ListBuilder>(
                 pool, std::make_shared<arrow::UInt32Builder>(pool)));
@@ -100,7 +104,15 @@ ProcessCode ArrowTrackOutputConverter::execute(
     check(tList.AppendNull(), "append null t list");
   }
   check(majIdList.Append(), "open majority_particle_id list");
-  check(hitIdsList.Append(), "open hit_ids outer list");
+  check(measIdsList.Append(), "open measurement_ids outer list");
+  if (measToSimHits != nullptr) {
+    check(hitIdsList.Append(), "open hit_ids outer list");
+  } else {
+    // Whole-list null: encodes "no truth information" with one definition-level
+    // entry instead of N per-track empty lists, which a consumer could not
+    // distinguish from tracks without hits.
+    check(hitIdsList.AppendNull(), "append null hit_ids list");
+  }
   check(trackIdList.Append(), "open track_id list");
 
   auto* d0V = static_cast<arrow::FloatBuilder*>(d0List.value_builder());
@@ -110,6 +122,10 @@ ProcessCode ArrowTrackOutputConverter::execute(
   auto* qopV = static_cast<arrow::FloatBuilder*>(qopList.value_builder());
   auto* tV = static_cast<arrow::FloatBuilder*>(tList.value_builder());
   auto* majIdV = static_cast<arrow::UInt64Builder*>(majIdList.value_builder());
+  auto* measIdsInner =
+      static_cast<arrow::ListBuilder*>(measIdsList.value_builder());
+  auto* measIdsV =
+      static_cast<arrow::UInt32Builder*>(measIdsInner->value_builder());
   auto* hitIdsInner =
       static_cast<arrow::ListBuilder*>(hitIdsList.value_builder());
   auto* hitIdsV =
@@ -174,32 +190,39 @@ ProcessCode ArrowTrackOutputConverter::execute(
     }
     majIdV->UnsafeAppend(majId);
 
-    check(hitIdsInner->Append(), "open hit_ids inner list");
-    // Without a measurement→sim-hit map we leave the inner list empty rather
-    // than silently emit measurement indices, which would alias mismatched
-    // ids into a downstream sim-hit table.
+    // `trackStatesReversed()` walks outermost→innermost (the only direct
+    // iteration the MultiTrajectory proxy offers); buffer and reverse so the
+    // per-track lists come out inner→outer along the trajectory, which is what
+    // downstream consumers expect.
+    std::vector<Index> measIndices;
+    for (const auto& state : track.trackStatesReversed()) {
+      if (!state.hasUncalibratedSourceLink()) {
+        continue;
+      }
+      const auto sl =
+          state.getUncalibratedSourceLink().template get<IndexSourceLink>();
+      measIndices.push_back(static_cast<Index>(sl.index()));
+    }
+    std::ranges::reverse(measIndices);
+
+    check(measIdsInner->Append(), "open measurement_ids inner list");
+    for (const auto measIdx : measIndices) {
+      check(measIdsV->Append(static_cast<std::uint32_t>(measIdx)),
+            "append measurement_id");
+    }
+
+    // Sim-hit indices need the measurement→sim-hit map; without it the whole
+    // column is null (see above) and there are no inner lists to fill.
     if (measToSimHits != nullptr) {
-      // `trackStatesReversed()` walks outermost→innermost (the only direct
-      // iteration the MultiTrajectory proxy offers); buffer and reverse so
-      // the per-track list comes out inner→outer along the trajectory, which
-      // is what downstream consumers expect.
-      std::vector<std::uint32_t> hitIds;
-      for (const auto& state : track.trackStatesReversed()) {
-        if (!state.hasUncalibratedSourceLink()) {
-          continue;
-        }
-        const auto sl =
-            state.getUncalibratedSourceLink().template get<IndexSourceLink>();
-        const auto measIdx = static_cast<Index>(sl.index());
+      check(hitIdsInner->Append(), "open hit_ids inner list");
+      for (const auto measIdx : measIndices) {
         // One measurement may map to multiple sim hits (clustering merged
         // them); flatten them into the per-track list.
         auto range = measToSimHits->equal_range(measIdx);
         for (auto it = range.first; it != range.second; ++it) {
-          hitIds.push_back(static_cast<std::uint32_t>(it->second));
+          check(hitIdsV->Append(static_cast<std::uint32_t>(it->second)),
+                "append hit_id");
         }
-      }
-      for (auto rit = hitIds.rbegin(); rit != hitIds.rend(); ++rit) {
-        check(hitIdsV->Append(*rit), "append hit_id");
       }
     }
 
@@ -213,9 +236,10 @@ ProcessCode ArrowTrackOutputConverter::execute(
   };
 
   std::vector<std::shared_ptr<arrow::Array>> arrays = {
-      finish(d0List),     finish(z0List),      finish(phiList),
-      finish(thetaList),  finish(qopList),     finish(majIdList),
-      finish(hitIdsList), finish(trackIdList), finish(tList),
+      finish(d0List),      finish(z0List),     finish(phiList),
+      finish(thetaList),   finish(qopList),    finish(majIdList),
+      finish(measIdsList), finish(hitIdsList), finish(trackIdList),
+      finish(tList),
   };
 
   auto table =

--- a/Examples/Io/Arrow/src/ArrowTrackOutputConverter.cpp
+++ b/Examples/Io/Arrow/src/ArrowTrackOutputConverter.cpp
@@ -108,9 +108,8 @@ ProcessCode ArrowTrackOutputConverter::execute(
   if (measToSimHits != nullptr) {
     check(hitIdsList.Append(), "open hit_ids outer list");
   } else {
-    // Whole-list null: encodes "no truth information" with one definition-level
-    // entry instead of N per-track empty lists, which a consumer could not
-    // distinguish from tracks without hits.
+    // Null column, not N empty lists: lets a consumer tell "no truth
+    // available" from "track has no hits".
     check(hitIdsList.AppendNull(), "append null hit_ids list");
   }
   check(trackIdList.Append(), "open track_id list");
@@ -190,11 +189,10 @@ ProcessCode ArrowTrackOutputConverter::execute(
     }
     majIdV->UnsafeAppend(majId);
 
-    // `trackStatesReversed()` walks outermost→innermost (the only direct
-    // iteration the MultiTrajectory proxy offers); buffer and reverse so the
-    // per-track lists come out inner→outer along the trajectory, which is what
-    // downstream consumers expect.
+    // `trackStatesReversed()` is the only iteration the proxy garantuees;
+    // reverse so the lists come out inner→outer, as consumers expect.
     std::vector<Index> measIndices;
+    measIndices.reserve(track.nMeasurements());
     for (const auto& state : track.trackStatesReversed()) {
       if (!state.hasUncalibratedSourceLink()) {
         continue;
@@ -211,8 +209,6 @@ ProcessCode ArrowTrackOutputConverter::execute(
             "append measurement_id");
     }
 
-    // Sim-hit indices need the measurement→sim-hit map; without it the whole
-    // column is null (see above) and there are no inner lists to fill.
     if (measToSimHits != nullptr) {
       check(hitIdsInner->Append(), "open hit_ids inner list");
       for (const auto measIdx : measIndices) {

--- a/Plugins/Arrow/include/ActsPlugins/Arrow/ArrowUtil.hpp
+++ b/Plugins/Arrow/include/ActsPlugins/Arrow/ArrowUtil.hpp
@@ -141,10 +141,9 @@ ACTS_ARROW_EXPORT std::shared_ptr<arrow::Schema> particleSchema();
 
 /// Schema for the per-event track table emitted by
 /// @c ArrowTrackOutputConverter. The @c t and @c hit_ids columns are nullable
-/// at the outer level so writers running with @c writeTime=false, or without a
-/// measurement → sim-hit map, can emit a single null per event row instead of
-/// an opened list of N inner nulls. @c measurement_ids is always written; only
-/// @c hit_ids requires truth information.
+/// at the outer level, so a writer lacking time info or a measurement →
+/// sim-hit map emits one null per event row instead of N inner nulls.
+/// @c measurement_ids is always written; only @c hit_ids needs truth.
 ACTS_ARROW_EXPORT std::shared_ptr<arrow::Schema> trackSchema();
 
 /// Schema for the per-event simulated-hit table emitted by

--- a/Plugins/Arrow/include/ActsPlugins/Arrow/ArrowUtil.hpp
+++ b/Plugins/Arrow/include/ActsPlugins/Arrow/ArrowUtil.hpp
@@ -140,9 +140,11 @@ ACTS_ARROW_EXPORT std::shared_ptr<arrow::Table> withEventId(
 ACTS_ARROW_EXPORT std::shared_ptr<arrow::Schema> particleSchema();
 
 /// Schema for the per-event track table emitted by
-/// @c ArrowTrackOutputConverter. The @c t column is nullable at the outer
-/// level so writers running with @c writeTime=false can emit a single null
-/// per event row instead of an opened list of N inner nulls.
+/// @c ArrowTrackOutputConverter. The @c t and @c hit_ids columns are nullable
+/// at the outer level so writers running with @c writeTime=false, or without a
+/// measurement → sim-hit map, can emit a single null per event row instead of
+/// an opened list of N inner nulls. @c measurement_ids is always written; only
+/// @c hit_ids requires truth information.
 ACTS_ARROW_EXPORT std::shared_ptr<arrow::Schema> trackSchema();
 
 /// Schema for the per-event simulated-hit table emitted by

--- a/Plugins/Arrow/src/ArrowUtil.cpp
+++ b/Plugins/Arrow/src/ArrowUtil.cpp
@@ -180,7 +180,9 @@ std::shared_ptr<arrow::Schema> trackSchema() {
       arrow::field("theta", nullableFloatList(), false),
       arrow::field("qop", nullableFloatList(), false),
       arrow::field("majority_particle_id", arrow::list(arrow::uint64()), false),
-      arrow::field("hit_ids", arrow::list(arrow::list(arrow::uint32())), false),
+      arrow::field("measurement_ids", arrow::list(arrow::list(arrow::uint32())),
+                   false),
+      arrow::field("hit_ids", arrow::list(arrow::list(arrow::uint32())), true),
       arrow::field("track_id", arrow::list(arrow::uint16()), false),
       arrow::field("t", nullableFloatList(), true),
   });

--- a/Python/Examples/tests/test_arrow.py
+++ b/Python/Examples/tests/test_arrow.py
@@ -667,6 +667,9 @@ def test_reader_schema_evolution_added_optional_column(tmp_path):
                 "majority_particle_id": pa.array(
                     [[1]], type=field_type("majority_particle_id")
                 ),
+                "measurement_ids": pa.array(
+                    [[[1, 2, 3]]], type=field_type("measurement_ids")
+                ),
                 "hit_ids": pa.array([[[1, 2, 3]]], type=field_type("hit_ids")),
                 "track_id": pa.array([[7]], type=field_type("track_id")),
             },
@@ -786,6 +789,9 @@ def test_python_alg_writes_arrow_table(tmp_path):
                     "majority_particle_id": pa.array(
                         [[1]], type=field_type("majority_particle_id")
                     ),
+                    "measurement_ids": pa.array(
+                        [[[1, 2, 3]]], type=field_type("measurement_ids")
+                    ),
                     "hit_ids": pa.array([[[1, 2, 3]]], type=field_type("hit_ids")),
                     "track_id": pa.array([[7]], type=field_type("track_id")),
                     "t": pa.array([None], type=field_type("t")),
@@ -830,6 +836,85 @@ def test_python_alg_writes_arrow_table(tmp_path):
     assert (
         TrackConsumer.events_seen == nevents
     ), f"consumer saw {TrackConsumer.events_seen} events, expected {nevents}"
+
+
+@pytest.mark.pypi
+@pytest.mark.parametrize("withSimHitMap", [False, True])
+def test_track_converter_hit_indices(withSimHitMap):
+    """`measurement_ids` is written from the track states alone; `hit_ids`
+    needs the measurement->sim-hit map and is null without it."""
+    pa = pytest.importorskip("pyarrow")
+
+    from acts.arrow import ArrowTable
+    from acts.examples import (
+        ConstTrackContainer,
+        IndexSourceLink,
+        MeasurementSimHitsMap,
+        ReadDataHandle,
+        TrackContainer,
+        WriteDataHandle,
+    )
+    from acts.examples.arrow import ArrowTrackOutputConverter
+
+    # One track over measurements 2 and 5, each mapping to one sim hit.
+    measIndices = [2, 5]
+    simHitIndices = [20, 50]
+
+    class TrackProducer(acts.examples.IAlgorithm):
+        def __init__(self):
+            super().__init__(name="TrackProducer", level=acts.logging.INFO)
+            self._tracks = WriteDataHandle(self, ConstTrackContainer, "tracks")
+            self._tracks.initialize("tracks")
+            self._map = WriteDataHandle(self, MeasurementSimHitsMap, "meas_simhits")
+            self._map.initialize("meas_simhits")
+
+        def execute(self, ctx):
+            tracks = TrackContainer()
+            track = tracks.makeTrack()
+            for measIdx in measIndices:
+                state = track.appendTrackState()
+                state.uncalibratedSourceLink = IndexSourceLink(
+                    geometryId=acts.GeometryIdentifier(), index=measIdx
+                ).toSourceLink()
+            self._tracks(ctx, tracks.makeConst())
+
+            measToSimHits = MeasurementSimHitsMap()
+            for measIdx, hitIdx in zip(measIndices, simHitIndices):
+                measToSimHits.insert(measIdx, hitIdx)
+            self._map(ctx, measToSimHits)
+
+            return acts.examples.ProcessCode.SUCCESS
+
+    class TableCheck(acts.examples.IAlgorithm):
+        events_seen = 0
+
+        def __init__(self):
+            super().__init__(name="TableCheck", level=acts.logging.INFO)
+            self._in = ReadDataHandle(self, ArrowTable, "tracks_arrow")
+            self._in.initialize("tracks_arrow")
+
+        def execute(self, ctx):
+            t = self._in(ctx.eventStore).as_table()
+            assert t.column("measurement_ids").to_pylist() == [[measIndices]]
+            expected = [[simHitIndices]] if withSimHitMap else [None]
+            assert t.column("hit_ids").to_pylist() == expected
+            type(self).events_seen += 1
+            return acts.examples.ProcessCode.SUCCESS
+
+    s = Sequencer(numThreads=1, events=2)
+    s.addAlgorithm(TrackProducer())
+    s.addAlgorithm(
+        ArrowTrackOutputConverter(
+            level=acts.logging.INFO,
+            inputTracks="tracks",
+            inputMeasurementSimHitsMap="meas_simhits" if withSimHitMap else "",
+            outputTable="tracks_arrow",
+        )
+    )
+    s.addAlgorithm(TableCheck())
+    s.run()
+
+    assert TableCheck.events_seen == 2
 
 
 @pytest.mark.pypi


### PR DESCRIPTION
The track output table only carried sim-hit indices, and only when an
`inputMeasurementSimHitsMap` was configured. Since the track-to-hit
association is a pure reconstruction quantity, this made it impossible to
export tracks without simulation truth, e.g. on data.

Add a `measurement_ids` column that is always written from the track
states. `hit_ids` keeps the sim-hit indices, but is now nullable at the
outer level: without the measurement -> sim-hit map the whole column is a
single null per event.