### PR TITLE
fix: move the avogadro constant to acts units

### DIFF
--- a/Core/include/Acts/Definitions/Units.hpp
+++ b/Core/include/Acts/Definitions/Units.hpp
@@ -172,7 +172,6 @@ constexpr double Gauss = 1e-4 * T;
 constexpr double kGauss = 1e-1 * T;
 /// Amount of substance, native unit mol
 constexpr double mol = 1.0;
-
 }  // namespace UnitConstants
 
 /// @brief Namespace for user-defined literals for physical units. See @ref
@@ -240,7 +239,6 @@ constexpr double c = 1.0;
 /// Computed from CODATA 2018 constants to double precision.
 constexpr double hbar =
     6.582119569509066e-25 * UnitConstants::GeV * UnitConstants::s;
-
 /// Avogadro constant
 constexpr double kAvogadro = 6.02214076e23 / UnitConstants::mol;
 }  // namespace PhysicalConstants

--- a/Core/include/Acts/Definitions/Units.hpp
+++ b/Core/include/Acts/Definitions/Units.hpp
@@ -172,8 +172,6 @@ constexpr double Gauss = 1e-4 * T;
 constexpr double kGauss = 1e-1 * T;
 /// Amount of substance, native unit mol
 constexpr double mol = 1.0;
-/// Avogadro constant
-constexpr double kAvogadro = 6.02214076e23;
 
 }  // namespace UnitConstants
 
@@ -242,6 +240,9 @@ constexpr double c = 1.0;
 /// Computed from CODATA 2018 constants to double precision.
 constexpr double hbar =
     6.582119569509066e-25 * UnitConstants::GeV * UnitConstants::s;
+
+/// Avogadro constant
+constexpr double kAvogadro = 6.02214076e23 / UnitConstants::mol;
 }  // namespace PhysicalConstants
 
 }  // namespace Acts

--- a/Core/include/Acts/Definitions/Units.hpp
+++ b/Core/include/Acts/Definitions/Units.hpp
@@ -172,6 +172,9 @@ constexpr double Gauss = 1e-4 * T;
 constexpr double kGauss = 1e-1 * T;
 /// Amount of substance, native unit mol
 constexpr double mol = 1.0;
+/// Avogadro constant
+constexpr double kAvogadro = 6.02214076e23;
+
 }  // namespace UnitConstants
 
 /// @brief Namespace for user-defined literals for physical units. See @ref

--- a/Core/src/Material/Material.cpp
+++ b/Core/src/Material/Material.cpp
@@ -96,7 +96,7 @@ float Material::massDensity() const {
   // perform computations in double precision to avoid loss of precision
   const double atomicMass = static_cast<double>(m_ar) * 1_u;
   const double numberDensity =
-      static_cast<double>(m_molarRho) * (PhysicalConstants::kAvogadro);
+      static_cast<double>(m_molarRho) * PhysicalConstants::kAvogadro;
   return atomicMass * numberDensity;
 }
 

--- a/Core/src/Material/Material.cpp
+++ b/Core/src/Material/Material.cpp
@@ -54,7 +54,7 @@ Material Material::fromMassDensity(float x0, float l0, float ar, float z,
   const double atomicMass = static_cast<double>(ar) * 1_u;
   float molarRho = static_cast<float>(
       massRho /
-      (atomicMass * (PhysicalConstants::kAvogadro / UnitConstants::mol)));
+      (atomicMass * PhysicalConstants::kAvogadro));
 
   return Material::fromMolarDensity(x0, l0, ar, z, molarRho);
 }

--- a/Core/src/Material/Material.cpp
+++ b/Core/src/Material/Material.cpp
@@ -24,9 +24,6 @@ enum MaterialClassificationNumberIndices {
   eMolarDensity = 4,
 };
 
-// Avogadro constant
-constexpr double kAvogadro = 6.02214076e23 / UnitConstants::mol;
-
 constexpr float calculateMolarElectronDensity(float z, float molarRho) {
   return z * molarRho;
 }
@@ -55,7 +52,8 @@ Material Material::fromMassDensity(float x0, float l0, float ar, float z,
   //
   // perform computations in double precision to avoid loss of precision
   const double atomicMass = static_cast<double>(ar) * 1_u;
-  float molarRho = static_cast<float>(massRho / (atomicMass * kAvogadro));
+  float molarRho = static_cast<float>(
+      massRho / (atomicMass * (UnitConstants::kAvogadro / UnitConstants::mol)));
 
   return Material::fromMolarDensity(x0, l0, ar, z, molarRho);
 }
@@ -96,7 +94,8 @@ float Material::massDensity() const {
 
   // perform computations in double precision to avoid loss of precision
   const double atomicMass = static_cast<double>(m_ar) * 1_u;
-  const double numberDensity = static_cast<double>(m_molarRho) * kAvogadro;
+  const double numberDensity = static_cast<double>(m_molarRho) *
+                               (UnitConstants::kAvogadro / UnitConstants::mol);
   return atomicMass * numberDensity;
 }
 

--- a/Core/src/Material/Material.cpp
+++ b/Core/src/Material/Material.cpp
@@ -52,9 +52,8 @@ Material Material::fromMassDensity(float x0, float l0, float ar, float z,
   //
   // perform computations in double precision to avoid loss of precision
   const double atomicMass = static_cast<double>(ar) * 1_u;
-  float molarRho = static_cast<float>(
-      massRho /
-      (atomicMass * PhysicalConstants::kAvogadro));
+  float molarRho =
+     static_cast<float>(massRho / (atomicMass * PhysicalConstants::kAvogadro));
 
   return Material::fromMolarDensity(x0, l0, ar, z, molarRho);
 }

--- a/Core/src/Material/Material.cpp
+++ b/Core/src/Material/Material.cpp
@@ -53,7 +53,7 @@ Material Material::fromMassDensity(float x0, float l0, float ar, float z,
   // perform computations in double precision to avoid loss of precision
   const double atomicMass = static_cast<double>(ar) * 1_u;
   float molarRho =
-     static_cast<float>(massRho / (atomicMass * PhysicalConstants::kAvogadro));
+      static_cast<float>(massRho / (atomicMass * PhysicalConstants::kAvogadro));
 
   return Material::fromMolarDensity(x0, l0, ar, z, molarRho);
 }

--- a/Core/src/Material/Material.cpp
+++ b/Core/src/Material/Material.cpp
@@ -53,7 +53,8 @@ Material Material::fromMassDensity(float x0, float l0, float ar, float z,
   // perform computations in double precision to avoid loss of precision
   const double atomicMass = static_cast<double>(ar) * 1_u;
   float molarRho = static_cast<float>(
-      massRho / (atomicMass * (UnitConstants::kAvogadro / UnitConstants::mol)));
+      massRho /
+      (atomicMass * (PhysicalConstants::kAvogadro / UnitConstants::mol)));
 
   return Material::fromMolarDensity(x0, l0, ar, z, molarRho);
 }
@@ -94,8 +95,8 @@ float Material::massDensity() const {
 
   // perform computations in double precision to avoid loss of precision
   const double atomicMass = static_cast<double>(m_ar) * 1_u;
-  const double numberDensity = static_cast<double>(m_molarRho) *
-                               (UnitConstants::kAvogadro / UnitConstants::mol);
+  const double numberDensity =
+      static_cast<double>(m_molarRho) * (PhysicalConstants::kAvogadro);
   return atomicMass * numberDensity;
 }
 

--- a/Plugins/GeoModel/src/GeoModelMaterialConverter.cpp
+++ b/Plugins/GeoModel/src/GeoModelMaterialConverter.cpp
@@ -43,8 +43,7 @@ Material ActsPlugins::GeoModel::geoMaterialConverter(const GeoMaterial& gm,
   if (useMolarDensity) {
     const double molarDensity =
         massDensity /
-        (A * Acts::UnitConstants::u *
-         (Acts::UnitConstants::kAvogadro / Acts::UnitConstants::mol));
+        (A * Acts::UnitConstants::u * (Acts::PhysicalConstants::kAvogadro));
     return Material::fromMolarDensity(x0, l0, A, Z, molarDensity);
   } else {
     return Material::fromMassDensity(x0, l0, A, Z, massDensity);

--- a/Plugins/GeoModel/src/GeoModelMaterialConverter.cpp
+++ b/Plugins/GeoModel/src/GeoModelMaterialConverter.cpp
@@ -43,7 +43,7 @@ Material ActsPlugins::GeoModel::geoMaterialConverter(const GeoMaterial& gm,
   if (useMolarDensity) {
     const double molarDensity =
         massDensity /
-        (A * Acts::UnitConstants::u * (Acts::PhysicalConstants::kAvogadro));
+        (A * Acts::UnitConstants::u * Acts::PhysicalConstants::kAvogadro);
     return Material::fromMolarDensity(x0, l0, A, Z, molarDensity);
   } else {
     return Material::fromMassDensity(x0, l0, A, Z, massDensity);

--- a/Plugins/GeoModel/src/GeoModelMaterialConverter.cpp
+++ b/Plugins/GeoModel/src/GeoModelMaterialConverter.cpp
@@ -19,8 +19,6 @@ namespace {
 constexpr double s_massDensitryCnvFactor =
     (GeoModelKernelUnits::cm3 * Acts::UnitConstants::g) /
     (GeoModelKernelUnits::gram * Acts::UnitConstants::cm3);
-// Avogadro constant
-constexpr double kAvogadro = 6.02214076e23 / Acts::UnitConstants::mol;
 
 }  // namespace
 
@@ -44,7 +42,9 @@ Material ActsPlugins::GeoModel::geoMaterialConverter(const GeoMaterial& gm,
   }
   if (useMolarDensity) {
     const double molarDensity =
-        massDensity / (A * Acts::UnitConstants::u * kAvogadro);
+        massDensity /
+        (A * Acts::UnitConstants::u *
+         (Acts::UnitConstants::kAvogadro / Acts::UnitConstants::mol));
     return Material::fromMolarDensity(x0, l0, A, Z, molarDensity);
   } else {
     return Material::fromMassDensity(x0, l0, A, Z, massDensity);


### PR DESCRIPTION
It streams the Avogadro constant through the `Acts/Definitions/Units.hpp`
