### PR TITLE
perf(detray): Assume compact device memory points to global memory

### DIFF
--- a/Detray/core/include/detray/core/detail/compact_device_vector.hpp
+++ b/Detray/core/include/detray/core/detail/compact_device_vector.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 // Project include(s)
+#include "detray/definitions/detail/macros.hpp"
 #include "detray/definitions/detail/qualifiers.hpp"
 
 // Vecmem include(s)
@@ -44,6 +45,7 @@ struct compact_device_vector {
   }
   DETRAY_HOST_DEVICE
   const_reference at(size_type pos) const {
+    DETRAY_ASSUME_PTR_GLOBAL(m_ptr);
     assert(pos < size());
     return m_ptr[pos];
   }
@@ -51,7 +53,10 @@ struct compact_device_vector {
   DETRAY_HOST_DEVICE
   reference operator[](size_type pos) { return m_ptr[pos]; }
   DETRAY_HOST_DEVICE
-  const_reference operator[](size_type pos) const { return m_ptr[pos]; }
+  const_reference operator[](size_type pos) const {
+    DETRAY_ASSUME_PTR_GLOBAL(m_ptr);
+    return m_ptr[pos];
+  }
 
   DETRAY_HOST_DEVICE
   reference front() {
@@ -60,6 +65,7 @@ struct compact_device_vector {
   }
   DETRAY_HOST_DEVICE
   const_reference front() const {
+    DETRAY_ASSUME_PTR_GLOBAL(m_ptr);
     assert(!empty());
     return m_ptr[0];
   }
@@ -71,6 +77,7 @@ struct compact_device_vector {
   }
   DETRAY_HOST_DEVICE
   const_reference back() const {
+    DETRAY_ASSUME_PTR_GLOBAL(m_ptr);
     assert(!empty());
     return m_ptr[size() - 1];
   }
@@ -78,19 +85,29 @@ struct compact_device_vector {
   DETRAY_HOST_DEVICE
   pointer data() { return m_ptr; }
   DETRAY_HOST_DEVICE
-  const_pointer data() const { return m_ptr; }
+  const_pointer data() const {
+    DETRAY_ASSUME_PTR_GLOBAL(m_ptr);
+    return m_ptr;
+  }
 
   DETRAY_HOST_DEVICE
   iterator begin() { return static_cast<iterator>(m_ptr); }
   DETRAY_HOST_DEVICE
-  const_iterator begin() const { return static_cast<const_iterator>(m_ptr); }
+  const_iterator begin() const {
+    DETRAY_ASSUME_PTR_GLOBAL(m_ptr);
+    return static_cast<const_iterator>(m_ptr);
+  }
   DETRAY_HOST_DEVICE
   const_iterator cbegin() const { return begin(); }
 
   DETRAY_HOST_DEVICE
-  iterator end() { return static_cast<iterator>(m_ptr + size()); }
+  iterator end() {
+    DETRAY_ASSUME_PTR_GLOBAL(m_ptr);
+    return static_cast<iterator>(m_ptr + size());
+  }
   DETRAY_HOST_DEVICE
   const_iterator end() const {
+    DETRAY_ASSUME_PTR_GLOBAL(m_ptr);
     return static_cast<const_iterator>(m_ptr + size());
   }
   DETRAY_HOST_DEVICE

--- a/Detray/core/include/detray/definitions/detail/macros.hpp
+++ b/Detray/core/include/detray/definitions/detail/macros.hpp
@@ -13,3 +13,10 @@
     not defined(SYCL_LANGUAGE_VERSION) && not defined(__HIP__)
 #define __NO_DEVICE__
 #endif
+
+// Define a macro that hints a pointer is in global memory
+#ifdef __CUDA_ARCH__
+#define DETRAY_ASSUME_PTR_GLOBAL(p) __builtin_assume(__isGlobal(p))
+#else
+#define DETRAY_ASSUME_PTR_GLOBAL(p)
+#endif

--- a/Traccc/core/include/traccc/geometry/detector.hpp
+++ b/Traccc/core/include/traccc/geometry/detector.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 // Project include(s).
+#include "detray/core/detail/compact_device_vector.hpp"
 #include "traccc/definitions/primitives.hpp"
 
 // Detray include(s).
@@ -48,7 +49,7 @@ namespace details {
 struct device_detector_container_types {
   /// Vector type to use in device code
   template <typename T>
-  using vector_type = vecmem::device_vector<std::add_const_t<T>>;
+  using vector_type = detray::compact_device_vector<std::add_const_t<T>>;
 
 };  // struct device_detector_container_types
 


### PR DESCRIPTION
This commit adds an assumption to all pointer usage in the detray compact device vector, such that the compiler can emit global memory loads rather than generic ones.