### PR TITLE
perf(traccc): Set block count of propagate kernel

### DIFF
--- a/Traccc/device/cuda/src/finding/kernels/specializations/propagate_to_next_surface_src.cuh
+++ b/Traccc/device/cuda/src/finding/kernels/specializations/propagate_to_next_surface_src.cuh
@@ -19,7 +19,7 @@ namespace traccc::cuda {
 namespace kernels {
 
 template <typename propagator_t, typename bfield_t>
-__global__ __launch_bounds__(128) void propagate_to_next_surface(
+__global__ __launch_bounds__(128, 5) void propagate_to_next_surface(
     const __grid_constant__ finding_config cfg,
     const typename propagator_t::detector_type* __restrict__ const det_data_ptr,
     const __grid_constant__ bfield_t field_data,


### PR DESCRIPTION
This commit updates the launch bound parameter of the propagation kernel such that at least 5 blocks are required. This guards us against spurious performance boundaries due to ptxas' register allocation algorithm.