### PR TITLE
fix(Geometry): take customizer node pointers by const reference

### DIFF
--- a/Core/include/Acts/Geometry/BlueprintBuilder.hpp
+++ b/Core/include/Acts/Geometry/BlueprintBuilder.hpp
@@ -408,12 +408,13 @@ class ElementLayerAssembler {
                                              std::decay_t<CustomizerT>>) {
       m_onLayer = std::move(customizer);
     } else {
-      m_onLayer = [customizer = std::move(customizer)](
-                      const std::optional<Element>& layerElement,
-                      std::shared_ptr<LayerBlueprintNode> layer) mutable {
-        customizer(layerElement, *layer);
-        return layer;
-      };
+      m_onLayer =
+          [customizer = std::move(customizer)](
+              const std::optional<Element>& layerElement,
+              const std::shared_ptr<LayerBlueprintNode>& layer) mutable {
+            customizer(layerElement, *layer);
+            return layer;
+          };
     }
     return std::move(*this);
   }
@@ -602,12 +603,13 @@ class SensorLayerAssembler {
                                              std::decay_t<CustomizerT>>) {
       m_onLayer = std::move(customizer);
     } else {
-      m_onLayer = [customizer = std::move(customizer)](
-                      const std::optional<Element>& elem,
-                      std::shared_ptr<LayerBlueprintNode> layer) mutable {
-        customizer(elem, *layer);
-        return layer;
-      };
+      m_onLayer =
+          [customizer = std::move(customizer)](
+              const std::optional<Element>& elem,
+              const std::shared_ptr<LayerBlueprintNode>& layer) mutable {
+            customizer(elem, *layer);
+            return layer;
+          };
     }
     return std::move(*this);
   }
@@ -751,12 +753,13 @@ class SensorLayer {
                                              std::decay_t<CustomizerT>>) {
       m_onLayer = std::move(customizer);
     } else {
-      m_onLayer = [customizer = std::move(customizer)](
-                      const std::optional<Element>& elem,
-                      std::shared_ptr<LayerBlueprintNode> layer) mutable {
-        customizer(elem, *layer);
-        return layer;
-      };
+      m_onLayer =
+          [customizer = std::move(customizer)](
+              const std::optional<Element>& elem,
+              const std::shared_ptr<LayerBlueprintNode>& layer) mutable {
+            customizer(elem, *layer);
+            return layer;
+          };
     }
     return std::move(*this);
   }
@@ -876,12 +879,13 @@ class BarrelEndcapAssembler {
                                              std::decay_t<CustomizerT>>) {
       m_onLayer = std::move(customizer);
     } else {
-      m_onLayer = [customizer = std::move(customizer)](
-                      const std::optional<Element>& elem,
-                      std::shared_ptr<LayerBlueprintNode> layer) mutable {
-        customizer(elem, *layer);
-        return layer;
-      };
+      m_onLayer =
+          [customizer = std::move(customizer)](
+              const std::optional<Element>& elem,
+              const std::shared_ptr<LayerBlueprintNode>& layer) mutable {
+            customizer(elem, *layer);
+            return layer;
+          };
     }
     return std::move(*this);
   }
@@ -908,7 +912,7 @@ class BarrelEndcapAssembler {
       m_onContainer =
           [customizer = std::move(customizer)](
               const Element& elem,
-              std::shared_ptr<ContainerBlueprintNode> node) mutable {
+              const std::shared_ptr<ContainerBlueprintNode>& node) mutable {
             customizer(elem, *node);
             return node;
           };
@@ -955,7 +959,7 @@ class BarrelEndcapAssembler {
  private:
   typename ElementLayerAssembler::LayerCustomizer m_onLayer;
   ContainerCustomizer m_onContainer =
-      [](const Element&, std::shared_ptr<ContainerBlueprintNode> node) {
+      [](const Element&, const std::shared_ptr<ContainerBlueprintNode>& node) {
         return node;
       };
 

--- a/Tests/UnitTests/Core/Geometry/BlueprintBuilderTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/BlueprintBuilderTests.cpp
@@ -12,9 +12,15 @@
 #include "Acts/Geometry/BlueprintNode.hpp"
 #include "Acts/Geometry/ContainerBlueprintNode.hpp"
 #include "Acts/Geometry/LayerBlueprintNode.hpp"
+#include "Acts/Geometry/detail/BlueprintBuilder_impl.hpp"
+#include "Acts/Utilities/Logger.hpp"
 
 #include <memory>
 #include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
 
 using namespace Acts;
 using Acts::detail::OnContainerMutatesContainer;
@@ -87,11 +93,90 @@ static_assert(OnContainerMutatesContainer<Element, decltype(mutateContainer)>,
 static_assert(!OnContainerReturnsNode<Element, decltype(mutateContainer)>,
               "void-returning callback must not match the node-returning form");
 
+// A minimal backend satisfying detail::BlueprintBackend plus the barrel/endcap
+// classifier, so the assemblers' member templates can be instantiated. The
+// plugins instantiate the assemblers with `template class`, which does not
+// cover member templates such as `onLayer`, leaving the in-place customizer
+// adapters below uncompiled anywhere else in the tree.
+struct StubBackend {
+  using Element = int;
+
+  struct AxisDefinition {};
+
+  struct LayerSpec {
+    std::optional<std::string> layerName;
+    std::optional<AxisDefinition> axes;
+    std::optional<AxisDefinition> layerAxes;
+  };
+
+  struct Config {};
+
+  static constexpr std::string_view kIdentifier = "Stub";
+
+  StubBackend(const Config& /*cfg*/, const Logger& /*logger*/) {}
+
+  detail::SurfaceVector makeSurfaces(std::span<const Element> /*sensitives*/,
+                                     const LayerSpec& /*layerSpec*/) const {
+    return {};
+  }
+
+  Element world() const { return 0; }
+  std::string nameOf(const Element& /*element*/) const { return {}; }
+  std::vector<Element> children(const Element& /*element*/) const { return {}; }
+  Element parent(const Element& /*element*/) const { return 0; }
+  bool isSensitive(const Element& /*element*/) const { return false; }
+
+  bool isBarrel(const Element& /*element*/) const { return false; }
+  bool isEndcap(const Element& /*element*/) const { return false; }
+  bool isTracker(const Element& /*element*/) const { return false; }
+};
+
+static_assert(detail::BlueprintBackend<StubBackend>);
+static_assert(detail::HasAxisDefinition<StubBackend>);
+static_assert(detail::HasBarrelEndcapClassifier<StubBackend>);
+
 BOOST_AUTO_TEST_SUITE(GeometrySuite)
 
 BOOST_AUTO_TEST_CASE(CustomizerReturnTypeBackwardCompatibility) {
   // The substantive checks are the static_asserts above; this case ensures the
   // translation unit is exercised by the test runner.
+  BOOST_CHECK(true);
+}
+
+// Instantiates every `onLayer`/`onContainer` overload with both accepted
+// callback shapes. The node-returning form stores the callback directly; the
+// void-returning form is wrapped in an adapter lambda, which is what this
+// exercises. Nothing is built -- instantiation is the assertion.
+BOOST_AUTO_TEST_CASE(CustomizerInstantiation) {
+  using Element = StubBackend::Element;
+
+  auto returnsNode = [](const std::optional<Element>&,
+                        std::shared_ptr<LayerBlueprintNode> layer) {
+    return layer;
+  };
+  auto mutatesLayer = [](const std::optional<Element>&, LayerBlueprintNode&) {};
+  auto returnsContainer = [](const Element&,
+                             std::shared_ptr<ContainerBlueprintNode> node) {
+    return node;
+  };
+  auto mutatesContainer = [](const Element&, ContainerBlueprintNode&) {};
+
+  BlueprintBuilder<StubBackend> builder{StubBackend::Config{}};
+
+  static_cast<void>(builder.layers().onLayer(returnsNode));
+  static_cast<void>(builder.layers().onLayer(mutatesLayer));
+
+  static_cast<void>(builder.layersFromSensors().onLayer(returnsNode));
+  static_cast<void>(builder.layersFromSensors().onLayer(mutatesLayer));
+
+  static_cast<void>(builder.layerFromSensors().onLayer(returnsNode));
+  static_cast<void>(builder.layerFromSensors().onLayer(mutatesLayer));
+
+  static_cast<void>(builder.barrelEndcap().onLayer(returnsNode));
+  static_cast<void>(builder.barrelEndcap().onLayer(mutatesLayer));
+  static_cast<void>(builder.barrelEndcap().onContainer(returnsContainer));
+  static_cast<void>(builder.barrelEndcap().onContainer(mutatesContainer));
+
   BOOST_CHECK(true);
 }
 


### PR DESCRIPTION
Fixes the six `performance-unnecessary-value-param` findings that turned `Analysis / clang_tidy` red on `main`, starting with the push for #5905.