### PR TITLE
fix(traccc): Fix CUDA 13.4 conversion warnings

### DIFF
--- a/Traccc/device/common/include/traccc/device/array_insertion_mutex.hpp
+++ b/Traccc/device/common/include/traccc/device/array_insertion_mutex.hpp
@@ -35,7 +35,7 @@ TRACCC_HOST_DEVICE inline uint64_t encode_insertion_mutex(const bool locked,
 TRACCC_HOST_DEVICE inline std::tuple<bool, uint32_t, float>
 decode_insertion_mutex(const uint64_t val) {
   const uint32_t hi = static_cast<uint32_t>(val >> 32);
-  const uint32_t lo = val & 0xFFFFFFFF;
+  const uint32_t lo = static_cast<uint32_t>(val & 0xFFFFFFFF);
 
   return {static_cast<bool>(hi & 0x80000000), (hi & 0x7FFFFFFF),
           std::bit_cast<float>(lo)};

--- a/Traccc/device/common/include/traccc/gbts_seeding/device/impl/gbts_bin_spacepoints.ipp
+++ b/Traccc/device/common/include/traccc/gbts_seeding/device/impl/gbts_bin_spacepoints.ipp
@@ -86,8 +86,9 @@ TRACCC_HOST_DEVICE inline void gbts_bin_spacepoints(
 
     const detray::geometry::identifier geo_id = measurement.surface_link();
     const unsigned int volume = geo_id.volume();
-    const short begin_or_bin =
-        (volume < payload.volumeMapSize) ? volumeToLayerMap[volume] : SHRT_MAX;
+    const short begin_or_bin = (volume < payload.volumeMapSize)
+                                   ? volumeToLayerMap[volume]
+                                   : static_cast<short>(SHRT_MAX);
 
     if (begin_or_bin == SHRT_MAX) {
       reducedSP[globalIndex].w = -CHAR_MAX - 1;

--- a/Traccc/device/common/include/traccc/gbts_seeding/device/impl/gbts_create_seed_candidate.ipp
+++ b/Traccc/device/common/include/traccc/gbts_seeding/device/impl/gbts_create_seed_candidate.ipp
@@ -51,7 +51,8 @@ inline void gbts_create_seed_candidate(
     if (competing_offer > seed_bid) {
       d_seed_ambiguity[prop_idx] = -1;
     } else if (competing_offer != 0) {
-      d_seed_ambiguity[competing_offer & 0xFFFFFFFFLL] = -1;
+      d_seed_ambiguity[static_cast<unsigned int>(competing_offer &
+                                                 0xFFFFFFFFULL)] = -1;
     }
   }
 }

--- a/Traccc/device/common/include/traccc/gbts_seeding/device/impl/gbts_run_cca_iteration.ipp
+++ b/Traccc/device/common/include/traccc/gbts_seeding/device/impl/gbts_run_cca_iteration.ipp
@@ -62,7 +62,7 @@ TRACCC_HOST_DEVICE inline void gbts_run_cca_iteration(
           d_output_graph[edge_pos + gbts_consts::nei_start + nIdx];
       const unsigned char forward_level = d_levels[levelLoad + nextglobalIndex];
       if (next_level == forward_level) {
-        next_level = forward_level + 1;
+        next_level = static_cast<unsigned char>(forward_level + 1);
         localChange = true;
         break;
       }

--- a/Traccc/device/cuda/src/ambiguity_resolution/kernels/remove_tracks.cu
+++ b/Traccc/device/cuda/src/ambiguity_resolution/kernels/remove_tracks.cu
@@ -396,9 +396,9 @@ __launch_bounds__(512) __global__
 
     auto trk_id = sorted_ids.at(n_accepted_prev - 1 - sh_threads[threadIndex]);
 
-    unsigned int worst_idx =
+    unsigned int worst_idx = static_cast<unsigned int>(
         thrust::lower_bound(thrust::seq, tracks.begin(), tracks.end(), trk_id) -
-        tracks.begin();
+        tracks.begin());
 
     track_status[worst_idx] = 0;
 
@@ -410,9 +410,10 @@ __launch_bounds__(512) __global__
 
         trk_id = sorted_ids[n_accepted_prev - 1 - sh_threads[i]];
 
-        worst_idx = thrust::lower_bound(thrust::seq, tracks.begin(),
-                                        tracks.end(), trk_id) -
-                    tracks.begin();
+        worst_idx = static_cast<unsigned int>(
+            thrust::lower_bound(thrust::seq, tracks.begin(), tracks.end(),
+                                trk_id) -
+            tracks.begin());
 
         track_status[worst_idx] = 0;
 
@@ -428,10 +429,10 @@ __launch_bounds__(512) __global__
 
     if (N_A == 1 + n_sharing_tracks) {
       active = true;
-      const unsigned int alive_idx =
+      const unsigned int alive_idx = static_cast<unsigned int>(
           thrust::find(thrust::seq, track_status.begin(), track_status.end(),
                        1) -
-          track_status.begin();
+          track_status.begin());
 
       pos1 = atomicAdd(&n_updating_threads, 1);
       alive_trk_id = static_cast<int>(tracks[alive_idx]);

--- a/Traccc/device/cuda/src/clusterization/kernels/sort_cells.cuh
+++ b/Traccc/device/cuda/src/clusterization/kernels/sort_cells.cuh
@@ -290,9 +290,11 @@ __global__ __launch_bounds__(SORT_THREADS_PER_BLOCK) void sort_cells(
       local_max_module_index = std::max(local_max_module_index, module_index);
 
       assert(channel0 <= 0xFFFF);
-      smem.cell_attribute_cache.channel0[i] = channel0;
+      smem.cell_attribute_cache.channel0[i] =
+          static_cast<unsigned short>(channel0);
       assert(channel1 <= 0xFFFF);
-      smem.cell_attribute_cache.channel1[i] = channel1;
+      smem.cell_attribute_cache.channel1[i] =
+          static_cast<unsigned short>(channel1);
       smem.cell_attribute_cache.module_index[i] = module_index;
     }
 
@@ -314,16 +316,21 @@ __global__ __launch_bounds__(SORT_THREADS_PER_BLOCK) void sort_cells(
      */
     const auto module_index_clz = __clz(max_module_index - min_module_index);
     const unsigned int module_index_bits =
-        CHAR_BIT * sizeof(std::decay_t<decltype(module_index_clz)>) -
-        module_index_clz;
+        static_cast<unsigned int>(
+            CHAR_BIT * sizeof(std::decay_t<decltype(module_index_clz)>)) -
+        static_cast<unsigned int>(module_index_clz);
 
     const auto channel0_clz = __clz(max_channel0);
     const unsigned int channel0_bits =
-        CHAR_BIT * sizeof(std::decay_t<decltype(channel0_clz)>) - channel0_clz;
+        static_cast<unsigned int>(
+            CHAR_BIT * sizeof(std::decay_t<decltype(channel0_clz)>)) -
+        static_cast<unsigned int>(channel0_clz);
 
     const auto channel1_clz = __clz(max_channel1);
     const unsigned int channel1_bits =
-        CHAR_BIT * sizeof(std::decay_t<decltype(channel1_clz)>) - channel1_clz;
+        static_cast<unsigned int>(
+            CHAR_BIT * sizeof(std::decay_t<decltype(channel1_clz)>)) -
+        static_cast<unsigned int>(channel1_clz);
 
     const unsigned int total_bits =
         module_index_bits + channel0_bits + channel1_bits;

--- a/Traccc/tests/cuda/test_grid2.cu
+++ b/Traccc/tests/cuda/test_grid2.cu
@@ -219,7 +219,7 @@ __global__ void grid_attach_assign_test_kernel(
 
   auto pts = g2_device.bin(threadIdx.x, threadIdx.y);
 
-  for (std::size_t i = 0u; i < pts.size(); i++) {
+  for (unsigned int i = 0u; i < pts.size(); i++) {
     pts[i] = {static_cast<scalar>(i), static_cast<scalar>(i + 1u),
               static_cast<scalar>(i + 2u)};
   }


### PR DESCRIPTION
This commit fixes a few conversion warnings that CUDA 13.4 has started flagging.