### PR TITLE
perf(detray): Make Jacobian a non-pointer member of param updater

### DIFF
--- a/Detray/core/include/detray/propagator/actors/parameter_updater.hpp
+++ b/Detray/core/include/detray/propagator/actors/parameter_updater.hpp
@@ -26,11 +26,14 @@
 
 namespace detray::actor {
 
-template <concepts::algebra algebra_t>
-struct parameter_transporter;
+template <concepts::algebra algebra_t, typename state_t>
+struct parameter_transporter_base;
+
+template <concepts::algebra algebra_t, typename state_t>
+struct parameter_setter_base;
 
 template <concepts::algebra algebra_t>
-struct parameter_setter;
+struct parameter_updater_mbf_state;
 
 /// Configuration of noise estimation
 struct noise_cfg {
@@ -47,18 +50,23 @@ struct noise_cfg {
 template <concepts::algebra algebra_t>
 struct parameter_updater_state {
   // Allow only the corresponding actors to modify the parameter data
-  friend struct parameter_transporter<algebra_t>;
-  friend struct parameter_setter<algebra_t>;
+  friend struct parameter_transporter_base<algebra_t,
+                                           parameter_updater_state<algebra_t>>;
+  friend struct parameter_setter_base<algebra_t,
+                                      parameter_updater_state<algebra_t>>;
+  friend struct parameter_transporter_base<
+      algebra_t, parameter_updater_mbf_state<algebra_t>>;
+  friend struct parameter_setter_base<algebra_t,
+                                      parameter_updater_mbf_state<algebra_t>>;
+
+  static constexpr bool stores_full_jacobian = false;
 
   constexpr parameter_updater_state() = default;
 
   /// Start without explicit track parameters
   DETRAY_HOST_DEVICE
-  explicit constexpr parameter_updater_state(
-      const propagation::config& cfg,
-      bound_matrix<algebra_t>* full_jac = nullptr)
-      : m_full_jacobian(full_jac),
-        m_cfg{cfg.navigation.accumulated_error,
+  explicit constexpr parameter_updater_state(const propagation::config& cfg)
+      : m_cfg{cfg.navigation.accumulated_error,
               cfg.navigation.n_scattering_stddev,
               cfg.navigation.estimate_scattering_noise} {}
 
@@ -66,10 +74,8 @@ struct parameter_updater_state {
   DETRAY_HOST_DEVICE
   constexpr parameter_updater_state(
       const propagation::config& cfg,
-      const free_track_parameters<algebra_t>& free_params,
-      bound_matrix<algebra_t>* full_jac = nullptr)
-      : m_full_jacobian(full_jac),
-        m_cfg{cfg.navigation.accumulated_error,
+      const free_track_parameters<algebra_t>& free_params)
+      : m_cfg{cfg.navigation.accumulated_error,
               cfg.navigation.n_scattering_stddev,
               cfg.navigation.estimate_scattering_noise} {
     // Set bound track parameters
@@ -81,10 +87,8 @@ struct parameter_updater_state {
   DETRAY_HOST_DEVICE
   constexpr parameter_updater_state(
       const propagation::config& cfg,
-      const bound_track_parameters<algebra_t>& bound_params,
-      bound_matrix<algebra_t>* full_jac = nullptr)
+      const bound_track_parameters<algebra_t>& bound_params)
       : m_bound_params{bound_params},
-        m_full_jacobian(full_jac),
         m_cfg{cfg.navigation.accumulated_error,
               cfg.navigation.n_scattering_stddev,
               cfg.navigation.estimate_scattering_noise} {}
@@ -148,6 +152,25 @@ struct parameter_updater_state {
     return m_bound_params;
   }
 
+ private:
+  /// Bound track parameters and covariance
+  bound_track_parameters<algebra_t> m_bound_params{};
+  /// Configuration for the noise estimation
+  noise_cfg m_cfg{};
+  /// Always update the free track parameters, even if nothing changed
+  bool m_always_update{false};
+  /// Notify observing actors on initial surface (propagation init)
+  bool m_notify_on_initial{true};
+};
+
+/// State of the parameter updater that can additionally accumulate the full
+/// Jacobian between two surfaces, as needed by the MBF smoother
+template <concepts::algebra algebra_t>
+struct parameter_updater_mbf_state : parameter_updater_state<algebra_t> {
+  static constexpr bool stores_full_jacobian = true;
+
+  using parameter_updater_state<algebra_t>::parameter_updater_state;
+
   /// @returns true if the full Jacobian matrix should be assembled.
   DETRAY_HOST_DEVICE
   constexpr bool has_full_jacobian() const {
@@ -176,16 +199,8 @@ struct parameter_updater_state {
   }
 
  private:
-  /// Bound track parameters and covariance
-  bound_track_parameters<algebra_t> m_bound_params{};
   /// Full jacobian for up to the current destination surface
   bound_matrix<algebra_t>* m_full_jacobian{nullptr};
-  /// Configuration for the noise estimation
-  noise_cfg m_cfg{};
-  /// Always update the free track parameters, even if nothing changed
-  bool m_always_update{false};
-  /// Notify observing actors on initial surface (propagation init)
-  bool m_notify_on_initial{true};
 };
 
 /// Result of the param. transporter: bound track parameters at dest. sf.
@@ -243,8 +258,8 @@ struct parameter_transporter_result : public actor::result {
 /// Transport the free track parameters at the destination surface
 /// and the covariance at the departure surface to bound track parameters
 /// at the destination surface (current sensitive/material surface)
-template <concepts::algebra algebra_t>
-struct parameter_transporter : base_actor {
+template <concepts::algebra algebra_t, typename state_t>
+struct parameter_transporter_base : base_actor {
   /// @name Type definitions for the struct
   /// @{
   // Transformation matching this struct
@@ -258,7 +273,7 @@ struct parameter_transporter : base_actor {
   /// @}
 
   /// Use the parameter updater state
-  using state = parameter_updater_state<algebra_t>;
+  using state = state_t;
   using result = parameter_transporter_result<algebra_t>;
 
   /// Filter the masks of a detector according to the local frame type
@@ -364,9 +379,11 @@ struct parameter_transporter : base_actor {
 
       // Update the full Jacobian, if required
       if (math::fabs(stepping.path_length()) > 0.f) {
-        if (updater_state.has_full_jacobian()) {
-          updater_state.set_full_jacobian(propagation_step_jacobian *
-                                          updater_state.full_jacobian());
+        if constexpr (state_t::stores_full_jacobian) {
+          if (updater_state.has_full_jacobian()) {
+            updater_state.set_full_jacobian(propagation_step_jacobian *
+                                            updater_state.full_jacobian());
+          }
         }
 
         // Reset transport Jacobian to identity matrix
@@ -554,12 +571,21 @@ struct parameter_transporter : base_actor {
   }
 };
 
+template <concepts::algebra algebra_t>
+using parameter_transporter =
+    parameter_transporter_base<algebra_t, parameter_updater_state<algebra_t>>;
+
+template <concepts::algebra algebra_t>
+using parameter_transporter_mbf =
+    parameter_transporter_base<algebra_t,
+                               parameter_updater_mbf_state<algebra_t>>;
+
 /// Set the free track parameters in the stepper state, in case
 /// observing actors (e.g. the material interactor) changed the bound parameters
-template <concepts::algebra algebra_t>
-struct parameter_setter : base_actor {
+template <concepts::algebra algebra_t, typename state_t>
+struct parameter_setter_base : base_actor {
   /// Access the same parameter updater state as the parameter transporter
-  using state = parameter_updater_state<algebra_t>;
+  using state = state_t;
 
   /// Actor interface: Observer to the parameter transporter and its observers
   template <typename propagator_state_t>
@@ -605,11 +631,24 @@ struct parameter_setter : base_actor {
   }
 };
 
+template <concepts::algebra algebra_t>
+using parameter_setter =
+    parameter_setter_base<algebra_t, parameter_updater_state<algebra_t>>;
+
+template <concepts::algebra algebra_t>
+using parameter_setter_mbf =
+    parameter_setter_base<algebra_t, parameter_updater_mbf_state<algebra_t>>;
+
 /// Call actors that depend on the bound track parameters safely together
 /// with the parameter transporter and parameter setter
 template <typename algebra_t, typename... transporter_observers>
 using parameter_updater =
     composite_actor<parameter_transporter<algebra_t>, transporter_observers...,
                     parameter_setter<algebra_t>>;
+
+template <typename algebra_t, typename... transporter_observers>
+using parameter_updater_mbf =
+    composite_actor<parameter_transporter_mbf<algebra_t>,
+                    transporter_observers..., parameter_setter_mbf<algebra_t>>;
 
 }  // namespace detray::actor

--- a/Detray/core/include/detray/propagator/actors/parameter_updater.hpp
+++ b/Detray/core/include/detray/propagator/actors/parameter_updater.hpp
@@ -167,6 +167,8 @@ struct parameter_updater_state {
 /// Jacobian between two surfaces, as needed by the MBF smoother
 template <concepts::algebra algebra_t>
 struct parameter_updater_mbf_state : parameter_updater_state<algebra_t> {
+  enum class jacobian_state { e_not_set, e_identity, e_set };
+
   static constexpr bool stores_full_jacobian = true;
 
   using parameter_updater_state<algebra_t>::parameter_updater_state;
@@ -174,33 +176,46 @@ struct parameter_updater_mbf_state : parameter_updater_state<algebra_t> {
   /// @returns true if the full Jacobian matrix should be assembled.
   DETRAY_HOST_DEVICE
   constexpr bool has_full_jacobian() const {
-    return m_full_jacobian != nullptr;
+    return m_state != jacobian_state::e_not_set;
   }
 
   /// @returns the current full Jacbian.
   DETRAY_HOST_DEVICE
-  constexpr const bound_matrix<algebra_t>& full_jacobian() const {
+  constexpr bound_matrix<algebra_t> full_jacobian() const {
     assert(has_full_jacobian());
-    return *m_full_jacobian;
+    if (m_state == jacobian_state::e_identity) {
+      return matrix::identity<bound_matrix<algebra_t>>();
+    } else {
+      return m_full_jacobian;
+    }
   }
+
+  /// Set the jacobian to identity
+  DETRAY_HOST_DEVICE
+  constexpr void reset_full_jacobian() { m_state = jacobian_state::e_identity; }
 
   /// Set new full Jacbian.
   DETRAY_HOST_DEVICE
   constexpr void set_full_jacobian(const bound_matrix<algebra_t>& jac) {
-    assert(has_full_jacobian());
-    *m_full_jacobian = jac;
+    m_full_jacobian = jac;
+    m_state = jacobian_state::e_set;
   }
 
-  /// Set new full Jacbian.
   DETRAY_HOST_DEVICE
-  constexpr void set_full_jacobian(bound_matrix<algebra_t>* jac_ptr) {
-    assert(jac_ptr);
-    m_full_jacobian = jac_ptr;
+  constexpr void update_full_jacobian(const bound_matrix<algebra_t>& jac) {
+    if (m_state == jacobian_state::e_identity) {
+      m_full_jacobian = jac;
+    } else {
+      m_full_jacobian = jac * m_full_jacobian;
+    }
+    m_state = jacobian_state::e_set;
   }
 
  private:
+  /// The state of the Jacobian
+  jacobian_state m_state = jacobian_state::e_not_set;
   /// Full jacobian for up to the current destination surface
-  bound_matrix<algebra_t>* m_full_jacobian{nullptr};
+  bound_matrix<algebra_t> m_full_jacobian;
 };
 
 /// Result of the param. transporter: bound track parameters at dest. sf.
@@ -381,8 +396,7 @@ struct parameter_transporter_base : base_actor {
       if (math::fabs(stepping.path_length()) > 0.f) {
         if constexpr (state_t::stores_full_jacobian) {
           if (updater_state.has_full_jacobian()) {
-            updater_state.set_full_jacobian(propagation_step_jacobian *
-                                            updater_state.full_jacobian());
+            updater_state.update_full_jacobian(propagation_step_jacobian);
           }
         }
 

--- a/Traccc/core/include/traccc/finding/details/combinatorial_kalman_filter.hpp
+++ b/Traccc/core/include/traccc/finding/details/combinatorial_kalman_filter.hpp
@@ -511,7 +511,8 @@ combinatorial_kalman_filter(
 
       typename detray::actor::pathlimit_aborter<scalar_type>::state
           aborter_state;
-      detray::actor::parameter_updater_state<typename detector_t::algebra_type>
+      detray::actor::parameter_updater_mbf_state<
+          typename detector_t::algebra_type>
           updater_state{prop_cfg, param};
       traccc::details::ckf_interactor_t::state interactor_state;
       typename detray::actor::momentum_aborter<scalar_type>::state

--- a/Traccc/core/include/traccc/finding/details/combinatorial_kalman_filter_types.hpp
+++ b/Traccc/core/include/traccc/finding/details/combinatorial_kalman_filter_types.hpp
@@ -38,7 +38,8 @@ using ckf_interactor_t =
 /// Actor chain used in the Combinatorial Kalman Filter (CKF)
 using ckf_actor_chain_t = detray::actor_chain<
     detray::actor::pathlimit_aborter<traccc::scalar>,
-    detray::actor::parameter_updater<traccc::default_algebra, ckf_interactor_t>,
+    detray::actor::parameter_updater_mbf<traccc::default_algebra,
+                                         ckf_interactor_t>,
     detray::actor::momentum_aborter<traccc::scalar>, ckf_aborter>;
 
 /// Propagator type used in the Combinatorial Kalman Filter (CKF)

--- a/Traccc/device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp
+++ b/Traccc/device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp
@@ -53,6 +53,10 @@ TRACCC_HOST_DEVICE inline void propagate_to_next_surface(
   vecmem::device_vector<unsigned int> params_liveness(
       payload.params_liveness_view);
 
+  // MBF jacobians
+  vecmem::device_vector<bound_matrix<default_algebra>> tmp_jacobian(
+      payload.tmp_jacobian_view);
+
   // tips
   vecmem::device_vector<unsigned int> tips(payload.tips_view);
   vecmem::device_vector<unsigned int> tip_lengths(payload.tip_lengths_view);
@@ -99,13 +103,8 @@ TRACCC_HOST_DEVICE inline void propagate_to_next_surface(
    * is set to the multiplicative identity.
    */
   if (cfg.run_smoother == smoother_type::e_mbf) {
-    assert(payload.tmp_jacobian_view.ptr() != nullptr);
-
-    vecmem::device_vector<bound_matrix<default_algebra>> tmp_jacobian(
-        payload.tmp_jacobian_view);
-    tmp_jacobian.at(param_id) =
-        matrix::identity<bound_matrix<default_algebra>>();
-    updater_state.set_full_jacobian(&(tmp_jacobian.at(param_id)));
+    assert(tmp_jacobian.size() != 0);
+    updater_state.reset_full_jacobian();
   }
 
   // Notify the KF and material interaction only at the first propagation
@@ -121,6 +120,10 @@ TRACCC_HOST_DEVICE inline void propagate_to_next_surface(
   propagator.propagate(
       propagation, detray::tie(aborter_state, updater_state, interactor_state,
                                momentum_aborter_state, ckf_aborter_state));
+
+  if (ckf_aborter_state.success && updater_state.has_full_jacobian()) {
+    tmp_jacobian.at(param_id) = updater_state.full_jacobian();
+  }
 
   // If a surface found, add the parameter for the next step
   if (ckf_aborter_state.success) {

--- a/Traccc/device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp
+++ b/Traccc/device/common/include/traccc/finding/device/impl/propagate_to_next_surface.ipp
@@ -82,7 +82,7 @@ TRACCC_HOST_DEVICE inline void propagate_to_next_surface(
   // Pathlimit aborter
   typename detray::actor::pathlimit_aborter<scalar_t>::state aborter_state{};
   // Parameter updater
-  typename detray::actor::parameter_updater_state<algebra_t> updater_state{
+  typename detray::actor::parameter_updater_mbf_state<algebra_t> updater_state{
       cfg.propagation, in_par};
   // CKF-interactor
   traccc::details::ckf_interactor_t::state interactor_state;


### PR DESCRIPTION
This commit makes the Jacobian a non-pointer member of the parameter updater and adds an optimisation of cases where the matrix is not set.