### PR TITLE
feat(traccc): allow GBTS seeding in alpaka full chain example

### DIFF
--- a/Traccc/examples/run/alpaka/include/traccc/examples/alpaka/full_chain_algorithm.hpp
+++ b/Traccc/examples/run/alpaka/include/traccc/examples/alpaka/full_chain_algorithm.hpp
@@ -12,6 +12,7 @@
 #include "traccc/alpaka/clusterization/measurement_sorting_algorithm.hpp"
 #include "traccc/alpaka/finding/combinatorial_kalman_filter_algorithm.hpp"
 #include "traccc/alpaka/fitting/kalman_fitting_algorithm.hpp"
+#include "traccc/alpaka/gbts_seeding/gbts_seeding_algorithm.hpp"
 #include "traccc/alpaka/seeding/seed_parameter_estimation_algorithm.hpp"
 #include "traccc/alpaka/seeding/silicon_pixel_spacepoint_formation_algorithm.hpp"
 #include "traccc/alpaka/seeding/triplet_seeding_algorithm.hpp"
@@ -23,6 +24,7 @@
 #include "traccc/edm/track_collection.hpp"
 #include "traccc/edm/track_parameters.hpp"
 #include "traccc/fitting/kalman_filter/kalman_fitter.hpp"
+#include "traccc/gbts_seeding/gbts_seeding_config.hpp"
 #include "traccc/geometry/detector.hpp"
 #include "traccc/geometry/detector_buffer.hpp"
 #include "traccc/geometry/detector_conditions_description.hpp"
@@ -31,8 +33,6 @@
 #include "traccc/utils/algorithm.hpp"
 #include "traccc/utils/messaging.hpp"
 #include "traccc/utils/propagation.hpp"
-// GBTS include for placeholder input (not implemented)
-#include "traccc/gbts_seeding/gbts_seeding_config.hpp"
 
 // VecMem include(s).
 #include <vecmem/containers/vector.hpp>
@@ -162,6 +162,8 @@ class full_chain_algorithm
   spacepoint_formation_algorithm m_spacepoint_formation;
   /// Seeding algorithm
   triplet_seeding_algorithm m_seeding;
+  /// Seeding with GBTS algorithm
+  gbts_seeding_algorithm m_gbts_seeding;
   /// Track parameter estimation algorithm
   seed_parameter_estimation_algorithm m_track_parameter_estimation;
 
@@ -183,8 +185,8 @@ class full_chain_algorithm
   spacepoint_grid_config m_grid_config;
   /// Configuration for the seed filtering
   seedfilter_config m_filter_config;
-  /// placeholder GBTS config
-  [[maybe_unused]] gbts_seedfinder_config m_gbts_config;
+  /// Configuration for GBTS seeding
+  gbts_seedfinder_config m_gbts_config;
   /// Configuration for track parameter estimation
   track_params_estimation_config m_track_params_estimation_config;
 

--- a/Traccc/examples/run/alpaka/src/full_chain_algorithm.cpp
+++ b/Traccc/examples/run/alpaka/src/full_chain_algorithm.cpp
@@ -76,6 +76,10 @@ full_chain_algorithm::full_chain_algorithm(
                 {m_cached_device_mr, &m_cached_pinned_host_mr},
                 m_vecmem_objects.async_copy(), m_queue,
                 logger->cloneWithSuffix("SeedingAlg")),
+      m_gbts_seeding(gbts_config,
+                     {m_cached_device_mr, &m_cached_pinned_host_mr},
+                     m_vecmem_objects.async_copy(), m_queue,
+                     logger->cloneWithSuffix("GbtsAlg")),
       m_track_parameter_estimation(
           track_params_estimation_config,
           {m_cached_device_mr, &m_cached_pinned_host_mr},
@@ -165,6 +169,10 @@ full_chain_algorithm::full_chain_algorithm(const full_chain_algorithm& parent)
                 {m_cached_device_mr, &m_cached_pinned_host_mr},
                 m_vecmem_objects.async_copy(), m_queue,
                 parent.logger().cloneWithSuffix("SeedingAlg")),
+      m_gbts_seeding(parent.m_gbts_config,
+                     {m_cached_device_mr, &m_cached_pinned_host_mr},
+                     m_vecmem_objects.async_copy(), m_queue,
+                     parent.logger().cloneWithSuffix("GbtsAlg")),
       m_track_parameter_estimation(
           parent.m_track_params_estimation_config,
           {m_cached_device_mr, &m_cached_pinned_host_mr},
@@ -223,9 +231,14 @@ full_chain_algorithm::output_type full_chain_algorithm::operator()(
     // Run the seed-finding (asynchronously).
     const spacepoint_formation_algorithm::output_type spacepoints =
         m_spacepoint_formation(m_device_detector, measurements);
+    triplet_seeding_algorithm::output_type seeds;
+    if (usingGBTS) {
+      seeds = m_gbts_seeding(spacepoints, measurements);
+    } else {
+      seeds = m_seeding(spacepoints);
+    }
     const seed_parameter_estimation_algorithm::output_type track_params =
-        m_track_parameter_estimation(m_field, measurements, spacepoints,
-                                     m_seeding(spacepoints));
+        m_track_parameter_estimation(m_field, measurements, spacepoints, seeds);
 
     // Run the track finding (asynchronously).
     const finding_algorithm::output_type track_candidates =
@@ -276,9 +289,14 @@ bound_track_parameters_collection_types::host full_chain_algorithm::seeding(
     // Run the seed-finding (asynchronously).
     const spacepoint_formation_algorithm::output_type spacepoints =
         m_spacepoint_formation(m_device_detector, measurements);
+    triplet_seeding_algorithm::output_type seeds;
+    if (usingGBTS) {
+      seeds = m_gbts_seeding(spacepoints, measurements);
+    } else {
+      seeds = m_seeding(spacepoints);
+    }
     const seed_parameter_estimation_algorithm::output_type track_params =
-        m_track_parameter_estimation(m_field, measurements, spacepoints,
-                                     m_seeding(spacepoints));
+        m_track_parameter_estimation(m_field, measurements, spacepoints, seeds);
 
     // Copy a limited amount of result data back to the host.
     const auto host_seeds =


### PR DESCRIPTION
The full chain algorithm example for alpaka wasn't updated to enable GBTS seeding when it was implemented.