### PR TITLE
perf(detray): Avoid local memory config copies in navigation

### DIFF
--- a/Detray/core/include/detray/navigation/caching_navigator.hpp
+++ b/Detray/core/include/detray/navigation/caching_navigator.hpp
@@ -91,7 +91,7 @@ class caching_navigator
     template <typename track_t, typename state_t, typename ctx_t>
     friend constexpr void navigation::local_navigation(
         const track_t &, state_t &, const navigation::config &, const ctx_t &,
-        const bool);
+        const float);
 
     template <typename track_t, typename state_t, typename ctx_t>
     friend constexpr void navigation::volume_switch(const track_t &, state_t &,
@@ -347,9 +347,8 @@ class caching_navigator
     if (navigation.trust_level() == navigation::trust_level::e_no_trust) {
       DETRAY_VERBOSE_HOST_DEVICE("Called 'update()' - no trust");
 
-      constexpr bool resolve_overstepping{true};
       navigation::local_navigation(track, navigation, cfg, ctx,
-                                   resolve_overstepping);
+                                   cfg.intersection.overstep_tolerance);
       return is_init;
     }
 

--- a/Detray/core/include/detray/navigation/detail/navigation_functions.hpp
+++ b/Detray/core/include/detray/navigation/detail/navigation_functions.hpp
@@ -181,7 +181,7 @@ DETRAY_HOST_DEVICE
                                     navigation_state_t &navigation,
                                     const navigation::config &cfg,
                                     const context_t &ctx,
-                                    const bool resolve_overstepping = true) {
+                                    const float overstep_tolerance) {
   DETRAY_VERBOSE_HOST_DEVICE("-> (Re-)initialize detector volume (idx: %d)",
                              navigation.volume());
 
@@ -199,9 +199,7 @@ DETRAY_HOST_DEVICE
   // Overstepping resolution needed? (if not, make sure full tolerance band is
   // observed around surface)
   intersection::config intr_cfg{cfg.intersection};
-  intr_cfg.overstep_tolerance = resolve_overstepping
-                                    ? cfg.intersection.overstep_tolerance
-                                    : -cfg.intersection.path_tolerance;
+  intr_cfg.overstep_tolerance = overstep_tolerance;
 
   using detector_t = typename navigation_state_t::detector_type;
   using algebra_t = typename detector_t::algebra_type;
@@ -272,55 +270,14 @@ DETRAY_HOST_DEVICE DETRAY_INLINE constexpr void volume_switch(
   // Check valid volume index
   assert(navigation.volume() < navigation.detector().volumes().size());
 
-  // Initialize new volume. Still on portal: No need to observe overstepping
-  local_navigation(track, navigation, cfg, ctx);
+  // Initialize new volume.
+  local_navigation(track, navigation, cfg, ctx,
+                   cfg.intersection.overstep_tolerance);
 
   // Fresh initialization, reset trust even though we are on [inner] portal
   navigation.trust_level(navigation::trust_level::e_full);
 
   DETRAY_VERBOSE_HOST_DEVICE("-> Switched to volume %d", navigation.volume());
-}
-
-/// @brief Initialize the volume with loose configuration.
-///
-/// If trust cannot be established and/or no surfaces can be found in the
-/// current volume anymore, try to save the navigation stream by looking
-/// for candidates further behind the track position.
-///
-/// @tparam track_t type of track, needs to provide pos() and dir() methods
-/// @tparam navigation_state_t the state type of the navigation stream
-/// @tparam context_t the type of geometry context
-///
-/// @param track access to the track parameters
-/// @param navigation the current navigation state
-/// @param loose_cfg the navigation configuration (copy on function stack)
-/// @param ctx the geometry context
-template <typename track_t, typename navigation_state_t, typename context_t>
-DETRAY_HOST_DEVICE DETRAY_INLINE constexpr void init_loose_cfg(
-    const track_t &track, navigation_state_t &navigation,
-    navigation::config loose_cfg, const context_t &ctx) {
-  if (navigation.trust_level() != navigation::trust_level::e_full) {
-    DETRAY_VERBOSE_HOST_DEVICE("Full trust could not be restored!");
-  } else if (navigation.cache_exhausted()) {
-    DETRAY_VERBOSE_HOST_DEVICE("Cache exhausted!");
-  }
-  DETRAY_VERBOSE_HOST_DEVICE("RESCURE MODE: Run init with large tolerances");
-
-  // Use the max mask tolerance in case a track leaves the volume
-  // when a sf is 'sticking' out of the portals due to the tol
-  const auto new_overstep_tol{
-      math::min(100.f * loose_cfg.intersection.overstep_tolerance,
-                -10.f * loose_cfg.intersection.max_mask_tolerance)};
-  loose_cfg.intersection.overstep_tolerance = new_overstep_tol;
-
-  constexpr bool resolve_overstepping{true};
-  local_navigation(track, navigation, loose_cfg, ctx, resolve_overstepping);
-
-  // Unrecoverable
-  if (navigation.trust_level() != navigation::trust_level::e_full ||
-      navigation.cache_exhausted()) [[unlikely]] {
-    navigation.abort("No reachable surfaces");
-  }
 }
 
 }  // namespace detray::navigation

--- a/Detray/core/include/detray/navigation/navigator.hpp
+++ b/Detray/core/include/detray/navigation/navigator.hpp
@@ -70,7 +70,7 @@ class navigator : public navigator_base<
     template <typename track_t, typename state_t, typename ctx_t>
     friend constexpr void navigation::local_navigation(
         const track_t &, state_t &, const navigation::config &, const ctx_t &,
-        const bool);
+        const float);
 
     template <typename track_t, typename state_t, typename ctx_t>
     friend constexpr void navigation::volume_switch(const track_t &, state_t &,
@@ -202,9 +202,8 @@ class navigator : public navigator_base<
     assert(navigation.trust_level() == navigation::trust_level::e_no_trust);
     DETRAY_VERBOSE_HOST_DEVICE("Called 'update()' - no trust");
 
-    constexpr bool resolve_overstepping{true};
     navigation::local_navigation(track, navigation, cfg, ctx,
-                                 resolve_overstepping);
+                                 cfg.intersection.overstep_tolerance);
     return is_init;
   }
 };

--- a/Detray/core/include/detray/navigation/navigator_base.hpp
+++ b/Detray/core/include/detray/navigation/navigator_base.hpp
@@ -60,7 +60,9 @@ class navigator_base {
       const bool resolve_overstepping = false) const {
     // Run local navigation in the current volume
     navigation::local_navigation(track, navigation, cfg, ctx,
-                                 resolve_overstepping);
+                                 resolve_overstepping
+                                     ? cfg.intersection.overstep_tolerance
+                                     : -cfg.intersection.path_tolerance);
 
     DETRAY_VERBOSE_HOST("Status: " << navigation.status() << " (next sf.: "
                                    << navigation.next_surface().index() << ")");
@@ -126,7 +128,27 @@ class navigator_base {
     if (navigation.trust_level() != navigation::trust_level::e_full ||
         navigation.cache_exhausted()) {
       is_init = true;
-      navigation::init_loose_cfg(track, navigation, cfg, ctx);
+      if (navigation.trust_level() != navigation::trust_level::e_full) {
+        DETRAY_VERBOSE_HOST_DEVICE("Full trust could not be restored!");
+      } else if (navigation.cache_exhausted()) {
+        DETRAY_VERBOSE_HOST_DEVICE("Cache exhausted!");
+      }
+      DETRAY_VERBOSE_HOST_DEVICE(
+          "RESCURE MODE: Run init with large tolerances");
+
+      // Use the max mask tolerance in case a track leaves the volume
+      // when a sf is 'sticking' out of the portals due to the tol
+      const auto new_overstep_tol{
+          math::min(100.f * cfg.intersection.overstep_tolerance,
+                    -10.f * cfg.intersection.max_mask_tolerance)};
+
+      local_navigation(track, navigation, cfg, ctx, new_overstep_tol);
+
+      // Unrecoverable
+      if (navigation.trust_level() != navigation::trust_level::e_full ||
+          navigation.cache_exhausted()) [[unlikely]] {
+        navigation.abort("No reachable surfaces");
+      }
 
       navigation.run_inspector(cfg, track.pos(), track.dir(), "Re-init: ");
     }


### PR DESCRIPTION
The local_navigation is, in one location, called with a copy of the navigation configuration. Because this object passes an ABI boundary by reference, it is necessarily put into local memory and thus eats up stack space. The only config difference here is the overstep tolerance, which can (as a scalar) replace the existing boolean argument.