### PR TITLE
refactor(detray): Shrink public API of navigator cache

### DIFF
--- a/Detray/core/include/detray/navigation/caching_navigator.hpp
+++ b/Detray/core/include/detray/navigation/caching_navigator.hpp
@@ -137,12 +137,45 @@ class caching_navigator
     }
 
    private:
+    DETRAY_HOST_DEVICE
+    constexpr void sort_candidates() {
+      const std::size_t beg{this->valid_begin()};
+      const std::size_t end{this->valid_end()};
+
+      for (std::size_t i = beg; i + 1 < end; ++i) {
+        std::size_t k = i;
+        for (std::size_t j = i + 1; j < end; ++j) {
+          if (this->candidate_at(j) < this->candidate_at(k)) {
+            k = j;
+          }
+        }
+        if (k != i) {
+          const candidate_t tmp = this->candidate_at(i);
+          this->set_candidate_at(i, this->candidate_at(k));
+          this->set_candidate_at(k, tmp);
+        }
+      }
+    }
+
     /// Insert a new element @param new_candidate before position @param pos
     DETRAY_HOST_DEVICE
-    constexpr void insert(candidate_const_itr_t pos,
-                          const intersection_type &new_candidate) {
+    constexpr void insert(const intersection_type &new_candidate) {
+      const std::size_t beg{this->valid_begin()};
+      const std::size_t end{this->valid_end()};
+
+      // For just two candidates int the cache, the navigation state keeps
+      // the first as the previously visited candidate -> no sorting needed
+      std::size_t pos = beg;
+      if constexpr (k_cache_capacity > 2u) {
+        for (; pos < end; ++pos) {
+          if (this->candidate_at(pos) > new_candidate) {
+            break;
+          }
+        }
+      }
+
       // Candidate is too far away to be placed in cache
-      if (pos == this->candidates().end()) {
+      if (pos == k_cache_capacity) {
         return;
       }
 
@@ -151,7 +184,7 @@ class caching_navigator
 
       // Insert the first candidate
       if (this->n_candidates() == 0) [[unlikely]] {
-        this->candidates()[0] = new_candidate;
+        this->set_target(new_candidate);
         this->last_index(this->last_index() + 1);
         assert(this->next_index() <= this->last_index() + 1);
         assert(static_cast<std::size_t>(this->last_index()) < k_cache_capacity);
@@ -159,13 +192,12 @@ class caching_navigator
       }
 
       // Position where to insert the new candidate
-      auto idx{static_cast<dist_t>(
-          detray::ranges::distance(this->candidates().cbegin(), pos))};
+      auto idx{static_cast<dist_t>(pos)};
       assert(idx >= 0);
 
       // Do not add the same surface (intersection) multiple times
       const auto is_overlap_at_pos = [this, &new_candidate](std::size_t index) {
-        return (math::fabs(this->candidates()[index].path() -
+        return (math::fabs(this->candidate_at(index).path() -
                            new_candidate.path()) <= 1.f * unit<scalar_t>::um);
       };
 
@@ -177,7 +209,7 @@ class caching_navigator
       // navigator getting stuck on that surface.
       const auto is_clash_at_pos = [this, &new_candidate,
                                     &is_overlap_at_pos](std::size_t index) {
-        return (this->candidates()[index].surface().identifier() ==
+        return (this->candidate_at(index).surface().identifier() ==
                 new_candidate.surface().identifier()) &&
                is_overlap_at_pos(index);
       };
@@ -205,11 +237,11 @@ class caching_navigator
 
       for (dist_t i = shift_begin; i >= idx; --i) {
         const auto j{static_cast<std::size_t>(i)};
-        this->candidates()[j + 1u] = this->candidates()[j];
+        this->set_candidate_at(j + 1, this->candidate_at(j));
       }
 
       // Now insert the new candidate and update candidate range
-      this->candidates()[static_cast<std::size_t>(idx)] = new_candidate;
+      this->set_candidate_at(static_cast<std::size_t>(idx), new_candidate);
       this->last_index(math::min(static_cast<dist_t>(this->last_index() + 1),
                                  static_cast<dist_t>(k_cache_capacity - 1)));
 
@@ -253,15 +285,22 @@ class caching_navigator
         track.pos(),
         static_cast<scalar_t>(navigation.direction()) * track.dir()};
 
+    const auto update_candidate = [&]() {
+      auto target = navigation.target();
+      const bool reachable = navigation::update_candidate(
+          target, tangential, det, cfg.intersection, navigation.external_tol(),
+          ctx);
+      navigation.set_target(target);
+      return reachable;
+    };
+
     // Update only the current candidate and the corresponding next target
     // - do this only when the navigation state is still coherent
     if (navigation.trust_level() == navigation::trust_level::e_high) {
       DETRAY_VERBOSE_HOST_DEVICE("Called 'update()' - high trust");
 
       // Update next candidate: If not reachable, 'high trust' is broken
-      if (!navigation::update_candidate(navigation.target(), tangential, det,
-                                        cfg.intersection,
-                                        navigation.external_tol(), ctx)) {
+      if (!update_candidate()) {
         DETRAY_VERBOSE_HOST_DEVICE(
             "-> Candidate not reachable! High trust broken:");
 
@@ -288,12 +327,11 @@ class caching_navigator
           }
           return !is_init;
         }
+
         // Else (if full trust): Track is on non-portal surface and
         // cache is not exhausted. Ready the next target
         if (navigation.trust_level() == navigation::trust_level::e_full &&
-            navigation::update_candidate(navigation.target(), tangential, det,
-                                         cfg.intersection,
-                                         navigation.external_tol(), ctx)) {
+            update_candidate()) {
           DETRAY_VERBOSE_HOST_DEVICE(
               "-> On non-portal surface (idx %d) and next candidate "
               "in cache is reachable",
@@ -316,7 +354,7 @@ class caching_navigator
         !navigation.cache_exhausted()) {
       DETRAY_VERBOSE_HOST_DEVICE("Called 'update()' - fair trust");
 
-      for (auto &candidate : navigation) {
+      navigation.for_each_valid([&](state::candidate_t &candidate) {
         // Disregard this candidate if it is not reachable
         if (!navigation::update_candidate(candidate, tangential, det,
                                           cfg.intersection,
@@ -324,12 +362,12 @@ class caching_navigator
           // Forcefully set dist to numeric max for sorting
           candidate.set_path(std::numeric_limits<scalar_t>::max());
         }
-      }
-      detray::sequential_sort(navigation.begin(), navigation.end());
+      });
+      navigation.sort_candidates();
       // Take the nearest (sorted) candidate first
-      navigation.set_next(navigation.begin());
+      navigation.set_next_to_begin();
       // Ignore unreachable elements (needed to determine exhaustion)
-      navigation.set_last(find_invalid(navigation.candidates()));
+      navigation.evict_invalid();
       // Update navigation flow on the new candidate information
       navigation::update_status(navigation, cfg);
 
@@ -354,23 +392,6 @@ class caching_navigator
     }
 
     return !is_init;
-  }
-
-  /// Helper to evict all unreachable/invalid candidates from the cache:
-  /// Finds the first unreachable candidate (has been invalidated during
-  /// update) in a sorted (!) cache.
-  ///
-  /// @param candidates the cache of candidates to be cleaned
-  ///
-  /// @returns iterator to the last reachable candidate
-  DETRAY_HOST_DEVICE constexpr auto find_invalid(
-      const typename state::candidate_cache_t &candidates) const {
-    // Depends on previous invalidation of unreachable candidates!
-    auto not_reachable = [](const intersection_type &candidate) {
-      return candidate.path() == std::numeric_limits<scalar_t>::max();
-    };
-
-    return detray::find_if(candidates.begin(), candidates.end(), not_reachable);
   }
 };
 

--- a/Detray/core/include/detray/navigation/detail/intersection_kernel.hpp
+++ b/Detray/core/include/detray/navigation/detail/intersection_kernel.hpp
@@ -139,16 +139,7 @@ struct intersection_initialize {
   DETRAY_HOST_DEVICE void insert_sorted(
       const typename nav_state_t::value_type &sfi,
       nav_state_t &intersections) const {
-    auto itr_pos{intersections.cbegin()};
-
-    // For just two candidates int the cache, the navigation state keeps
-    // the first as the previously visited candidate -> no sorting needed
-    if constexpr (nav_state_t::capacity() > 2u) {
-      itr_pos = detray::upper_bound(intersections.cbegin(),
-                                    intersections.cend(), sfi);
-    }
-
-    intersections.insert(itr_pos, sfi);
+    intersections.insert(sfi);
   }
 };
 

--- a/Detray/core/include/detray/navigation/detail/print_state.hpp
+++ b/Detray/core/include/detray/navigation/detail/print_state.hpp
@@ -70,13 +70,11 @@ DETRAY_HOST inline std::string print_state(const state_type &state) {
   }
 
   // Next surface
-  if (!state.candidates().empty()) {
-    debug_stream << std::setw(cw) << "next object:";
-    if (state.n_candidates() == 0u) {
-      debug_stream << "exhausted" << std::endl;
-    } else {
-      debug_stream << state.next_surface().identifier() << std::endl;
-    }
+  debug_stream << std::setw(cw) << "next object:";
+  if (state.n_candidates() == 0u) {
+    debug_stream << "exhausted" << std::endl;
+  } else {
+    debug_stream << state.next_surface().identifier() << std::endl;
   }
 
   // Distance to next
@@ -133,7 +131,7 @@ DETRAY_HOST inline std::string print_candidates(const state_type &state,
 
   debug_stream << "Surface candidates: " << std::endl;
 
-  for (const auto &sf_cand : state) {
+  state.for_each_valid([&](const auto &sf_cand) {
     debug_stream << std::left << std::setw(6) << "-> " << sf_cand;
 
     assert(!sf_cand.surface().identifier().is_invalid());
@@ -152,7 +150,7 @@ DETRAY_HOST inline std::string print_candidates(const state_type &state,
     } else {
       debug_stream << std::endl;
     }
-  }
+  });
 
   return debug_stream.str();
 }

--- a/Detray/core/include/detray/navigation/direct_navigator.hpp
+++ b/Detray/core/include/detray/navigation/direct_navigator.hpp
@@ -88,7 +88,9 @@ class direct_navigator {
           is_forward() ? 0 : static_cast<dist_t>(m_sequence.size()) - 1;
 
       // Update the target with the next external surface
-      this->target().set_surface(next_external());
+      auto target = this->target();
+      target.set_surface(next_external());
+      this->set_target(target);
 
       // The next candidate is always stored in the second cache entry
       this->next_index(1u);
@@ -130,7 +132,7 @@ class direct_navigator {
     DETRAY_HOST_DEVICE
     constexpr void advance() {
       // The target has become the current candidate
-      this->candidates()[0] = this->target();
+      this->set_current(this->target());
 
       assert(has_next_external());
       if (is_forward()) {
@@ -143,8 +145,10 @@ class direct_navigator {
       // Could make the target invalid -> exit navigation
       if (has_next_external()) {
         // If the next external can be indexed, the cast is safe
-        this->target().set_surface(
+        auto target = this->target();
+        target.set_surface(
             m_sequence[static_cast<unsigned int>(m_next_external)]);
+        this->set_target(target);
       }
 
       assert(
@@ -243,11 +247,17 @@ class direct_navigator {
           track.pos(),
           static_cast<scalar_t>(navigation.direction()) * track.dir()};
 
+      const auto update_candidate = [&]() {
+        auto target = navigation.target();
+        const bool reachable = navigation::update_candidate(
+            target, tangential, det, intr_cfg, navigation.external_tol(), ctx);
+        navigation.set_target(target);
+        return reachable;
+      };
+
       // Update the current target. If it cannot be reached, direct
       // navigation is broken
-      if (!navigation::update_candidate(navigation.target(), tangential, det,
-                                        intr_cfg, navigation.external_tol(),
-                                        ctx)) {
+      if (!update_candidate()) {
         navigation.abort("Could not reach current target");
         return !is_init;
       }
@@ -270,10 +280,7 @@ class direct_navigator {
       }
 
       // Otherwise, track is on surface: Update the next target
-      if (navigation.has_next_external() &&
-          !navigation::update_candidate(navigation.target(), tangential, det,
-                                        intr_cfg, navigation.external_tol(),
-                                        ctx)) {
+      if (navigation.has_next_external() && !update_candidate()) {
         navigation.abort("Could not find new target after surface was reached");
         return !is_init;
       }

--- a/Detray/core/include/detray/navigation/navigation_state.hpp
+++ b/Detray/core/include/detray/navigation/navigation_state.hpp
@@ -69,9 +69,7 @@ struct void_inspector {
 /// @tparam intersection_t result of an intersection operation
 template <typename derived_t, typename detector_t, std::size_t k_cache_capacity,
           typename inspector_t, typename intersection_t>
-class base_state : public detray::ranges::view_interface<
-                       base_state<derived_t, detector_t, k_cache_capacity,
-                                  inspector_t, intersection_t>> {
+class base_state {
   /// Need at least two slots for the caching to work
   static_assert(k_cache_capacity >= 2u,
                 "Navigation cache needs to have a capacity larger than 1");
@@ -124,42 +122,6 @@ class base_state : public detray::ranges::view_interface<
   DETRAY_HOST_DEVICE
   constexpr auto detector() const -> const detector_t & {
     return (*m_detector);
-  }
-
-  /// @return start position of the valid candidate range - const
-  DETRAY_HOST_DEVICE
-  constexpr auto begin() const -> candidate_const_itr_t {
-    candidate_const_itr_t itr = m_candidates.cbegin();
-    const dist_t idx{next_index()};
-    detray::ranges::advance(itr,
-                            (is_on_surface() && (idx >= 1)) ? idx - 1 : idx);
-    return itr;
-  }
-
-  DETRAY_HOST_DEVICE
-  constexpr auto cbegin() const -> candidate_const_itr_t {
-    return std::as_const(*this).begin();
-  }
-
-  /// @return sentinel of the valid candidate range.
-  DETRAY_HOST_DEVICE
-  constexpr auto end() const -> candidate_const_itr_t {
-    candidate_const_itr_t itr = m_candidates.cbegin();
-    detray::ranges::advance(itr, m_last + 1);
-    return itr;
-  }
-
-  DETRAY_HOST_DEVICE
-  constexpr auto cend() const -> candidate_const_itr_t {
-    return std::as_const(*this).end();
-  }
-
-  /// @returns last valid candidate (by position in the cache) - const
-  DETRAY_HOST_DEVICE
-  constexpr auto last() const -> const candidate_t & {
-    assert(!cache_exhausted());
-    assert(m_last >= 0);
-    return m_candidates[static_cast<std::size_t>(m_last)];
   }
 
   /// @returns the capacity of the internal candidate storage
@@ -285,12 +247,6 @@ class base_state : public detray::ranges::view_interface<
     m_volume_index = static_cast<nav_link_t>(v);
   }
 
-  /// @returns currently cached candidates - const
-  DETRAY_HOST_DEVICE
-  constexpr auto candidates() const -> const candidate_cache_t & {
-    return m_candidates;
-  }
-
   /// @returns number of currently cached (reachable) candidates - const
   DETRAY_HOST_DEVICE
   constexpr auto n_candidates() const -> dindex {
@@ -306,17 +262,17 @@ class base_state : public detray::ranges::view_interface<
 
   /// @returns current/previous object that was reached - const
   DETRAY_HOST_DEVICE
-  constexpr auto current() const -> const candidate_t & {
+  constexpr auto current() const -> const candidate_t {
     assert(cast_impl().is_on_surface());
     assert(m_next > 0);
-    return m_candidates[static_cast<std::size_t>(m_next - 1)];
+    return this->candidate_at(m_next - 1);
   }
 
   /// @returns next object that we want to reach (current target) - const
   DETRAY_HOST_DEVICE
-  constexpr auto target() const -> const candidate_t & {
+  constexpr auto target() const -> const candidate_t {
     assert(m_next >= 0);
-    return m_candidates[static_cast<std::size_t>(m_next)];
+    return this->candidate_at(m_next);
   }
 
   /// @returns identifier of the detector surface the navigator is on
@@ -455,48 +411,57 @@ class base_state : public detray::ranges::view_interface<
   DETRAY_HOST_DEVICE
   constexpr auto &inspector() { return m_inspector; }
 
+  template <typename callable_t>
+  DETRAY_HOST_DEVICE constexpr void for_each_valid(callable_t &&f) const {
+    for (std::size_t i = this->valid_begin(); i < this->valid_end(); ++i) {
+      f(this->candidate_at(i));
+    }
+  }
+
  protected:
-  /// @return start position of valid candidate range.
   DETRAY_HOST_DEVICE
-  constexpr auto begin() -> candidate_itr_t {
-    candidate_itr_t itr = m_candidates.begin();
-    const dist_t idx{cast_impl().next_index()};
-    detray::ranges::advance(
-        itr, (cast_impl().is_on_surface() && (idx >= 1)) ? idx - 1 : idx);
-    return itr;
+  constexpr std::size_t valid_begin() const {
+    const dist_t idx{next_index()};
+    return (is_on_surface() && (idx >= 1)) ? idx - 1 : idx;
   }
 
-  /// @return sentinel of the valid candidate range.
   DETRAY_HOST_DEVICE
-  constexpr auto end() -> candidate_itr_t {
-    candidate_itr_t itr = m_candidates.begin();
-    detray::ranges::advance(itr, m_last + 1);
-    return itr;
-  }
-
-  /// @returns last valid candidate (by position in the cache)
-  DETRAY_HOST_DEVICE
-  constexpr auto last() -> candidate_t & {
-    assert(static_cast<std::size_t>(m_last) < m_candidates.size());
-    return m_candidates[static_cast<std::size_t>(m_last)];
-  }
+  constexpr std::size_t valid_end() const { return m_last + 1; }
 
   /// Set the next surface that we want to reach (update target)
   DETRAY_HOST_DEVICE
-  constexpr void set_next(candidate_const_itr_t new_next) {
-    const auto new_idx{
-        detray::ranges::distance(m_candidates.cbegin(), new_next)};
-    cast_impl().next_index(static_cast<dist_t>(new_idx));
+  constexpr void set_next_to_begin() {
+    cast_impl().next_index(static_cast<dist_t>(valid_begin()));
     assert(cast_impl().next_index() <= m_last + 1);
   }
 
-  /// Updates the position of the last valid candidate
+  /// Helper to evict all unreachable/invalid candidates from the cache:
   DETRAY_HOST_DEVICE
-  constexpr void set_last(candidate_const_itr_t new_last) {
-    const auto new_idx{
-        detray::ranges::distance(m_candidates.cbegin(), new_last) - 1};
-    last_index(static_cast<dist_t>(new_idx));
+  constexpr void evict_invalid() {
+    // Depends on previous invalidation of unreachable candidates!
+    auto not_reachable = [](const intersection_t &candidate) {
+      return candidate.path() == std::numeric_limits<scalar_t>::max();
+    };
+
+    std::size_t i = 0;
+
+    for (; i < k_cache_capacity; ++i) {
+      if (not_reachable(this->candidate_at(i))) {
+        break;
+      }
+    }
+
+    last_index(static_cast<dist_t>(i) - 1);
     assert(m_last < static_cast<dist_t>(k_cache_capacity));
+  }
+
+  template <typename callable_t>
+  DETRAY_HOST_DEVICE constexpr void for_each_valid(callable_t &&f) {
+    for (std::size_t i = this->valid_begin(); i < this->valid_end(); ++i) {
+      auto cand = this->candidate_at(i);
+      f(cand);
+      this->set_candidate_at(i, cand);
+    }
   }
 
   /// @returns the index to the target surface
@@ -531,23 +496,38 @@ class base_state : public detray::ranges::view_interface<
     assert(cast_impl().next_index() <= cast_impl().last_index() + 1);
   }
 
-  /// @returns currently cached candidates
   DETRAY_HOST_DEVICE
-  constexpr auto candidates() -> candidate_cache_t & { return m_candidates; }
+  constexpr void set_current(const candidate_t &c) {
+    assert(m_next >= 1);
+    m_candidates[m_next - 1] = c;
+  };
+
+  DETRAY_HOST_DEVICE
+  constexpr void set_target(const candidate_t &c) { m_candidates[m_next] = c; };
+
+  DETRAY_HOST_DEVICE
+  constexpr void set_candidate_at(std::size_t i, const candidate_t &c) {
+    m_candidates[i] = c;
+  };
 
   /// @returns current/previous object that was reached
   DETRAY_HOST_DEVICE
-  constexpr auto current() -> candidate_t & {
+  constexpr auto current() -> const candidate_t {
     assert(cast_impl().is_on_surface());
     assert(m_next > 0);
-    return m_candidates[static_cast<std::size_t>(m_next - 1)];
+    return this->candidate_at(m_next - 1);
   }
 
   /// @returns next object that we want to reach (current target)
   DETRAY_HOST_DEVICE
-  constexpr auto target() -> candidate_t & {
-    assert(static_cast<std::size_t>(m_next) < m_candidates.size());
-    return m_candidates[static_cast<std::size_t>(m_next)];
+  constexpr auto target() -> const candidate_t {
+    assert(static_cast<std::size_t>(m_next) < k_cache_capacity);
+    return this->candidate_at(m_next);
+  }
+
+  DETRAY_HOST_DEVICE
+  constexpr auto candidate_at(std::size_t i) const -> const candidate_t {
+    return m_candidates[i];
   }
 
   /// Set the status to @param s
@@ -569,7 +549,9 @@ class base_state : public detray::ranges::view_interface<
   constexpr void clear_cache() {
     // Mark all data in the cache as unreachable
     for (std::size_t i = 0u; i < k_cache_capacity; ++i) {
-      m_candidates[i].set_path(std::numeric_limits<scalar_t>::max());
+      auto cand = this->candidate_at(i);
+      cand.set_path(std::numeric_limits<scalar_t>::max());
+      this->set_candidate_at(i, cand);
     }
     m_next = 0;
     m_last = -1;


### PR DESCRIPTION
This commit shrinks the navigator cache public API to a small number of setters and getters, which should make it easier to modify the internal layout of the cache while also making it easier to reason about the workings of the type.