### PR TITLE
refactor(Json): decouple surface and surface bounds json decoding

### DIFF
--- a/Plugins/Json/include/ActsPlugins/Json/SurfaceJsonConverter.hpp
+++ b/Plugins/Json/include/ActsPlugins/Json/SurfaceJsonConverter.hpp
@@ -73,8 +73,20 @@ class SurfaceJsonConverter {
       TypeDispatcher<Surface,
                      nlohmann::json(const GeometryContext&, const Options&)>;
 
-  /// Deccoder type for the surfaces
-  using SurfaceDecoder = JsonKindDispatcher<std::shared_ptr<Surface>>;
+  /// Decoder type for the surface bounds
+  ///
+  /// Keyed on the serialized SurfaceBounds::BoundsType, independently of the
+  /// surface carrying them. Returns nullptr for boundless surfaces.
+  using SurfaceBoundsDecoder =
+      JsonKindDispatcher<std::shared_ptr<const SurfaceBounds>>;
+
+  /// Decoder type for the surfaces
+  ///
+  /// Keyed on the serialized Surface::SurfaceType and handed the already
+  /// decoded bounds, which it narrows to the type it stores.
+  using SurfaceDecoder =
+      JsonKindDispatcher<std::shared_ptr<Surface>,
+                         std::shared_ptr<const SurfaceBounds>>;
 
   /// Configuration struct
   struct Config {
@@ -84,7 +96,9 @@ class SurfaceJsonConverter {
     SurfaceBoundsEncoder surfaceBoundsEncoder{};
 
     /// Decoder for the surfaces
-    SurfaceDecoder surfaceDecoder{};
+    SurfaceDecoder surfaceDecoder{"type", "surface"};
+    /// Decoder for the surface bounds
+    SurfaceBoundsDecoder surfaceBoundsDecoder{"type", "surface bounds"};
 
     /// Default configuration construction
     ///

--- a/Plugins/Json/src/SurfaceJsonConverter.cpp
+++ b/Plugins/Json/src/SurfaceJsonConverter.cpp
@@ -15,12 +15,14 @@
 #include "Acts/Surfaces/CylinderBounds.hpp"
 #include "Acts/Surfaces/CylinderSurface.hpp"
 #include "Acts/Surfaces/DiamondBounds.hpp"
+#include "Acts/Surfaces/DiscBounds.hpp"
 #include "Acts/Surfaces/DiscSurface.hpp"
 #include "Acts/Surfaces/DiscTrapezoidBounds.hpp"
 #include "Acts/Surfaces/EllipseBounds.hpp"
 #include "Acts/Surfaces/InfiniteBounds.hpp"
 #include "Acts/Surfaces/LineBounds.hpp"
 #include "Acts/Surfaces/PerigeeSurface.hpp"
+#include "Acts/Surfaces/PlanarBounds.hpp"
 #include "Acts/Surfaces/PlaneSurface.hpp"
 #include "Acts/Surfaces/PointBounds.hpp"
 #include "Acts/Surfaces/PointSurface.hpp"
@@ -35,72 +37,20 @@
 #include "ActsPlugins/Json/SurfaceBoundsJsonConverter.hpp"
 
 #include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
 
 namespace {
 
-// @brief Get string representation of the surface bounds kind
-//
-// @return string representation of the surface bounds kind
-template <typename bounds_t>
-std::string getSurfaceBoundsKind() {
-  if (std::is_same_v<bounds_t, Acts::EllipseBounds>) {
-    return "Ellipse";
-  } else if (std::is_same_v<bounds_t, Acts::RectangleBounds>) {
-    return "Rectangle";
-  } else if (std::is_same_v<bounds_t, Acts::TrapezoidBounds>) {
-    return "Trapezoid";
-  } else if (std::is_same_v<bounds_t, Acts::DiamondBounds>) {
-    return "Diamond";
-  } else if (std::is_same_v<bounds_t, Acts::AnnulusBounds>) {
-    return "Annulus";
-  } else if (std::is_same_v<bounds_t, Acts::RadialBounds>) {
-    return "Radial";
-  } else if (std::is_same_v<bounds_t, Acts::DiscTrapezoidBounds>) {
-    return "DiscTrapezoid";
-  } else if (std::is_same_v<bounds_t, Acts::CylinderBounds>) {
-    return "Cylinder";
-  } else if (std::is_same_v<bounds_t, Acts::ConeBounds>) {
-    return "Cone";
-  } else if (std::is_same_v<bounds_t, Acts::LineBounds>) {
-    return "Line";
-  } else if (std::is_same_v<bounds_t, Acts::PointBounds>) {
-    return "Point";
-  } else if (std::is_same_v<bounds_t, Acts::ConvexPolygonBoundsBase>) {
-    // Single kind for every Acts::ConvexPolygonBounds<N> specialization
-    // (including PolygonDynamic), routed via the abstract base class so the
-    // TypeDispatcher only needs one registration.
-    return "ConvexPolygon";
-  } else if (std::is_same_v<bounds_t, Acts::SurfaceBounds>) {
-    return "DefaultBounds";
-  } else if (std::is_same_v<bounds_t, Acts::InfiniteBounds>) {
-    return "Infinite";
-  } else {
-    throw std::invalid_argument("Unknown surface bounds kind");
-  }
+// @brief Registration key for a surface, from the serialized SurfaceType
+std::string surfaceKey(Acts::Surface::SurfaceType type) {
+  return nlohmann::json(type).get<std::string>();
 }
 
-// @brief Get string representation of the surface kind
-//
-// @return string representation of the surface kind
-template <typename surface_t>
-std::string getSurfaceKind() {
-  if (std::is_same_v<surface_t, Acts::PlaneSurface>) {
-    return "Plane";
-  } else if (std::is_same_v<surface_t, Acts::DiscSurface>) {
-    return "Disc";
-  } else if (std::is_same_v<surface_t, Acts::CylinderSurface>) {
-    return "Cylinder";
-  } else if (std::is_same_v<surface_t, Acts::ConeSurface>) {
-    return "Cone";
-  } else if (std::is_same_v<surface_t, Acts::StrawSurface>) {
-    return "Straw";
-  } else if (std::is_same_v<surface_t, Acts::PerigeeSurface>) {
-    return "Perigee";
-  } else if (std::is_same_v<surface_t, Acts::PointSurface>) {
-    return "Point";
-  } else {
-    throw std::invalid_argument("Unknown surface kind");
-  }
+// @brief Registration key for surface bounds, from the serialized BoundsType
+std::string boundsKey(Acts::SurfaceBounds::BoundsType type) {
+  return nlohmann::json(type).get<std::string>();
 }
 
 // @brief Type-based surface bounds json encoding
@@ -112,20 +62,18 @@ std::string getSurfaceKind() {
 // @return json representation of the surface bounds
 template <typename bounds_t>
 nlohmann::json surfaceBoundsToJsonT(const bounds_t& bounds) {
-  nlohmann::json jBounds = Acts::SurfaceBoundsJsonConverter::toJson(bounds);
-  jBounds["kind"] = getSurfaceBoundsKind<bounds_t>();
-  return jBounds;
+  return Acts::SurfaceBoundsJsonConverter::toJson(bounds);
 }
 
 // @brief Type-based surface json encoding
 //
 // @tparam surface_t surface type
 //
-// @param bounds surface to be converted
+// @param surface surface to be converted
 // @param gctx geometry context
 // @param opt surface json conversion options
 //
-// @return json representation of the surface bounds
+// @return json representation of the surface
 template <typename surface_t>
 nlohmann::json surfaceToJsonT(const surface_t& surface,
                               const Acts::GeometryContext& gctx,
@@ -142,41 +90,71 @@ nlohmann::json surfaceToJsonT(const surface_t& surface,
     jSurface["material"] =
         nlohmann::json(surface.surfaceMaterial())["material"];
   }
-  jSurface["kind"] = getSurfaceKind<surface_t>();
   return jSurface;
 }
 
-// @brief Type-based surface json decoding
+// @brief Type-based surface bounds json decoding
 //
-// @tparam surface_t surface type
-//
-// @param j json encoding of the surface
-//
-// @return shared pointer to the decoded surface
-template <typename surface_t>
-std::shared_ptr<Acts::Surface> surfaceFromJsonT(const nlohmann::json& j) {
-  nlohmann::json jTransform = j["transform"];
-  Acts::Transform3 sTransform =
-      Acts::Transform3JsonConverter::fromJson(jTransform);
-  return Acts::Surface::makeShared<surface_t>(sTransform);
-}
-
-// @brief Type-based surface json decoding
-//
-// @tparam surface_t surface type
 // @tparam bounds_t surface bounds type
 //
+// @param j json encoding of the surface bounds
+//
+// @return shared pointer to the decoded bounds, as the base type
+template <typename bounds_t>
+std::shared_ptr<const Acts::SurfaceBounds> boundsFromJsonT(
+    const nlohmann::json& j) {
+  return Acts::SurfaceBoundsJsonConverter::fromJson<bounds_t>(j);
+}
+
+// @brief Surface json decoding from already decoded bounds
+//
+// @tparam surface_t surface type
+// @tparam bounds_t bounds base type the surface stores
+//
 // @param j json encoding of the surface
+// @param bounds the bounds decoded from the surface's "bounds" payload
 //
 // @return shared pointer to the decoded surface
 template <typename surface_t, typename bounds_t>
-std::shared_ptr<Acts::Surface> surfaceFromJsonT(const nlohmann::json& j) {
-  nlohmann::json jTransform = j["transform"];
+std::shared_ptr<Acts::Surface> surfaceFromJsonT(
+    const nlohmann::json& j,
+    const std::shared_ptr<const Acts::SurfaceBounds>& bounds) {
   Acts::Transform3 sTransform =
-      Acts::Transform3JsonConverter::fromJson(jTransform);
-  nlohmann::json jBounds = j["bounds"];
-  auto sBounds = Acts::SurfaceBoundsJsonConverter::fromJson<bounds_t>(jBounds);
+      Acts::Transform3JsonConverter::fromJson(j["transform"]);
+
+  std::shared_ptr<const bounds_t> sBounds{};
+  if (bounds != nullptr) {
+    sBounds = std::dynamic_pointer_cast<const bounds_t>(bounds);
+    // The surface/bounds pairing is only checked here, at decode time
+    if (sBounds == nullptr) {
+      throw std::invalid_argument(
+          "Surface of type " + j.at("type").get<std::string>() +
+          " cannot be built from bounds of type " + boundsKey(bounds->type()));
+    }
+  }
   return Acts::Surface::makeShared<surface_t>(sTransform, std::move(sBounds));
+}
+
+// @brief Surface json decoding for surfaces that carry no bounds
+//
+// @tparam surface_t surface type
+//
+// @param j json encoding of the surface
+// @param bounds must be nullptr for these surfaces
+//
+// @return shared pointer to the decoded surface
+template <typename surface_t>
+std::shared_ptr<Acts::Surface> boundlessSurfaceFromJsonT(
+    const nlohmann::json& j,
+    const std::shared_ptr<const Acts::SurfaceBounds>& bounds) {
+  if (bounds != nullptr) {
+    throw std::invalid_argument("Surface of type " +
+                                j.at("type").get<std::string>() +
+                                " does not accept bounds");
+  }
+  Acts::Transform3 sTransform =
+      Acts::Transform3JsonConverter::fromJson(j["transform"]);
+  return Acts::Surface::makeShared<surface_t>(sTransform);
 }
 
 }  // namespace
@@ -241,43 +219,49 @@ Acts::SurfaceJsonConverter::Config::defaultConfig() {
       surfaceBoundsToJsonT<InfiniteBounds>);
   // ConvexPolygonBounds is templated on the vertex count N. Registering the
   // abstract ConvexPolygonBoundsBase lets a single encoder handle every
-  // specialization (ConvexPolygonBounds<3>, <4>, <6>, ..., <PolygonDynamic>);
-  // the runtime dynamic_cast inside TypeDispatcher resolves them all to the
-  // same handler. This fixes the regression introduced by PR #5195 where TGeo
-  // shapes that produce ConvexPolygonBounds<4> (e.g. TGeoTrap / TGeoArb8) made
-  // the JsonSurfacesWriter throw "No function registered for type:
-  // Acts::ConvexPolygonBounds<4>".
+  // specialization; the runtime dynamic_cast inside TypeDispatcher resolves
+  // them all to the same handler.
   cfg.surfaceBoundsEncoder.registerFunction(
       surfaceBoundsToJsonT<ConvexPolygonBoundsBase>);
 
-  // Decoders
-  cfg.surfaceDecoder.registerKind(
-      getSurfaceKind<PlaneSurface>() + getSurfaceBoundsKind<EllipseBounds>(),
-      surfaceFromJsonT<PlaneSurface, EllipseBounds>);
-  cfg.surfaceDecoder.registerKind(
-      getSurfaceKind<PlaneSurface>() + getSurfaceBoundsKind<RectangleBounds>(),
-      surfaceFromJsonT<PlaneSurface, RectangleBounds>);
-  cfg.surfaceDecoder.registerKind(
-      getSurfaceKind<PlaneSurface>() + getSurfaceBoundsKind<TrapezoidBounds>(),
-      surfaceFromJsonT<PlaneSurface, TrapezoidBounds>);
-  cfg.surfaceDecoder.registerKind(
-      getSurfaceKind<PlaneSurface>() + getSurfaceBoundsKind<DiamondBounds>(),
-      surfaceFromJsonT<PlaneSurface, DiamondBounds>);
-  cfg.surfaceDecoder.registerKind(
-      getSurfaceKind<PlaneSurface>() + getSurfaceBoundsKind<InfiniteBounds>(),
-      surfaceFromJsonT<PlaneSurface>);
-  // Custom decoder for ConvexPolygonBounds: the number of vertices is encoded
-  // only via the size of the "values" array (2 doubles per vertex), so we
-  // build a dynamically-sized polygon. The kind string ("PlaneConvexPolygon")
-  // is the same one the encoder writes, since getSurfaceBoundsKind returns
-  // "ConvexPolygon" for any ConvexPolygonBounds<N>.
-  cfg.surfaceDecoder.registerKind(
-      getSurfaceKind<PlaneSurface>() +
-          getSurfaceBoundsKind<ConvexPolygonBoundsBase>(),
-      [](const nlohmann::json& j) -> std::shared_ptr<Surface> {
-        Transform3 sTransform =
-            Transform3JsonConverter::fromJson(j["transform"]);
-        std::vector<double> bVector = j["bounds"]["values"];
+  // Bounds decoders, keyed on BoundsType alone
+  cfg.surfaceBoundsDecoder
+      .registerKind(boundsKey(SurfaceBounds::BoundsType::eEllipse),
+                    boundsFromJsonT<EllipseBounds>)
+      .registerKind(boundsKey(SurfaceBounds::BoundsType::eRectangle),
+                    boundsFromJsonT<RectangleBounds>)
+      .registerKind(boundsKey(SurfaceBounds::BoundsType::eTrapezoid),
+                    boundsFromJsonT<TrapezoidBounds>)
+      .registerKind(boundsKey(SurfaceBounds::BoundsType::eDiamond),
+                    boundsFromJsonT<DiamondBounds>)
+      .registerKind(boundsKey(SurfaceBounds::BoundsType::eAnnulus),
+                    boundsFromJsonT<AnnulusBounds>)
+      .registerKind(boundsKey(SurfaceBounds::BoundsType::eDisc),
+                    boundsFromJsonT<RadialBounds>)
+      .registerKind(boundsKey(SurfaceBounds::BoundsType::eDiscTrapezoid),
+                    boundsFromJsonT<DiscTrapezoidBounds>)
+      .registerKind(boundsKey(SurfaceBounds::BoundsType::eCylinder),
+                    boundsFromJsonT<CylinderBounds>)
+      .registerKind(boundsKey(SurfaceBounds::BoundsType::eCone),
+                    boundsFromJsonT<ConeBounds>)
+      .registerKind(boundsKey(SurfaceBounds::BoundsType::eLine),
+                    boundsFromJsonT<LineBounds>)
+      .registerKind(boundsKey(SurfaceBounds::BoundsType::ePoint),
+                    boundsFromJsonT<PointBounds>);
+
+  // Boundless surfaces carry no bounds object to build
+  cfg.surfaceBoundsDecoder.registerKind(
+      boundsKey(SurfaceBounds::BoundsType::eBoundless),
+      [](const nlohmann::json& /*j*/) -> std::shared_ptr<const SurfaceBounds> {
+        return nullptr;
+      });
+
+  // The vertex count of a ConvexPolygonBounds is recoverable only from the
+  // length of the values array, so decode into a dynamically sized polygon.
+  cfg.surfaceBoundsDecoder.registerKind(
+      boundsKey(SurfaceBounds::BoundsType::eConvexPolygon),
+      [](const nlohmann::json& j) -> std::shared_ptr<const SurfaceBounds> {
+        std::vector<double> bVector = j["values"];
         if (bVector.size() < 6 || bVector.size() % 2 != 0) {
           throw std::invalid_argument(
               "Invalid ConvexPolygonBounds 'values' array: need an even "
@@ -288,45 +272,29 @@ Acts::SurfaceJsonConverter::Config::defaultConfig() {
         for (std::size_t i = 0; i < bVector.size(); i += 2) {
           vertices.emplace_back(bVector[i], bVector[i + 1]);
         }
-        auto sBounds =
-            std::make_shared<const ConvexPolygonBounds<PolygonDynamic>>(
-                vertices);
-        return Surface::makeShared<PlaneSurface>(sTransform,
-                                                 std::move(sBounds));
+        return std::make_shared<const ConvexPolygonBounds<PolygonDynamic>>(
+            vertices);
       });
 
-  cfg.surfaceDecoder.registerKind(
-      getSurfaceKind<DiscSurface>() + getSurfaceBoundsKind<AnnulusBounds>(),
-      surfaceFromJsonT<DiscSurface, AnnulusBounds>);
-  cfg.surfaceDecoder.registerKind(
-      getSurfaceKind<DiscSurface>() + getSurfaceBoundsKind<RadialBounds>(),
-      surfaceFromJsonT<DiscSurface, RadialBounds>);
-  cfg.surfaceDecoder.registerKind(
-      getSurfaceKind<DiscSurface>() +
-          getSurfaceBoundsKind<DiscTrapezoidBounds>(),
-      surfaceFromJsonT<DiscSurface, DiscTrapezoidBounds>);
+  // Surface decoders, keyed on SurfaceType alone. Each narrows the decoded
+  // bounds to the base type it stores, so any bounds deriving from that base
+  // works without being enumerated here.
+  cfg.surfaceDecoder
+      .registerKind(surfaceKey(Surface::SurfaceType::Plane),
+                    surfaceFromJsonT<PlaneSurface, PlanarBounds>)
+      .registerKind(surfaceKey(Surface::SurfaceType::Disc),
+                    surfaceFromJsonT<DiscSurface, DiscBounds>)
+      .registerKind(surfaceKey(Surface::SurfaceType::Cylinder),
+                    surfaceFromJsonT<CylinderSurface, CylinderBounds>)
+      .registerKind(surfaceKey(Surface::SurfaceType::Cone),
+                    surfaceFromJsonT<ConeSurface, ConeBounds>)
+      .registerKind(surfaceKey(Surface::SurfaceType::Straw),
+                    surfaceFromJsonT<StrawSurface, LineBounds>)
+      .registerKind(surfaceKey(Surface::SurfaceType::Point),
+                    surfaceFromJsonT<PointSurface, PointBounds>)
+      .registerKind(surfaceKey(Surface::SurfaceType::Perigee),
+                    boundlessSurfaceFromJsonT<PerigeeSurface>);
 
-  cfg.surfaceDecoder.registerKind(
-      getSurfaceKind<CylinderSurface>() +
-          getSurfaceBoundsKind<CylinderBounds>(),
-      surfaceFromJsonT<CylinderSurface, CylinderBounds>);
-  cfg.surfaceDecoder.registerKind(
-      getSurfaceKind<ConeSurface>() + getSurfaceBoundsKind<ConeBounds>(),
-      surfaceFromJsonT<ConeSurface, ConeBounds>);
-  cfg.surfaceDecoder.registerKind(
-      getSurfaceKind<StrawSurface>() + getSurfaceBoundsKind<LineBounds>(),
-      surfaceFromJsonT<StrawSurface, LineBounds>);
-
-  cfg.surfaceDecoder.registerKind(
-      getSurfaceKind<PerigeeSurface>() + getSurfaceBoundsKind<InfiniteBounds>(),
-      surfaceFromJsonT<PerigeeSurface>);
-
-  cfg.surfaceDecoder.registerKind(
-      getSurfaceKind<PointSurface>() + getSurfaceBoundsKind<PointBounds>(),
-      surfaceFromJsonT<PointSurface, PointBounds>);
-  cfg.surfaceDecoder.registerKind(
-      getSurfaceKind<PointSurface>() + getSurfaceBoundsKind<InfiniteBounds>(),
-      surfaceFromJsonT<PointSurface>);
   return cfg;
 }
 
@@ -335,8 +303,10 @@ Acts::SurfaceJsonConverter::Config Acts::SurfaceJsonConverter::m_cfg =
 
 std::shared_ptr<Acts::Surface> Acts::SurfaceJsonConverter::fromJson(
     const nlohmann::json& j) {
-  std::shared_ptr<Acts::Surface> mutableSf = nullptr;
-  mutableSf = m_cfg.surfaceDecoder(j);
+  std::shared_ptr<const SurfaceBounds> bounds =
+      m_cfg.surfaceBoundsDecoder(j.at("bounds"));
+  std::shared_ptr<Acts::Surface> mutableSf =
+      m_cfg.surfaceDecoder(j, std::move(bounds));
 
   if (j.find("geo_id") != j.end() && !j["geo_id"].empty()) {
     GeometryIdentifier geoID = j["geo_id"].get<GeometryIdentifier>();
@@ -360,9 +330,6 @@ nlohmann::json Acts::SurfaceJsonConverter::toJson(const GeometryContext& gctx,
                                                   const Surface& surface,
                                                   const Options& options) {
   nlohmann::json jSurface = m_cfg.surfaceEncoder(surface, gctx, options);
-  nlohmann::json jBounds = m_cfg.surfaceBoundsEncoder(surface.bounds());
-  jSurface["bounds"] = jBounds;
-  jSurface["kind"] =
-      jSurface["kind"].get<std::string>() + jBounds["kind"].get<std::string>();
+  jSurface["bounds"] = m_cfg.surfaceBoundsEncoder(surface.bounds());
   return jSurface;
 }

--- a/Tests/UnitTests/Plugins/Json/SurfaceJsonConverterTests.cpp
+++ b/Tests/UnitTests/Plugins/Json/SurfaceJsonConverterTests.cpp
@@ -13,6 +13,7 @@
 #include "Acts/Geometry/GeometryIdentifier.hpp"
 #include "Acts/Surfaces/ConeBounds.hpp"
 #include "Acts/Surfaces/ConeSurface.hpp"
+#include "Acts/Surfaces/ConvexPolygonBounds.hpp"
 #include "Acts/Surfaces/CylinderBounds.hpp"
 #include "Acts/Surfaces/CylinderSurface.hpp"
 #include "Acts/Surfaces/DiamondBounds.hpp"
@@ -23,14 +24,17 @@
 #include "Acts/Surfaces/PointBounds.hpp"
 #include "Acts/Surfaces/PointSurface.hpp"
 #include "Acts/Surfaces/RadialBounds.hpp"
+#include "Acts/Surfaces/RectangleBounds.hpp"
 #include "Acts/Surfaces/StrawSurface.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Surfaces/SurfaceBounds.hpp"
 #include "Acts/Surfaces/TrapezoidBounds.hpp"
 #include "ActsPlugins/Json/SurfaceJsonConverter.hpp"
 
+#include <array>
 #include <fstream>
 #include <memory>
+#include <stdexcept>
 #include <string>
 
 #include <nlohmann/json.hpp>
@@ -283,6 +287,38 @@ BOOST_AUTO_TEST_CASE(DiamondPlaneSurfaceRoundTripTests) {
   BOOST_CHECK_EQUAL(diamondPlaneTest->geometryId(),
                     diamondPlaneRef->geometryId());
   BOOST_CHECK_EQUAL(diamondPlaneTest->bounds(), diamondPlaneRef->bounds());
+}
+
+BOOST_AUTO_TEST_CASE(SurfaceBoundsDecouplingTests) {
+  Transform3 trf(Transform3::Identity());
+  auto planeRef = Surface::makeShared<PlaneSurface>(
+      trf, std::make_shared<RectangleBounds>(4., 6.));
+
+  nlohmann::json jPlane = SurfaceJsonConverter::toJson(gctx, *planeRef);
+
+  // Surface and bounds each carry their own discriminator, so neither needs
+  // the concatenated "kind" the decoder used to be keyed on
+  BOOST_CHECK(!jPlane.contains("kind"));
+  BOOST_CHECK(!jPlane["bounds"].contains("kind"));
+  BOOST_CHECK_EQUAL(jPlane["type"], "PlaneSurface");
+  BOOST_CHECK_EQUAL(jPlane["bounds"]["type"], "RectangleBounds");
+
+  // ConvexPolygonBounds<N> resolves through the single ConvexPolygonBounds
+  // bounds decoder, whatever N was written
+  std::array<Vector2, 4> vertices{Vector2(-1., -1.), Vector2(1., -1.),
+                                  Vector2(1., 1.), Vector2(-1., 1.)};
+  auto polyRef = Surface::makeShared<PlaneSurface>(
+      trf, std::make_shared<ConvexPolygonBounds<4>>(vertices));
+  auto polyTest = SurfaceJsonConverter::fromJson(
+      SurfaceJsonConverter::toJson(gctx, *polyRef));
+  BOOST_CHECK_EQUAL(polyTest->bounds().type(), SurfaceBounds::eConvexPolygon);
+  BOOST_CHECK(polyTest->bounds().values() == polyRef->bounds().values());
+
+  // A surface paired with bounds it cannot store is a decode-time error
+  nlohmann::json jMismatch = jPlane;
+  jMismatch["type"] = "CylinderSurface";
+  BOOST_CHECK_THROW(SurfaceJsonConverter::fromJson(jMismatch),
+                    std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The surface decoder was keyed on a **concatenated** string built from the surface kind and the bounds kind (`"PlaneRectangle"`), so every valid surface/bounds pairing had to be registered explicitly. That made the table quadratic in principle, left legal combinations undecodable because nobody had enumerated them, and leaked the concatenation into the file format.
