### PR TITLE
feat: Let a GBTS caller ask whether its strips arrived

### DIFF
--- a/Core/include/Acts/Seeding/GbtsNodeStorage.hpp
+++ b/Core/include/Acts/Seeding/GbtsNodeStorage.hpp
@@ -124,6 +124,12 @@ class GbtsNodeStorage final {
     return m_nodes.copiedFromIndexColumn()[node];
   }
 
+  /// Whether any node carries a stereo pair, i.e. whether the graph has a
+  /// strip path to take. A caller that fed strip space points in can check
+  /// here that their pairs arrived.
+  /// @return Whether there are any
+  bool hasStrips() const { return !m_strips.empty(); }
+
  private:
   // Only the seeder builds one and walks the graph inside it.
   friend class GraphBasedTrackSeeder;
@@ -199,11 +205,6 @@ class GbtsNodeStorage final {
            "node carries no stereo pair");
     return m_strips[m_stripIndex[node]];
   }
-
-  /// Whether any node carries a stereo pair, i.e. whether the graph has a
-  /// strip path to take.
-  /// @return Whether there are any
-  bool hasStrips() const { return !m_strips.empty(); }
 
   /// A node as recorded by `insert`, before sorting.
   struct StagedNode {


### PR DESCRIPTION
`hasStrips` is private, so only the seeder can ask. The stereo pair goes into `insert` as an optional pointer, so an integration that gets it wrong loses every strip cut in the graph, silently. Make the accessor public: it answers a question about what the caller put in, and that half of the storage is public already.