### PR TITLE
perf(seeding): index best seed quality by a flat vector

### DIFF
--- a/Core/include/Acts/Seeding/BroadTripletSeedFilter.hpp
+++ b/Core/include/Acts/Seeding/BroadTripletSeedFilter.hpp
@@ -18,7 +18,6 @@
 #include "Acts/Utilities/Logger.hpp"
 
 #include <memory>
-#include <unordered_map>
 #include <vector>
 
 namespace Acts {
@@ -153,13 +152,14 @@ class BroadTripletSeedFilter final : public ITripletSeedFilter {
     /// Maximum radius for seed confirmation
     float rMaxSeedConf{};
 
-    /// Map to store the best seed quality for each space point.
-    /// This is used to avoid creating seeds with lower quality than the best
-    /// seed quality already found for that space point.
-    /// The key is the space point index, and the value is the best seed quality
-    /// found for that space point.
-    /// @note The index is the space point index, not the seed index.
-    std::unordered_map<SpacePointIndex, float> bestSeedQualityMap;
+    /// Best seed quality found so far for each space point, indexed directly by
+    /// the space point index. Space points that have not been part of a seed
+    /// yet hold std::numeric_limits<float>::lowest(). This is used to avoid
+    /// creating seeds with lower quality than the best already found for one of
+    /// their space points.
+    /// @note The index is the space point index, not the seed index. The
+    /// vector is sized to the number of space points on first use per event.
+    std::vector<float> bestSeedQuality;
   };
 
   /// Cache for intermediate results to avoid reallocations. No information is

--- a/Core/src/Seeding/BroadTripletSeedFilter.cpp
+++ b/Core/src/Seeding/BroadTripletSeedFilter.cpp
@@ -21,31 +21,16 @@ namespace Acts {
 
 namespace {
 
-float getBestSeedQuality(
-    const std::unordered_map<SpacePointIndex, float>& bestSeedQualityMap,
-    SpacePointIndex sp) {
-  auto it = bestSeedQualityMap.find(sp);
-  if (it != bestSeedQualityMap.end()) {
-    return it->second;
-  }
-  return std::numeric_limits<float>::lowest();
+float getBestSeedQuality(const std::vector<float>& bestSeedQuality,
+                         SpacePointIndex sp) {
+  return bestSeedQuality[sp];
 }
 
-void setBestSeedQuality(
-    std::unordered_map<SpacePointIndex, float>& bestSeedQualityMap,
-    SpacePointIndex bottom, SpacePointIndex middle, SpacePointIndex top,
-    float quality) {
-  const auto set = [&](SpacePointIndex sp) {
-    auto it = bestSeedQualityMap.find(sp);
-    if (it != bestSeedQualityMap.end()) {
-      it->second = std::max(quality, it->second);
-    } else {
-      bestSeedQualityMap.emplace(sp, quality);
-    }
-  };
-
+void setBestSeedQuality(std::vector<float>& bestSeedQuality,
+                        SpacePointIndex bottom, SpacePointIndex middle,
+                        SpacePointIndex top, float quality) {
   for (SpacePointIndex sp : {top, middle, bottom}) {
-    set(sp);
+    bestSeedQuality[sp] = std::max(quality, bestSeedQuality[sp]);
   }
 }
 
@@ -97,6 +82,13 @@ void BroadTripletSeedFilter::filterTripletTopCandidates(
     const SpacePointContainer& spacePoints, const ConstSpacePointProxy& spM,
     const DoubletsForMiddleSp::Proxy& bottomLink,
     const TripletTopCandidates& tripletTopCandidates) const {
+  // The best-seed-quality vector is indexed directly by space point index, so
+  // size it to the number of space points on first use for this event. State is
+  // constructed per event, so an empty vector means we have not sized it yet.
+  if (state().bestSeedQuality.empty()) {
+    state().bestSeedQuality.assign(spacePoints.size(),
+                                   std::numeric_limits<float>::lowest());
+  }
   auto spB = spacePoints[bottomLink.spacePointIndex()];
   auto bottomSp = spB.index();
   auto middleSp = spM.index();
@@ -275,12 +267,9 @@ void BroadTripletSeedFilter::filterTripletTopCandidates(
 
       // skip a bad quality seed if any of its constituents has a weight larger
       // than the seed weight
-      if (weight <
-              getBestSeedQuality(state().bestSeedQualityMap, spB.index()) &&
-          weight <
-              getBestSeedQuality(state().bestSeedQualityMap, spM.index()) &&
-          weight <
-              getBestSeedQuality(state().bestSeedQualityMap, spT.index())) {
+      if (weight < getBestSeedQuality(state().bestSeedQuality, spB.index()) &&
+          weight < getBestSeedQuality(state().bestSeedQuality, spM.index()) &&
+          weight < getBestSeedQuality(state().bestSeedQuality, spT.index())) {
         continue;
       }
 
@@ -324,6 +313,13 @@ void BroadTripletSeedFilter::filterTripletTopCandidates(
 void BroadTripletSeedFilter::filterTripletsMiddleFixed(
     const SpacePointContainer& spacePoints,
     SeedContainer& outputCollection) const {
+  // The best-seed-quality vector is indexed directly by space point index, so
+  // size it to the number of space points on first use for this event. State is
+  // constructed per event, so an empty vector means we have not sized it yet.
+  if (state().bestSeedQuality.empty()) {
+    state().bestSeedQuality.assign(spacePoints.size(),
+                                   std::numeric_limits<float>::lowest());
+  }
   const std::size_t numQualitySeeds =
       state().candidatesCollector.nHighQualityCandidates();
 
@@ -362,17 +358,17 @@ void BroadTripletSeedFilter::filterTripletsMiddleFixed(
         continue;
       }
       if (bestSeedQuality <
-              getBestSeedQuality(state().bestSeedQualityMap, triplet[0]) &&
+              getBestSeedQuality(state().bestSeedQuality, triplet[0]) &&
           bestSeedQuality <
-              getBestSeedQuality(state().bestSeedQualityMap, triplet[1]) &&
+              getBestSeedQuality(state().bestSeedQuality, triplet[1]) &&
           bestSeedQuality <
-              getBestSeedQuality(state().bestSeedQualityMap, triplet[2])) {
+              getBestSeedQuality(state().bestSeedQuality, triplet[2])) {
         continue;
       }
     }
 
     // set quality of seed components
-    setBestSeedQuality(state().bestSeedQualityMap, triplet[0], triplet[1],
+    setBestSeedQuality(state().bestSeedQuality, triplet[0], triplet[1],
                        triplet[2], bestSeedQuality);
 
     ACTS_VERBOSE("Adding seed: original indices=["


### PR DESCRIPTION
I was profiling the triplet seeding filter and noticed the best-seed-quality lookup shows up in the hot path. It was kept in an `unordered_map<SpacePointIndex, float>` and read three times per triplet candidate, once for each of the bottom, middle and top space points.

The space point index is a dense `std::uint32_t` into the space point container, and the filter already has the container in hand, so the map can be a plain `std::vector<float>` indexed directly by that index. It is sized once per event to `spacePoints.size()` and filled with `std::numeric_limits<float>::lowest()`, which is the same value the map returned for a space point that hadn't been part of a seed yet, so the behaviour is identical. The filter state is constructed fresh per event in each seeding algorithm, so the vector starts empty each event just like the map did.

I checked the results are bit-for-bit the same as the map for an interleaved sequence of writes and reads, and the change compiles clean with the full warning set under gcc 13. The two helpers now index the vector instead of hashing, and I dropped the now-unused `<unordered_map>` include.

I didn't benchmark the full seeding chain here since that needs the physics performance job, so I'd rely on physmon in CI for the end-to-end number and to confirm the physics output is unchanged.
